### PR TITLE
Squad Vehicle Ownership

### DIFF
--- a/DH_Engine/Classes/DHVehicleMessage.uc
+++ b/DH_Engine/Classes/DHVehicleMessage.uc
@@ -10,6 +10,7 @@ class DHVehicleMessage extends ROVehicleMessage
 var localized string AllRiderPositionsFull;
 var localized string NoRiderPositions;
 var localized string VehicleBurning;
+var localized string OwnedByAnotherSquad;
 
 // Can't exit vehicle
 var localized string OpenHatchToExit;
@@ -108,6 +109,9 @@ static function string GetString(optional int Switch, optional PlayerReplication
         case 29:
             S = default.VehicleScuttleInitiated;
             break;
+        case 30:
+            S = default.OwnedByAnotherSquad;
+            break;
         default:
             break;
     }
@@ -145,4 +149,5 @@ defaultproperties
     CanOnlyLockFromCrewPosition="Can only lock or unlock vehicle if you are in a tank crew position"
     OtherCrewmanCanLockVehicle="Only the most senior crew position can lock or unlock vehicle"
     VehicleScuttleInitiated="Vehicle scuttle initiated, vehicle must be clear of occupents"
+    OwnedByAnotherSquad="Vehicle owned by another squad"
 }

--- a/DH_Vehicles/Classes/DH_GMCTruckSupport.uc
+++ b/DH_Vehicles/Classes/DH_GMCTruckSupport.uc
@@ -7,6 +7,7 @@ class DH_GMCTruckSupport extends DH_GMCTruck;
 
 defaultproperties
 {
+    bSquadOwned=true
     VehicleNameString="GMC CCKW (Logistics)"
     PassengerPawns(1)=(AttachBone="passenger_l_5",DrivePos=(X=8.0,Y=0.0,Z=5.0),DriveAnim="VHalftrack_Rider4_idle")
     PassengerPawns(2)=(AttachBone="passenger_r_5",DrivePos=(X=8.0,Y=0.0,Z=5.0),DriveAnim="VHalftrack_Rider1_idle")


### PR DESCRIPTION
The goal of this pull request is:

- [ ] To create a system by which we can flag certain vehicles to only be enter-able by a particular squad

- [ ] To have options for the SL to control the owned vehicle, from releasing ownership to salvaging

- [ ] To have UI and visuals better indicate which squad owns said vehicle and showing them on the map properly, etc.

 * Added the basics to allow setting for vehicles to be squad owned, meaning NO ONE else can enter the vehicle