### PR TITLE
Gunstats2

### DIFF
--- a/DH_Weapons/Classes/DH_KorovinWeapon.uc
+++ b/DH_Weapons/Classes/DH_KorovinWeapon.uc
@@ -3,7 +3,7 @@
 // Darklight Games (c) 2008-2019
 //==============================================================================
 
-class DH_KorovinWeapon extends DHFastAutoWeapon;
+class DH_KorovinWeapon extends DHAutoWeapon;
 
 defaultproperties
 {

--- a/DH_Weapons/Classes/DH_M1928_20rndFire.uc
+++ b/DH_Weapons/Classes/DH_M1928_20rndFire.uc
@@ -16,7 +16,7 @@ defaultproperties
     RecoilRate=0.05
     MaxVerticalRecoilAngle=270
     MaxHorizontalRecoilAngle=85
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.5),(InVal=5.0,OutVal=0.66),(InVal=9.0,OutVal=1.2),(InVal=20.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.33),(InVal=2.0,OutVal=0.6),(InVal=5.0,OutVal=0.7),(InVal=9.0,OutVal=1.2),(InVal=20.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=12.0
 
     FlashEmitterClass=class'ROEffects.MuzzleFlash1stPistol'

--- a/DH_Weapons/Classes/DH_M1928_30rndFire.uc
+++ b/DH_Weapons/Classes/DH_M1928_30rndFire.uc
@@ -16,7 +16,7 @@ defaultproperties
     RecoilRate=0.05
     MaxVerticalRecoilAngle=270
     MaxHorizontalRecoilAngle=85
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.5),(InVal=5.0,OutVal=0.66),(InVal=9.0,OutVal=1.2),(InVal=20.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.33),(InVal=2.0,OutVal=0.6),(InVal=5.0,OutVal=0.7),(InVal=9.0,OutVal=1.2),(InVal=20.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=12.0
 
     FlashEmitterClass=class'ROEffects.MuzzleFlash1stPistol'

--- a/DH_Weapons/Classes/DH_M1928_50rndFire.uc
+++ b/DH_Weapons/Classes/DH_M1928_50rndFire.uc
@@ -16,7 +16,7 @@ defaultproperties
     RecoilRate=0.05
     MaxVerticalRecoilAngle=245
     MaxHorizontalRecoilAngle=115
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.5),(InVal=5.0,OutVal=0.66),(InVal=9.0,OutVal=1.2),(InVal=20.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.33),(InVal=2.0,OutVal=0.6),(InVal=5.0,OutVal=0.7),(InVal=9.0,OutVal=1.2),(InVal=20.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=12.0
 
     FlashEmitterClass=class'ROEffects.MuzzleFlash1stPistol'

--- a/DH_Weapons/Classes/DH_M712Fire.uc
+++ b/DH_Weapons/Classes/DH_M712Fire.uc
@@ -16,7 +16,7 @@ defaultproperties
     RecoilRate=0.05
     MaxVerticalRecoilAngle=275
     MaxHorizontalRecoilAngle=120
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.5),(InVal=3.0,OutVal=0.66),(InVal=6.0,OutVal=1.3),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.3),(InVal=2.0,OutVal=0.7),(InVal=6.0,OutVal=1.3),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=10.0
 
     AmbientFireSound=SoundGroup'DH_WeaponSounds.c96.C96_FireLoop01'

--- a/DH_Weapons/Classes/DH_MP41RFire.uc
+++ b/DH_Weapons/Classes/DH_MP41RFire.uc
@@ -15,8 +15,8 @@ defaultproperties
     // Recoil
     RecoilRate=0.03335
     MaxVerticalRecoilAngle=235
-    MaxHorizontalRecoilAngle=66
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=5.0,OutVal=0.8),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    MaxHorizontalRecoilAngle=71
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.33),(InVal=2.0,OutVal=0.7),(InVal=4.0,OutVal=0.8),(InVal=10.0,OutVal=1.1),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=18.0
 
     AmbientFireSound=SoundGroup'DH_WeaponSounds.ppsh41.mp41r_fire_loopg'

--- a/DH_Weapons/Classes/DH_MP41RWeapon.uc
+++ b/DH_Weapons/Classes/DH_MP41RWeapon.uc
@@ -37,7 +37,7 @@ simulated function bool StartFire(int Mode)
 defaultproperties
 {
     SwayModifyFactor=0.75 // -0.5
-    ItemName="MP-41(r)"
+    ItemName="Maschinenpistole 41(r)"
 
     FireModeClass(0)=class'DH_Weapons.DH_MP41RFire'
     FireModeClass(1)=class'DH_Weapons.DH_MP41RMeleeFire'

--- a/DH_Weapons/Classes/DH_PPD40Fire.uc
+++ b/DH_Weapons/Classes/DH_PPD40Fire.uc
@@ -16,7 +16,7 @@ defaultproperties
     RecoilRate=0.05
     MaxVerticalRecoilAngle=270
     MaxHorizontalRecoilAngle=80
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.5),(InVal=4.0,OutVal=0.8),(InVal=10.0,OutVal=1.1),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.33),(InVal=2.0,OutVal=0.6),(InVal=4.0,OutVal=0.85),(InVal=10.0,OutVal=1.1),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=14.0
 
     AmbientFireSound=SoundGroup'DH_WeaponSounds.ppd40.ppd40_fire_loop'

--- a/DH_Weapons/Classes/DH_PPS43Fire.uc
+++ b/DH_Weapons/Classes/DH_PPS43Fire.uc
@@ -15,7 +15,7 @@ defaultproperties
     // Recoil
     RecoilRate=0.04285
     MaxVerticalRecoilAngle=260
-    MaxHorizontalRecoilAngle=85
+    MaxHorizontalRecoilAngle=80
     RecoilCurve=(Points=((InVal=0.0,OutVal=0.7),(InVal=5.0,OutVal=0.85),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=13.0
 

--- a/DH_Weapons/Classes/DH_PPSH41Fire.uc
+++ b/DH_Weapons/Classes/DH_PPSH41Fire.uc
@@ -14,9 +14,9 @@ defaultproperties
 
     // Recoil
     RecoilRate=0.03335
-    MaxVerticalRecoilAngle=230
+    MaxVerticalRecoilAngle=235
     MaxHorizontalRecoilAngle=85
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.5),(InVal=5.0,OutVal=0.8),(InVal=10.0,OutVal=1.1),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.33),(InVal=2.0,OutVal=0.7),(InVal=4.0,OutVal=0.8),(InVal=10.0,OutVal=1.1),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=18.0
 
     AmbientFireSound=SoundGroup'DH_WeaponSounds.ppsh41.ppsh41_fire_loop'

--- a/DH_Weapons/Classes/DH_PPSH41_stickFire.uc
+++ b/DH_Weapons/Classes/DH_PPSH41_stickFire.uc
@@ -16,7 +16,7 @@ defaultproperties
     RecoilRate=0.03335
     MaxVerticalRecoilAngle=245
     MaxHorizontalRecoilAngle=75
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=5.0,OutVal=0.8),(InVal=10.0,OutVal=1.1),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.33),(InVal=2.0,OutVal=0.7),(InVal=4.0,OutVal=0.8),(InVal=10.0,OutVal=1.1),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=18.0
 
     AmbientFireSound=SoundGroup'DH_WeaponSounds.ppsh41.ppsh41_fire_loop'


### PR DESCRIPTION
adjustment of recoil patterns on fast auto weapons:

In one of recent updates i discovered that there is an inconsistency in recoil between "fast auto" weapons and normal "auto", which seems to be caused by the special double shot mechanic that exists in "fast auto" that seemingly always makes the first shot into "double" (practically impossible to actually single tap), thus also applying double recoil for what appears to be the first shot, causing the weapon to jump higher after the first shot sound than if the weapon was just regular auto. 

This makes it harder to control short bursts on "fast auto" weapons than on "auto", even if their recoil values are the same. This became very apparent to me after PPS-43 was switched from "fast auto" to normal, it became significantly more controllable and consistent in short bursts without any changes to recoil values themselves.

In order to reduce this recoil effect from first 2 shots being "merged", thus causing the weapon to "jump" higher in the first moment of the burst, I decided to lower the recoil for the first 1-2 shots on the recoil curve of "fast auto" weapons, while "restoring" a regular value on the second shot already so that this change only applies for the first 2 shots in the burst. Also in small compensation for this first shot "buff", recoil overall was increased a tiny bit.