### PR TITLE
Existing bThrowRagdoll may be a candidate to replace hardcoded class literals

### DIFF
--- a/DH_Engine/Classes/DHPawn.uc
+++ b/DH_Engine/Classes/DHPawn.uc
@@ -2126,9 +2126,12 @@ ignores Trigger, Bump, HitWall, HeadVolumeChange, PhysicsVolumeChange, Falling, 
                 return; // can't shoot corpses during de-res
             }
 
-            // Move the body if it's a grenade or mine explosion // TODO: add others explosive types & try to remove projectile-specific literals as far as possible
-            if (DamageType.Name == 'DH_StielGranateDamType' || DamageType.Name == 'DH_M1GrenadeDamType' || DamageType.Name == 'DH_F1GrenadeDamType'
-                || DamageType.Name == 'ROMineDamType' || DamageType.Name == 'ROSMineDamType' || DamageType.Name == 'DHATMineDamage')
+            // Move the body if it's a grenade or mine explosion
+            if (
+                    DamageType.default.bThrowRagdoll
+                ||  DamageType.IsA(class'ROMineDamType'.Name)//TODO: set default bThrowRagdoll=true in base RO class and remove this line
+                ||  DamageType.IsA(class'ROSMineDamType'.Name)//TODO: set default bThrowRagdoll=true in base RO class and remove this line
+            )
             {
                 ShotDir = Normal(Momentum);
                 PushLinVel = (RagDeathVel * ShotDir) +  vect(0.0, 0.0, 250.0);

--- a/DH_Engine/Classes/DHThrowableExplosiveDamageType.uc
+++ b/DH_Engine/Classes/DHThrowableExplosiveDamageType.uc
@@ -17,4 +17,5 @@ defaultproperties
     FemaleSuicide="%o was blown up by her own %w."
     DeathOverlayMaterial=Combiner'Effects_Tex.GoreDecals.PlayerDeathOverlay'
     DeathOverlayTime=999.0
+    bThrowRagdoll=true
 }


### PR DESCRIPTION
Hi,
I found that there is this existing DamageType.uc property "bThrowRagdoll" and it probably may help resolve TODO note from DHPawn line 2129:
> // TODO: add others explosive types & try to remove projectile-specific literals as far as possible

As far as I can tell both ROMineDamType and ROSMineDamType have bThrowRagdoll set to false so they cannot be removed from this if() statement completely (being outside of scope for this repository).
DHATMineDamage was fine to remove as it extends ROTankShellExplosionDamage with bThrowRagdoll==true.
All three DH_* classes inherit from DHThrowableExplosiveDamageType.uc for which value is changed in this pr.