### PR TITLE
Carpiquet Overhaul and Rakowice Advance

### DIFF
--- a/DarkestHourDev/Maps/DH-Carpiquet_Airfield_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Carpiquet_Airfield_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81bf4c4ba862d61d5fc55e66cc7b4b413eaab5d2edd9686e5e44b0d1c1268b86
-size 37257929
+oid sha256:65257e52a57a90379267c1ef3c96061cd0a236a025ea3303df44e83784fe9f3b
+size 37578085

--- a/DarkestHourDev/Maps/DH-Rakowice_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Rakowice_Advance.rom
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6bb1c8349b7350a0e5307777c8545c6e962b2d8c8ce7b4a40447db638456793
+size 15593449


### PR DESCRIPTION
Significantly overhauled Carpiquet Airfield level:

- Optimization pass with improved culling for various statics and grass. Removed decolayer grass underneath wheat fields. Reduced overall resource usage in heaviest parts of the map.

- Bug fixes for various floating objects, spawnhints facing the wrong direction, transparent walls in small hangars and removed the ability to build AT guns on roofs.

- Replaced HQs with objective spawns.

- Rebalanced roles and constructions for both teams to better reflect historical situation. 

- Added limited Panther G tanks to Axis, added limited Sherman Firefly tanks to Allies.

- Increased view distance by roughly 50-75 meters. 

- Changed lighting and removed haze.

- Removed ticket bleed from all but first objective, set Refueling Area objective to inactive at start (first objective must be captured before it unlocks now). 

Converted Rakowice level to Advance game mode. 