### PR TITLE
Fix the 'impossible to resupply hetzer' bug ? i guess?

### DIFF
--- a/DH_Vehicles/Classes/DH_HetzerCannon.uc
+++ b/DH_Vehicles/Classes/DH_HetzerCannon.uc
@@ -60,6 +60,9 @@ defaultproperties
      InitialSecondaryAmmo=10
      PrimaryProjectileClass=Class'DH_Vehicles.DH_JagdpanzerIVL48CannonShell'
      SecondaryProjectileClass=Class'DH_Vehicles.DH_JagdpanzerIVL48CannonShellHE'
+     MaxPrimaryAmmo=30
+     MaxSecondaryAmmo=15
+     MaxTertiaryAmmo=5
      Mesh=SkeletalMesh'DH_Hetzer_anm.Hetzer_turret'
      Skins(0)=Texture'DH_Hetzer_tex.hetzer_body'
 }


### PR DESCRIPTION
the hetzer cannon class didn't have its max ammo defined,
I guess it's why it couldn't resuply the main gun. if it the case, then this should solve it