### PR TITLE
add DHRoundDuration to GameReplicationInfo. This variable always repl…

### DIFF
--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -72,6 +72,7 @@ var int                 RoundOverTime;      // The time stamp at which the round
 var int                 SpawningEnableTime; // When spawning for the round should be enabled (default: 0)
 
 var int                 DHRoundLimit;       // Added this so that a changing round limit can be replicated to clients.
+var int                 DHRoundDuration;    // Added this so that a more flexible changing round duration can be replicated to clients (e.g change to unlimited)
 
 var DHRoleInfo          DHAxisRoles[ROLES_MAX];
 var DHRoleInfo          DHAlliesRoles[ROLES_MAX];
@@ -183,7 +184,8 @@ replication
         AlliesMapMarkers,
         bAllowAllChat,
         RoundOverTime,
-        DHRoundLimit;
+        DHRoundLimit,
+        DHRoundDuration;
 
     reliable if (bNetInitial && (Role == ROLE_Authority))
         AlliedNationID, AlliesVictoryMusicIndex, AxisVictoryMusicIndex,

--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -4680,7 +4680,7 @@ function DrawSpectatingHud(Canvas C)
         // Update & draw round timer
         CurrentTime = DHGRI.GetRoundTimeRemaining();
 
-        if (DHGRI.RoundDuration == 0)
+        if (DHGRI.DHRoundDuration == 0)
         {
             s = default.TimeRemainingText $ default.NoTimeLimitText;
         }

--- a/DH_Engine/Classes/DarkestHourGame.uc
+++ b/DH_Engine/Classes/DarkestHourGame.uc
@@ -216,6 +216,7 @@ function PostBeginPlay()
     }
 
     GRI.RoundDuration = RoundDuration;
+    GRI.DHRoundDuration = RoundDuration;
     GRI.bReinforcementsComing[AXIS_TEAM_INDEX] = 0;
     GRI.bReinforcementsComing[ALLIES_TEAM_INDEX] = 0;
     GRI.ReinforcementInterval[AXIS_TEAM_INDEX] = LevelInfo.Axis.ReinforcementInterval;

--- a/DH_Interface/Classes/DHDeployMenu.uc
+++ b/DH_Interface/Classes/DHDeployMenu.uc
@@ -371,7 +371,7 @@ function UpdateRoundStatus()
             i_SizeAdvantage.Hide();
         }
 
-        if (GRI.RoundDuration == 0 && GRI.bMatchHasBegun)
+        if (GRI.DHRoundDuration == 0 && GRI.bMatchHasBegun)
         {
             l_RoundTime.Caption = class'DHHud'.default.NoTimeLimitText;
         }

--- a/DH_Interface/Classes/DHScoreBoard.uc
+++ b/DH_Interface/Classes/DHScoreBoard.uc
@@ -390,7 +390,7 @@ simulated function UpdateScoreBoard(Canvas C)
     // Construct a line with various information about the round & the server
     s = HUD.default.TimeRemainingText; // start with the round timer (time remaining)
 
-    if (DHGRI.RoundDuration == 0)
+    if (DHGRI.DHRoundDuration == 0)
     {
         s $= HUD.default.NoTimeLimitText;
     }


### PR DESCRIPTION
…icates, allowing more flexible changes to the Round Duration (like setting it to Unlimited from in the game without restarting the map). A mutator will be baked in to the Admin Menu in the near future to take advantage of this functionality. This is my first commit to this repository, feel free to look it over and change if necessary. I'm open to all feedback.