### PR TITLE
Level butovo

### DIFF
--- a/DH_Guns/Classes/DH_ZiS3Cannon.uc
+++ b/DH_Guns/Classes/DH_ZiS3Cannon.uc
@@ -25,7 +25,7 @@ defaultproperties
     ProjectileClass=class'DH_Guns.DH_ZiS3CannonShell'
     PrimaryProjectileClass=class'DH_Guns.DH_ZiS3CannonShell'
     SecondaryProjectileClass=class'DH_Guns.DH_ZiS3CannonShellHE'
-    TertiaryProjectileClass=class'DH_Guns.DH_ZiS3CannonShellAPCR'
+    //TertiaryProjectileClass=class'DH_Guns.DH_ZiS3CannonShellAPCR'
 
 
     ProjectileDescriptions(0)="APBC"

--- a/DH_Guns/Classes/DH_ZiS3CannonLate.uc
+++ b/DH_Guns/Classes/DH_ZiS3CannonLate.uc
@@ -1,0 +1,17 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2020
+//==============================================================================
+
+class DH_ZiS3CannonLate extends DH_ZiS3Cannon; //added APCR
+
+defaultproperties
+{
+    TertiaryProjectileClass=class'DH_Guns.DH_ZiS3CannonShellAPCR'
+    ProjectileDescriptions(2)="APCR"
+	nProjectileDescriptions(2)="BR-350P"
+
+    InitialTertiaryAmmo=2 
+    MaxTertiaryAmmo=4
+
+}

--- a/DH_Guns/Classes/DH_ZiS3CannonPawnLate.uc
+++ b/DH_Guns/Classes/DH_ZiS3CannonPawnLate.uc
@@ -1,0 +1,11 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2020
+//==============================================================================
+
+class DH_ZiS3CannonPawnLate extends DH_ZiS3CannonPawn;
+
+defaultproperties
+{
+    GunClass=class'DH_Guns.DH_ZiS3CannonLate'
+}

--- a/DH_Guns/Classes/DH_ZiS3FactoryLate.uc
+++ b/DH_Guns/Classes/DH_ZiS3FactoryLate.uc
@@ -1,0 +1,11 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2020
+//==============================================================================
+
+class DH_ZiS3FactoryLate extends DH_ZiS3Factory; // with APCR
+
+defaultproperties
+{
+    VehicleClass=class'DH_Guns.DH_ZiS3GunLate'
+}

--- a/DH_Guns/Classes/DH_ZiS3FactoryLate_Snow.uc
+++ b/DH_Guns/Classes/DH_ZiS3FactoryLate_Snow.uc
@@ -1,0 +1,12 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2020
+//==============================================================================
+
+class DH_ZiS3FactoryLate_Snow extends DH_ZiS3FactoryLate;
+
+defaultproperties
+{
+    VehicleClass=class'DH_Guns.DH_ZiS3GunLate_Snow'
+    Skins(0)=Texture'DH_Artillery_tex.ZiS3.ZiS3Gun_winter'
+}

--- a/DH_Guns/Classes/DH_ZiS3GunLate.uc
+++ b/DH_Guns/Classes/DH_ZiS3GunLate.uc
@@ -1,0 +1,11 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2020
+//==============================================================================
+
+class DH_ZiS3GunLate extends DH_ZiS3Gun; //added APCR
+
+defaultproperties
+{
+    PassengerWeapons(0)=(WeaponPawnClass=class'DH_Guns.DH_ZiS3CannonPawnLate')
+}

--- a/DH_Guns/Classes/DH_ZiS3GunLate_Snow.uc
+++ b/DH_Guns/Classes/DH_ZiS3GunLate_Snow.uc
@@ -1,0 +1,13 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2020
+//==============================================================================
+
+class DH_ZiS3GunLate_Snow extends DH_ZiS3GunLate;
+
+defaultproperties
+{
+    Skins(0)=Texture'DH_Artillery_tex.ZiS3.ZiS3Gun_winter'
+    CannonSkins(0)=Texture'DH_Artillery_tex.ZiS3.ZiS3Gun_winter'
+    DestroyedMeshSkins(0)=Combiner'DH_Artillery_tex.ZiS3.ZiS3Gun_winter_dest'
+}

--- a/DarkestHourDev/Maps/DH-WIP_Butovo_Advance.rom
+++ b/DarkestHourDev/Maps/DH-WIP_Butovo_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c102b4195bcb7914be9f5953d1e2a9a5af151221319769a5900d401670dc8a87
-size 37447316
+oid sha256:b5acca90332fea43c687209d2634e0e569eeab7e41777e2afda85150fe22edf7
+size 37440110

--- a/DarkestHourDev/Maps/DH-WIP_Butovo_Advance.rom
+++ b/DarkestHourDev/Maps/DH-WIP_Butovo_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5acca90332fea43c687209d2634e0e569eeab7e41777e2afda85150fe22edf7
-size 37440110
+oid sha256:876f0bc7b9847389f5fa2be424fd2d4ba180c9052151f5fbc9a3ee10e282d591
+size 37439474


### PR DESCRIPTION
- added extra tanks (including tigers) and extra tank reinforcements to axis
- fixed t34 m42 being locked away from being used; removed lock from several other tanks
- added 5 ZIS-3 and 5 45mm guns preplaced 
- increased soviet maxactive tanks by 1 

on the previous commit: soviet maxactive tanks stay the same, but they have about 2 times more preplaced AT guns (we can revert to this version, if the newer is too axis favored)