### PR TITLE
Significant changes to the voice system!

### DIFF
--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -12,6 +12,7 @@ const VEHICLE_POOLS_MAX = 32;
 const SPAWN_POINTS_MAX = 63;
 const OBJECTIVES_MAX = 32;
 const CONSTRUCTION_CLASSES_MAX = 32;
+const VOICEID_MAX = 100;
 
 struct ArtilleryTarget
 {
@@ -790,6 +791,35 @@ simulated function string GetTeamScaleString(int Team)
    {
        return string(i) $ "%";
    }
+}
+
+// Modified to allow VoiceID to be greater than 32
+simulated function AddPRI(PlayerReplicationInfo PRI)
+{
+    local byte      NewVoiceID;
+    local int       i;
+
+    if (Level.NetMode == NM_ListenServer || Level.NetMode == NM_DedicatedServer)
+    {
+        for (i = 0; i < PRIArray.Length; i++)
+        {
+            if (PRIArray[i].VoiceID == NewVoiceID)
+            {
+                i = -1;
+                NewVoiceID++;
+                continue;
+            }
+        }
+
+        if (NewVoiceID >= VOICEID_MAX)
+        {
+            NewVoiceID = 0;
+        }
+
+        PRI.VoiceID = NewVoiceID;
+    }
+
+    PRIArray[PRIArray.Length] = PRI;
 }
 
 defaultproperties

--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -801,7 +801,7 @@ simulated function AddPRI(PlayerReplicationInfo PRI)
 
     if (Level.NetMode == NM_ListenServer || Level.NetMode == NM_DedicatedServer)
     {
-        for (i = 0; i < PRIArray.Length; i++)
+        for (i = 0; i < PRIArray.Length; ++i)
         {
             if (PRIArray[i].VoiceID == NewVoiceID)
             {

--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -912,7 +912,15 @@ simulated function DrawHudPassC(Canvas C)
             // Draw second line of text
             if (VCR != none)
             {
-                PortraitText[1].Text = "(" @ VCR.GetTitle() @ ")";
+                // If it is a public channel display its title normally
+                if (!VCR.IsPrivateChannel())
+                {
+                    PortraitText[1].Text = "(" @ VCR.GetTitle() @ ")";
+                }
+                else // Private channels will be displayed as "Local" (way to make private channels look like a single local channel)
+                {
+                    PortraitText[1].Text = "(" @ class'DHVoiceReplicationInfo'.default.PublicChannelNames[1] @ ")";
+                }
             }
             else
             {
@@ -5061,14 +5069,20 @@ function DisplayVoiceGain(Canvas C)
 
         if (VCR != none)
         {
-            ActiveName = VCR.GetTitle();
+            // If it is a public channel display its title normally
+            if (!VCR.IsPrivateChannel())
+            {
+                ActiveName = VCR.GetTitle();
+            }
+            else // Private channels will be displayed as "Local" (way to make private channels look like a single local channel)
+            {
+                ActiveName = class'DHVoiceReplicationInfo'.default.PublicChannelNames[1];
+            }
         }
-    }
-
-    // Display name of currently active channel
-    if (PlayerOwner != none && PlayerOwner.ActiveRoom != none)
-    {
-        ActiveName = PlayerOwner.ActiveRoom.GetTitle();
+        else if (PlayerOwner.ActiveRoom != none)
+        {
+            ActiveName = PlayerOwner.ActiveRoom.GetTitle();
+        }
     }
 
     // Remove for release

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -4528,6 +4528,28 @@ exec function Speak(string ChannelTitle)
             }
         }
     }
+    else if (ChannelTitle ~= "LOCAL")
+    {
+        VRI = DHVoiceReplicationInfo(VoiceReplicationInfo);
+
+        // Hack, instead of speaking in local channel, lets speak in our own private channel (which acts as local)
+        VCR = VRI.GetPrivateChannel(PRI);
+
+        if (VCR == none)
+        {
+            return;
+        }
+    }
+    else if (ChannelTitle ~= "UNASSIGNED" && PRI.IsInSquad())
+    {
+        // If we are trying to speak in unassigned and we are in a squad, then return out
+        return;
+    }
+    else if (ChannelTitle ~= "COMMAND" && !PRI.IsSquadLeader())
+    {
+        // Don't let non squad leaders speak in command
+        return;
+    }
     else
     {
         // Check that we are a member of this room.

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -4945,6 +4945,54 @@ function bool TeleportPlayer(vector SpawnLocation, rotator SpawnRotation)
     return false;
 }
 
+// Modified to allow for switching to a channel the user is already a member of (for private channels)
+function ServerSpeak(int ChannelIndex, optional string ChannelPassword)
+{
+    local VoiceChatRoom VCR;
+    local int Index;
+
+    if (VoiceReplicationInfo == none)
+    {
+        return;
+    }
+
+    VCR = VoiceReplicationInfo.GetChannelAt(ChannelIndex);
+
+    if (VCR == none)
+    {
+        if (VoiceReplicationInfo.bEnableVoiceChat)
+        {
+            ChatRoomMessage(0, ChannelIndex);
+        }
+        else
+        {
+            ChatRoomMessage(15, ChannelIndex);
+        }
+
+        return;
+    }
+
+    if (!VCR.IsMember(PlayerReplicationInfo) && VCR.IsPublicChannel())
+    {
+        if (ServerJoinVoiceChannel(ChannelIndex, ChannelPassword) != JCR_Success)
+        {
+            return;
+        }
+    }
+
+    Index = -1;
+    ActiveRoom = VCR;
+    Log(PlayerReplicationInfo.PlayerName@"speaking on"@VCR.GetTitle(),'VoiceChat');
+    ChatRoomMessage(9, ChannelIndex);
+    ClientSetActiveRoom(VCR.ChannelIndex);
+    Index = VCR.ChannelIndex;
+
+    if (PlayerReplicationInfo != none)
+    {
+        PlayerReplicationinfo.ActiveChannel = Index;
+    }
+}
+
 defaultproperties
 {
     // Sway values

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -4993,6 +4993,30 @@ function ServerSpeak(int ChannelIndex, optional string ChannelPassword)
     }
 }
 
+simulated event ChatRoomMessage(byte Result, int ChannelIndex, optional PlayerReplicationInfo RelatedPRI)
+{
+    local VoiceChatRoom     VCR;
+
+    if (VoiceReplicationInfo != none && ChatRoomMessageClass != none)
+    {
+        VCR = VoiceReplicationInfo.GetChannelAt(ChannelIndex);
+
+        if (VCR == none)
+        {
+            return;
+        }
+
+        if (!VCR.IsPrivateChannel())
+        {
+            ClientMessage(ChatRoomMessageClass.static.AssembleMessage(Result, VCR.GetTitle(), RelatedPRI));
+        }
+        else
+        {
+            ClientMessage(ChatRoomMessageClass.static.AssembleMessage(Result, class'DHVoiceReplicationInfo'.default.PublicChannelNames[1], RelatedPRI));
+        }
+    }
+}
+
 defaultproperties
 {
     // Sway values

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -4518,7 +4518,7 @@ exec function Speak(string ChannelTitle)
     {
         VRI = DHVoiceReplicationInfo(VoiceReplicationInfo);
 
-        if (VRI != none)
+        if (VRI != none && PRI != none)
         {
             VCR = VRI.GetSquadChannel(GetTeamNum(), PRI.SquadIndex);
 
@@ -4533,11 +4533,14 @@ exec function Speak(string ChannelTitle)
         VRI = DHVoiceReplicationInfo(VoiceReplicationInfo);
 
         // Hack, instead of speaking in local channel, lets speak in our own private channel (which acts as local)
-        VCR = VRI.GetPrivateChannel(PRI);
-
-        if (VCR == none)
+        if (VRI != none && PRI != none)
         {
-            return;
+            VCR = VRI.GetChannel(PRI.PlayerName, PRI.Team.TeamIndex);
+
+            if (VCR == none)
+            {
+                return;
+            }
         }
     }
     else if (ChannelTitle ~= "UNASSIGNED" && PRI.IsInSquad())

--- a/DH_Engine/Classes/DHSquadReplicationInfo.uc
+++ b/DH_Engine/Classes/DHSquadReplicationInfo.uc
@@ -538,7 +538,7 @@ function bool LeaveSquad(DHPlayerReplicationInfo PRI)
 
         if (SquadVCR != none)
         {
-            TeamVCR = VRI.GetChannel("Team", TeamIndex);
+            TeamVCR = VRI.GetChannel("Unassigned", TeamIndex);
 
             // Change the player's voice channel to the "team" channel.
             Level.Game.ChangeVoiceChannel(PRI, TeamVCR.ChannelIndex, SquadVCR.ChannelIndex);

--- a/DH_Engine/Classes/DHVehicle.uc
+++ b/DH_Engine/Classes/DHVehicle.uc
@@ -2445,7 +2445,7 @@ function SetTeamNum(byte NewTeam)
         TeamChanged();
     }
 
-    for (i = 0; i < WeaponPawns.length; ++i)
+    for (i = 0; i < WeaponPawns.Length; ++i)
     {
         if (WeaponPawns[i] != none)
         {

--- a/DH_Engine/Classes/DHVoiceChatRoom.uc
+++ b/DH_Engine/Classes/DHVoiceChatRoom.uc
@@ -67,7 +67,6 @@ simulated event bool IsMember(PlayerReplicationInfo PRI, optional bool bNoCascad
 
                 if (OwnerPawn != none && CheckPawn != none && VSizeSquared(OwnerPawn.Location - CheckPawn.Location) < Square(class'DHVoiceReplicationInfo'.default.LocalBroadcastRange))
                 {
-                    Log ("This channel's index is: " $ ChannelIndex);
                     return true;
                 }
                 else

--- a/DH_Engine/Classes/DHVoiceChatRoom.uc
+++ b/DH_Engine/Classes/DHVoiceChatRoom.uc
@@ -65,7 +65,7 @@ simulated event bool IsMember(PlayerReplicationInfo PRI, optional bool bNoCascad
                     CheckPawn = PlayerController(MyPRI.Owner).Pawn;
                 }
 
-                if (OwnerPawn != none && CheckPawn != none && VSizeSquared(OwnerPawn.Location - CheckPawn.Location) < class'DHUnits'.static.MetersToUnreal(20))
+                if (OwnerPawn != none && CheckPawn != none && VSizeSquared(OwnerPawn.Location - CheckPawn.Location) < Square(class'DHVoiceReplicationInfo'.default.LocalBroadcastRange))
                 {
                     Log ("This channel's index is: " $ ChannelIndex);
                     return true;
@@ -102,15 +102,11 @@ simulated function array<PlayerReplicationInfo> GetMembers()
 
     if (GRI != none && ValidMask())
     {
-        for (i = 0; i < GRI.PRIArray.length; ++i)
+        for (i = 0; i < GRI.PRIArray.Length; ++i)
         {
-            if (IsMember(GRI.PRIArray[i]))
+            if (IsMember(GRI.PRIArray[i]) || (IsPrivateChannel() && GRI.PRIArray[i].Team != none && GRI.PRIArray[i].Team.TeamIndex == GetTeam()))
             {
-                PRIArray[PRIArray.length] = GRI.PRIArray[i];
-            }
-            else if (IsPrivateChannel() && GRI.PRIArray[i].Team != none && GRI.PRIArray[i].Team.TeamIndex == GetTeam())
-            {
-                PRIArray[PRIArray.length] = GRI.PRIArray[i];
+                PRIArray[PRIArray.Length] = GRI.PRIArray[i];
             }
         }
     }

--- a/DH_Engine/Classes/DHVoiceChatRoom.uc
+++ b/DH_Engine/Classes/DHVoiceChatRoom.uc
@@ -11,7 +11,7 @@ var int SquadIndex;
 // NOTE: overridden to eliminate "has left channel" chat messages
 function RemoveMember(PlayerReplicationInfo PRI)
 {
-    if (PRI != none && PRI.VoiceID < 32 && IsMember(PRI, true))
+    if (PRI != none && PRI.VoiceID < 255 && IsMember(PRI, true))
     {
         SetMask(GetMask() & ~(1 << PRI.VoiceID));
     }
@@ -22,9 +22,16 @@ simulated function bool IsSquadChannel()
     return SquadIndex >= 0;
 }
 
+simulated function bool IsCommandChannel()
+{
+    return ChannelIndex == 0;
+}
+
 simulated event bool IsMember(PlayerReplicationInfo PRI, optional bool bNoCascade)
 {
-    local DHPlayerReplicationInfo MyPRI;
+    local DHPlayerReplicationInfo   MyPRI;
+    local Pawn                      OwnerPawn, CheckPawn;
+    //local DHPlayer                  PC;
 
     MyPRI = DHPlayerReplicationInfo(PRI);
 
@@ -36,8 +43,42 @@ simulated event bool IsMember(PlayerReplicationInfo PRI, optional bool bNoCascad
             {
                 return MyPRI != none && MyPRI.SquadIndex == SquadIndex;
             }
+            else if (IsCommandChannel() && MyPRI.IsSquadLeader())
+            {
+                return true;
+            }
+            else if (!IsSquadChannel() && MyPRI.IsInSquad())
+            {
+                return false;
+            }
+            else if (IsPrivateChannel())
+            {
+                // Get owner pawn
+                if (PlayerReplicationInfo(Owner) != none && PlayerReplicationInfo(Owner).Owner != none && PlayerController(PlayerReplicationInfo(Owner).Owner).Pawn != none)
+                {
+                    OwnerPawn = PlayerController(PlayerReplicationInfo(Owner).Owner).Pawn;
+                }
 
-            return true;
+                // Get CheckPawn
+                if (MyPRI != none && MyPRI.Owner != none && PlayerController(MyPRI.Owner).Pawn != none)
+                {
+                    CheckPawn = PlayerController(MyPRI.Owner).Pawn;
+                }
+
+                if (OwnerPawn != none && CheckPawn != none && VSizeSquared(OwnerPawn.Location - CheckPawn.Location) < class'DHUnits'.static.MetersToUnreal(20))
+                {
+                    Log ("This channel's index is: " $ ChannelIndex);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return true;
+            }
         }
     }
 
@@ -52,6 +93,29 @@ simulated event bool IsMember(PlayerReplicationInfo PRI, optional bool bNoCascad
     }
 
     return bool(GetMask() & (1 << PRI.VoiceID));
+}
+
+simulated function array<PlayerReplicationInfo> GetMembers()
+{
+    local array<PlayerReplicationInfo>      PRIArray;
+    local int                               i;
+
+    if (GRI != none && ValidMask())
+    {
+        for (i = 0; i < GRI.PRIArray.length; ++i)
+        {
+            if (IsMember(GRI.PRIArray[i]))
+            {
+                PRIArray[PRIArray.length] = GRI.PRIArray[i];
+            }
+            else if (IsPrivateChannel() && GRI.PRIArray[i].Team != none && GRI.PRIArray[i].Team.TeamIndex == GetTeam())
+            {
+                PRIArray[PRIArray.length] = GRI.PRIArray[i];
+            }
+        }
+    }
+
+    return PRIArray;
 }
 
 defaultproperties

--- a/DH_Engine/Classes/DHVoiceReplicationInfo.uc
+++ b/DH_Engine/Classes/DHVoiceReplicationInfo.uc
@@ -16,11 +16,6 @@ replication
         AxisSquadChannels, AlliesSquadChannels;
 }
 
-simulated function VoiceChatRoom GetPrivateChannel(PlayerReplicationInfo PRI)
-{
-    return GetChannel(PRI.PlayerName, PRI.Team.TeamIndex);
-}
-
 simulated function VoiceChatRoom GetSquadChannel(int TeamIndex, int SquadIndex)
 {
     if (SquadIndex < 0 || SquadIndex >= SQUAD_CHANNELS_MAX)
@@ -119,7 +114,6 @@ function JoinSquadChannel(PlayerReplicationInfo PRI, int TeamIndex, int SquadInd
         VCR.AddMember(PRI);
     }
 
-    // Leave UNASSIGNED Channel
     LeaveUnassignedChannel(PRI, TeamIndex);
 }
 
@@ -136,9 +130,13 @@ function VerifyTeamChatters()
     for (P = Level.ControllerList; P != none; P = P.NextController)
     {
         PC = PlayerController(P);
-        PRI = DHPlayerReplicationInfo(PC.PlayerReplicationInfo);
 
-        if (PC != none && P.PlayerReplicationInfo != none && P.PlayerReplicationInfo.Team != none && PRI != none)
+        if (PC != none)
+        {
+            PRI = DHPlayerReplicationInfo(PC.PlayerReplicationInfo);
+        }
+
+        if (PRI != none && P.PlayerReplicationInfo != none && P.PlayerReplicationInfo.Team != none)
         {
             if (P.PlayerReplicationInfo.Team.TeamIndex == ALLIES_TEAM_INDEX)
             {
@@ -203,5 +201,7 @@ defaultproperties
     PublicChannelNames(17)="Squad"
     PublicChannelNames(18)="Squad"
     PublicChannelNames(19)="Squad"
+
+    LocalBroadcastRange=1500
 }
 

--- a/DH_Engine/Classes/DHVoiceReplicationInfo.uc
+++ b/DH_Engine/Classes/DHVoiceReplicationInfo.uc
@@ -202,6 +202,6 @@ defaultproperties
     PublicChannelNames(18)="Squad"
     PublicChannelNames(19)="Squad"
 
-    LocalBroadcastRange=1500
+    LocalBroadcastRange=1500 // Distance in UUs
 }
 

--- a/DH_Engine/Classes/DarkestHourGame.uc
+++ b/DH_Engine/Classes/DarkestHourGame.uc
@@ -4603,6 +4603,8 @@ defaultproperties
     bTimeChangesAtZeroReinf=true
     bPublicPlay=true
 
+    DefaultVoiceChannel="Unassigned"
+
     WeaponLockTimes(0)=0
     WeaponLockTimes(1)=2
     WeaponLockTimes(2)=5

--- a/DH_Interface/Classes/DHTab_Controls.uc
+++ b/DH_Interface/Classes/DHTab_Controls.uc
@@ -93,6 +93,12 @@ defaultproperties
     ControlProfiles(2)="Contemporary"
     ControlProfiles(3)="Recommended"
 
+    bindings_comm(6)="Speak Command"
+    captions_comm(6)="Switch to Command Voice Channel"
+    bindings_comm(7)="Speak Local"
+    captions_comm(7)="Switch to Local Voice Channel"
+    bindings_comm(8)="Speak Unassigned"
+    captions_comm(8)="Switch to Unassigned Voice Channel"
     bindings_comm(9)="SquadTalk"
     captions_comm(9)="Squad Say"
 
@@ -164,7 +170,7 @@ defaultproperties
     // Profile Bindings
     //****************
     // default (With DH fixes) this always gets applied before another profile
-    ControlProfileBindings(1)=(KeyNames=("Tab","GreyMinus","F2","F3","Minus","Equals","I","Insert","Capslock"),KeyValues=("ScoreToggle","CommunicationMenu","ShowVoteMenu","CommunicationMenu","","","SquadTalk","Speak Squad","ShowOrderMenu | OnRelease HideOrderMenu"))
+    ControlProfileBindings(1)=(KeyNames=("Tab","GreyMinus","F2","F3","Minus","Equals","I","Insert","Capslock","Home","End"),KeyValues=("ScoreToggle","CommunicationMenu","ShowVoteMenu","CommunicationMenu","","","SquadTalk","Speak Squad","ShowOrderMenu | OnRelease HideOrderMenu","Speak Command","Speak Unassigned"))
     // Contemporary
     ControlProfileBindings(2)=(KeyNames=("F","Z","V","RightMouse","MiddleMouse"),KeyValues=("Use","Prone","Deploy","ROIronSights","AltFire"))
     // Recommended


### PR DESCRIPTION
 * Removed limit on VoiceID to be less than 32 (will break bit field masks, so muting players, local, and public channels will no longer work)
 * Replaced "Team" channel with "Unassigned"
 * Replaced "Public" channel with "Command"
 * Hijacked "Local" channel so it is no longer used and instead when a player "Speaks Local" they speak in their own private voice channel
 * Changed the IsMember() function to handle new channels appropriately
 * Change some default controls to fit the changes

Note how it all works:

The "Team" channel is now just labeled as "Unassigned" and it basically acts the same way as it did before, but now it will ignore players that are in a squad.  Also I've made it so if you are in a squad, you can't "Speak Unassigned" which if allowed would be confusing (speak but not receive).

The "Public" channel is now just labeled as "Command" and it was changed to act the same way as "Team" was, but now it will ignore players that are not Squad Leaders.  Also I've made it so only Squad Leaders can "Speak Command"

Now for the crazy part!
The local channel is FUBAR, so lets just ignore it!  Instead I've made it so if you "Speak Local" instead of activating Local it activates the players personal voice channel.  Which always existed before!  However, now its more useful in that when players speak into their own channels, it does a member check and anyone on their team and within a radius can hear them!  Functionally it is the same as "Local" was before, but now it shouldn't break with more than 32 players because it isn't bit mask based.