### PR TITLE
Initial commit for Munition Changes

### DIFF
--- a/DH_Construction/Classes/DHConstruction_Resupply.uc
+++ b/DH_Construction/Classes/DHConstruction_Resupply.uc
@@ -82,9 +82,9 @@ defaultproperties
     DuplicateFriendlyDistanceInMeters=25.0
     CollisionRadius=50.0
     CollisionHeight=30.0
-    SupplyCost=250
+    SupplyCost=500
     bCanPlaceIndoors=true
-    ResupplyCount=25
+    ResupplyCount=100
     HealthMax=50
     ConstructionVerb="drop"
     StartRotationMin=(Yaw=-16384)

--- a/DH_Construction/Classes/DHConstruction_Resupply.uc
+++ b/DH_Construction/Classes/DHConstruction_Resupply.uc
@@ -28,6 +28,7 @@ function PostBeginPlay()
             ResupplyAttachment.SetCollisionSize(ResupplyAttachmentCollisionRadius, ResupplyAttachmentCollisionHeight);
             ResupplyAttachment.SetBase(self);
             ResupplyAttachment.OnPawnResupplied = MyOnPawnResupplied;
+            ResupplyAttachment.bShowOnMap = true;
         }
         else
         {

--- a/DH_Construction/Classes/DHConstruction_Resupply_Vehicles.uc
+++ b/DH_Construction/Classes/DHConstruction_Resupply_Vehicles.uc
@@ -29,5 +29,4 @@ defaultproperties
     ResupplyAttachmentCollisionRadius=600.0
     MenuName="Ammo Crate (Vehicles)"
     MenuDescription="Provides a resupply point for vehicles and guns."
-    ResupplyCount=50    // TODO: remove this once we decrease the maximum amount AT guns can hold etc.
 }

--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -14,6 +14,7 @@ const OBJECTIVES_MAX = 32;
 const CONSTRUCTION_CLASSES_MAX = 32;
 const VOICEID_MAX = 255;
 const SUPPLY_POINTS_MAX = 15;
+const RESUPPLY_ATTACHEMENTS_MAX = 32;
 const MAP_MARKERS_MAX = 20;
 const MAP_MARKERS_CLASSES_MAX = 16;
 const ARTILLERY_TYPES_MAX = 8;
@@ -134,6 +135,8 @@ var DHSpawnPointBase    SpawnPoints[SPAWN_POINTS_MAX];
 var DHObjective             DHObjectives[OBJECTIVES_MAX];
 var Hashtable_string_int    DHObjectiveTable; // not replicated, but clients create their own so can be used by both client/server
 
+var DHResupplyAttachment    ResupplyAttachments[RESUPPLY_ATTACHEMENTS_MAX];
+
 var bool                bIsInSetupPhase;
 var bool                bRoundIsOver;
 
@@ -214,6 +217,7 @@ replication
         GameType,
         CurrentAlliedToAxisRatio,
         SpawnPoints,
+        ResupplyAttachments,
         SpawningEnableTime,
         bIsInSetupPhase,
         bRoundIsOver,
@@ -540,6 +544,59 @@ simulated event Timer()
     if (Role < ROLE_Authority && DHPlayer(Level.GetLocalPlayerController()) != none)
     {
         DHPlayer(Level.GetLocalPlayerController()).CheckUnlockWeapons();
+    }
+}
+
+//==============================================================================
+// Resupply Attachements
+//==============================================================================
+// Function to add a ResupplyAttachement to an array which is used for iteration, returns the index it was added (-1 if it wasn't added)
+function int AddResupplyAttachement(DHResupplyAttachment Attachment)
+{
+    local int i;
+
+    if (Attachment == none)
+    {
+        return -1;
+    }
+
+    // Check for a duplicate first
+    for (i = 0; i < arraycount(ResupplyAttachments); ++i)
+    {
+        if (Attachment == ResupplyAttachments[i])
+        {
+            return -1; // Attachement already exists in array (return -1 as it wasn't added)
+        }
+    }
+
+    // Now find the nearest valid spot and add it
+    for (i = 0; i < arraycount(ResupplyAttachments); ++i)
+    {
+        if (ResupplyAttachments[i] == none)
+        {
+            ResupplyAttachments[i] = Attachment;
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+function RemoveResupplyAttachement(DHResupplyAttachment Attachment)
+{
+    local int i;
+
+    if (Attachment == none)
+    {
+        return;
+    }
+
+    for (i = 0; i < arraycount(ResupplyAttachments); ++i)
+    {
+        if (ResupplyAttachments[i] == Attachment)
+        {
+            ResupplyAttachments[i] = none;
+        }
     }
 }
 

--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -86,6 +86,9 @@ var     SpriteWidget        SupplyCountWidget;
 var     SpriteWidget        SupplyCountIconWidget;
 var     TextWidget          SupplyCountTextWidget;
 
+// Resupply Attachment
+var     SpriteWidget        ResupplyAttachmentIcon;
+
 // Construction
 var     SpriteWidget        VehicleSuppliesIcon;
 var     TextWidget          VehicleSuppliesText;
@@ -3387,6 +3390,22 @@ function DrawMap(Canvas C, AbsoluteCoordsInfo SubCoords, DHPlayer Player, Box Vi
         }
     }
 
+    // Draw resupply attachments
+    for (i = 0; i < arraycount(DHGRI.ResupplyAttachments); ++i)
+    {
+        if (DHGRI.ResupplyAttachments[i] == none || !DHGRI.ResupplyAttachments[i].bShowOnMap ||
+            (DHGRI.ResupplyAttachments[i].GetTeamIndex() != OwnerTeam && DHGRI.ResupplyAttachments[i].GetTeamIndex() != NEUTRAL_TEAM_INDEX))
+        {
+            continue;
+        }
+
+        // Get the Widget texture
+        ResupplyAttachmentIcon.WidgetTexture = DHGRI.ResupplyAttachments[i].GetAttachmentIcon();
+
+        // Draw the Widget
+        DHDrawIconOnMap(C, SubCoords, ResupplyAttachmentIcon, MyMapScale, DHGRI.ResupplyAttachments[i].Location, MapCenter, Viewport);
+    }
+
     // Draw supply points
     for (i = 0; i < arraycount(DHGRI.SupplyPoints); ++i)
     {
@@ -6090,6 +6109,8 @@ defaultproperties
 
     SupplyPointIcon=(WidgetTexture=FinalBlend'DH_GUI_tex.GUI.supply_point_final',TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.04,DrawPivot=DP_MiddleMiddle,ScaleMode=SM_Left,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
 
+    ResupplyAttachmentIcon=(WidgetTexture=none,TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.03,DrawPivot=DP_MiddleMiddle,ScaleMode=SM_Left,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=0,G=124,B=252,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
+
     // Map markers
     MapMarkerIcon=(WidgetTexture=none,RenderStyle=STY_Alpha,TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.04,DrawPivot=DP_MiddleMiddle,ScaleMode=SM_Left,Scale=1.0,Tints[0]=(R=0,G=0,B=255,A=255),Tints[1]=(R=0,G=0,B=255,A=255))
 
@@ -6129,7 +6150,7 @@ defaultproperties
     VehicleSmokeLauncherRangeInfill=(WidgetTexture=Texture'DH_InterfaceArt_tex.Tank_Hud.SmokeLauncher_rangebar_infill',TextureCoords=(X1=0,Y1=0,X2=63,Y2=255),TextureScale=0.096,DrawPivot=DP_LowerLeft,PosX=0.37,PosY=1.0,OffsetX=-10,OffsetY=-18,ScaleMode=SM_Up,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
 
     // Construction
-    VehicleSuppliesIcon=(WidgetTexture=Texture'DH_InterfaceArt2_tex.Icons.supply_cache',TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=1.0,DrawPivot=DP_MiddleMiddle,PosX=0.5,PosY=0.0,OffsetX=-24,OffsetY=-16,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
+    VehicleSuppliesIcon=(WidgetTexture=Texture'DH_InterfaceArt2_tex.Icons.supply_cache',TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.4,DrawPivot=DP_MiddleMiddle,PosX=0.5,PosY=0.0,OffsetX=-24,OffsetY=-16,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
     VehicleSuppliesText=(PosX=0.5,PosY=0,WrapWidth=0,WrapHeight=0,OffsetX=-8,OffsetY=-16,DrawPivot=DP_MiddleLeft,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255),bDrawShadow=true)
 
     // Indicators

--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -6109,7 +6109,7 @@ defaultproperties
 
     SupplyPointIcon=(WidgetTexture=FinalBlend'DH_GUI_tex.GUI.supply_point_final',TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.04,DrawPivot=DP_MiddleMiddle,ScaleMode=SM_Left,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
 
-    ResupplyAttachmentIcon=(WidgetTexture=none,TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.03,DrawPivot=DP_MiddleMiddle,ScaleMode=SM_Left,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=0,G=124,B=252,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
+    ResupplyAttachmentIcon=(WidgetTexture=none,TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.05,DrawPivot=DP_MiddleMiddle,ScaleMode=SM_Left,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=0,G=124,B=252,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
 
     // Map markers
     MapMarkerIcon=(WidgetTexture=none,RenderStyle=STY_Alpha,TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.04,DrawPivot=DP_MiddleMiddle,ScaleMode=SM_Left,Scale=1.0,Tints[0]=(R=0,G=0,B=255,A=255),Tints[1]=(R=0,G=0,B=255,A=255))
@@ -6150,7 +6150,7 @@ defaultproperties
     VehicleSmokeLauncherRangeInfill=(WidgetTexture=Texture'DH_InterfaceArt_tex.Tank_Hud.SmokeLauncher_rangebar_infill',TextureCoords=(X1=0,Y1=0,X2=63,Y2=255),TextureScale=0.096,DrawPivot=DP_LowerLeft,PosX=0.37,PosY=1.0,OffsetX=-10,OffsetY=-18,ScaleMode=SM_Up,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
 
     // Construction
-    VehicleSuppliesIcon=(WidgetTexture=Texture'DH_InterfaceArt2_tex.Icons.supply_cache',TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.4,DrawPivot=DP_MiddleMiddle,PosX=0.5,PosY=0.0,OffsetX=-24,OffsetY=-16,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
+    VehicleSuppliesIcon=(WidgetTexture=Texture'DH_InterfaceArt2_tex.Icons.supply_cache',TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.3,DrawPivot=DP_MiddleMiddle,PosX=0.5,PosY=0.0,OffsetX=-24,OffsetY=-16,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
     VehicleSuppliesText=(PosX=0.5,PosY=0,WrapWidth=0,WrapHeight=0,OffsetX=-8,OffsetY=-16,DrawPivot=DP_MiddleLeft,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255),bDrawShadow=true)
 
     // Indicators

--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -6107,7 +6107,7 @@ defaultproperties
     MapIconMortarHit=(WidgetTexture=Texture'InterfaceArt_tex.OverheadMap.overheadmap_Icons',RenderStyle=STY_Alpha,TextureCoords=(Y1=64,X2=63,Y2=127),TextureScale=0.05,DrawPivot=DP_LowerMiddle,ScaleMode=SM_Left,Scale=1.0,Tints[0]=(B=255,G=255,R=255,A=255),Tints[1]=(B=255,G=255,R=255,A=255))
     MapIconEnemyRallyPoint=(WidgetTexture=Texture'DH_InterfaceArt2_tex.Icons.rally_point',RenderStyle=STY_Alpha,TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.04,DrawPivot=DP_MiddleMiddle,ScaleMode=SM_Left,Scale=1.0,Tints[0]=(R=255,G=0,B=0,A=255),Tints[1]=(R=255,G=0,B=0,A=255))
 
-    SupplyPointIcon=(WidgetTexture=FinalBlend'DH_GUI_tex.GUI.supply_point_final',TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.04,DrawPivot=DP_MiddleMiddle,ScaleMode=SM_Left,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
+    SupplyPointIcon=(WidgetTexture=FinalBlend'DH_GUI_tex.GUI.supply_point_final',TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.03,DrawPivot=DP_MiddleMiddle,ScaleMode=SM_Left,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
 
     ResupplyAttachmentIcon=(WidgetTexture=none,TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.05,DrawPivot=DP_MiddleMiddle,ScaleMode=SM_Left,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=0,G=124,B=252,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
 
@@ -6150,7 +6150,7 @@ defaultproperties
     VehicleSmokeLauncherRangeInfill=(WidgetTexture=Texture'DH_InterfaceArt_tex.Tank_Hud.SmokeLauncher_rangebar_infill',TextureCoords=(X1=0,Y1=0,X2=63,Y2=255),TextureScale=0.096,DrawPivot=DP_LowerLeft,PosX=0.37,PosY=1.0,OffsetX=-10,OffsetY=-18,ScaleMode=SM_Up,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
 
     // Construction
-    VehicleSuppliesIcon=(WidgetTexture=Texture'DH_InterfaceArt2_tex.Icons.supply_cache',TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=0.3,DrawPivot=DP_MiddleMiddle,PosX=0.5,PosY=0.0,OffsetX=-24,OffsetY=-16,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
+    VehicleSuppliesIcon=(WidgetTexture=Texture'DH_InterfaceArt2_tex.Icons.supply_cache',TextureCoords=(X1=0,Y1=0,X2=31,Y2=31),TextureScale=1.0,DrawPivot=DP_MiddleMiddle,PosX=0.5,PosY=0.0,OffsetX=-24,OffsetY=-16,Scale=1.0,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255))
     VehicleSuppliesText=(PosX=0.5,PosY=0,WrapWidth=0,WrapHeight=0,OffsetX=-8,OffsetY=-16,DrawPivot=DP_MiddleLeft,RenderStyle=STY_Alpha,Tints[0]=(R=255,G=255,B=255,A=255),Tints[1]=(R=255,G=255,B=255,A=255),bDrawShadow=true)
 
     // Indicators

--- a/DarkestHourDev/Textures/DH_InterfaceArt2_tex.utx
+++ b/DarkestHourDev/Textures/DH_InterfaceArt2_tex.utx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8fe8c6bd7a89c74c0a4deeebca9cf7363788f83a4484b55c0c8e4dedbc595b88
+oid sha256:ed5c3159ff09202029e487aec227cac9f20f0e3d8ebe350e33aab08f2c7821fc
 size 474377

--- a/DarkestHourDev/Textures/DH_InterfaceArt2_tex.utx
+++ b/DarkestHourDev/Textures/DH_InterfaceArt2_tex.utx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58356cbe3a3604b0356d4d4b17801f31a1e81ae72d94bd9717b316f83e80fbe5
+oid sha256:8fe8c6bd7a89c74c0a4deeebca9cf7363788f83a4484b55c0c8e4dedbc595b88
 size 474377

--- a/DarkestHourDev/Textures/DH_InterfaceArt2_tex.utx
+++ b/DarkestHourDev/Textures/DH_InterfaceArt2_tex.utx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:547e39c84afd1c76dad82ffcc61a53927b112b2c36590903bdd4d776a00015f0
-size 465938
+oid sha256:58356cbe3a3604b0356d4d4b17801f31a1e81ae72d94bd9717b316f83e80fbe5
+size 474377


### PR DESCRIPTION
Initial Changes:
 * Added 2 icons for Infantry and Vehicle munition boxes
 * Reduced size of the supply cache icon
 * Munition boxes (both infantry and vehicle) now show on the map for friendlies (via HUD changes)
 * Added replicated array in GRI to keep track of the resupply attachments for client use to display them on the map
 * ResupplyAttachment is now a dumb_proxy replicated actor (required so client knows location and other replicated variables)
 * Added replicated variable to ResupplyAttachment to determine if it should draw on the map or not (this way its not drawn for logi-trucks, etc.)

Notes:
Tested to work in MP, more testing is needed with enemies and digging them up. Icons use the same color as the team color but its defined in the widgit to save on function calls.