### PR TITLE
Fix dedicated server (machine) HTTP connection issue

### DIFF
--- a/UCore/Classes/UCoreBufferedTCPLink.uc
+++ b/UCore/Classes/UCoreBufferedTCPLink.uc
@@ -31,6 +31,8 @@ function Resolved(IpAddr Addr)
 
     BindPortResult = BindPort();
 
+    Log("============================================= BINDPORT returns:" @ BindPortResult);
+
     // Bind the local port.
     if (BindPortResult == 0)
     {


### PR DESCRIPTION
This is one of the most important things to fix/solve because it opens a door to so many potentially good things that I'm surprised we haven't fixed it yet. If we can't solve it, then we should consider making an outside tool which effectively does the same thing.

This could be used for:
- Properly getting Patron ID
- Can make use of the Steam Web API: https://steamcommunity.com/dev
- Stats/experience/badges/achievements/reputation
- Global ban list
- Servers could communicate 
- A on-going campaign could be created
