### PR TITLE
stug armor fix

### DIFF
--- a/DH_Vehicles/Classes/DH_Stug3GDestroyer.uc
+++ b/DH_Vehicles/Classes/DH_Stug3GDestroyer.uc
@@ -51,8 +51,8 @@ defaultproperties
     RearArmor(2)=(Thickness=1.7,Slope=78.0,MaxRelativeHeight=43.3,LocationName="deck")
     RearArmor(3)=(Thickness=3.0,LocationName="superstructure")
 
-    FrontLeftAngle=330.0
-    FrontRightAngle=30.0
+    FrontLeftAngle=315.0
+    FrontRightAngle=45.0
     RearRightAngle=150.0
     RearLeftAngle=210.0
 


### PR DESCRIPTION
adjusted stug armor angle values to remove/reduce amount of glitchy deflections when frontal armor is somehow counted as "side", it seems to work although these deflections still sometimes happen