### PR TITLE
Fixes for Prussia Push

### DIFF
--- a/DarkestHourDev/Maps/DH-WIP_Prussia_Push.rom
+++ b/DarkestHourDev/Maps/DH-WIP_Prussia_Push.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:398a7ac8bdaf6e812547e69e90d1a01ed231b6845ab81803d52fef46fbcdf24c
-size 27246717
+oid sha256:4c7a7a3f5e38a5a893aeb90257db0faa0dc43da210496d44e41c7c1f5fc16e98
+size 27692267


### PR DESCRIPTION
* Renamed Bunker objective to Dugout
* Fixed the "death on spawn" issue on the Dugout obective
* Moved Dugout spawn point back to the street

Author: Pvt.Winter