### PR TITLE
Bugfixes for Hurtgenwald Advance

### DIFF
--- a/DarkestHourDev/Maps/DH-Hurtgenwald_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Hurtgenwald_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1da35ba82e42c31fbedd66734ed0fb20a5de55b8c438e4b12bb0da7553471839
-size 38813465
+oid sha256:a7234a3d4b1d28dfd82b45f42336b6500085bc695910fd5836ee87b14488634c
+size 38813789

--- a/DarkestHourDev/Maps/DH-Hurtgenwald_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Hurtgenwald_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:21982c2ed590b936539edf7510dd8b32e27af510e5774c70f47a330907fad427
-size 38813936
+oid sha256:1da35ba82e42c31fbedd66734ed0fb20a5de55b8c438e4b12bb0da7553471839
+size 38813465


### PR DESCRIPTION
- Potential fix for Ruins and Pak Bunker objective capture issue.

- Increased reinforcements value for Allies to 21 (was 19) and Axis to 20 (was 17).

- Slightly expanded minefield volume protecting Axis main spawn.