### PR TITLE
New map for Halloween event, House of Horror is a "nazi zombies map" …

### DIFF
--- a/DarkestHourDev/Maps/DH-House_Of_Horror_Push.rom
+++ b/DarkestHourDev/Maps/DH-House_Of_Horror_Push.rom
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8e6d731973b3595d7c8e74ac4a3de137e73cf092c9d002584a77543cc4c5077
+size 81852544


### PR DESCRIPTION
…were the axis only spawn with melee weapone while the allies spawn with weapones but the allies can not respawn when they die so they have to change team when they die. The map was made by 29th Infantry and I got their promision to use the map.