### PR TITLE
Fix for bug https://github.com/DarklightGames/DarkestHour/issues/911

### DIFF
--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -1261,7 +1261,7 @@ simulated function vector GetWorldCoords(float X, float Y)
     MapCenter = NorthEastBounds + ((SouthWestBounds - NorthEastBounds) * 0.5);
     WorldLocation.X = ((0.5 - X) * MapScale);
     WorldLocation.Y = ((0.5 - Y) * MapScale);
-    WorldLocation = GetAdjustedHudLocation(WorldLocation);
+    WorldLocation = GetAdjustedHudLocation(WorldLocation, true);
     WorldLocation += MapCenter;
 
     return WorldLocation;


### PR DESCRIPTION
Tested on rotated maps along with non-rotated maps.
Markers now match up to where you place them.
![](https://i.imgur.com/EHpZPvv.gif)
