### PR TITLE
FJ45 Pawn Fix

### DIFF
--- a/DH_GerPlayers/Classes/DH_GermanArdennesFJPawn.uc
+++ b/DH_GerPlayers/Classes/DH_GermanArdennesFJPawn.uc
@@ -7,7 +7,7 @@ class DH_GermanArdennesFJPawn extends DH_GermanFJPawn;
 
 defaultproperties
 {
-    Skins(0)=Texture'DHGermanCharactersTex.Luftwaffe.FJ_Tan&Water'
+    Skins(0)=Texture'DHGermanCharactersTex.Luftwaffe.FJ_TanAndWater'
 
-    BodySkins(0)=Texture'DHGermanCharactersTex.Luftwaffe.FJ_Tan&Water'
+    BodySkins(0)=Texture'DHGermanCharactersTex.Luftwaffe.FJ_TanAndWater'
 }

--- a/DarkestHourDev/Textures/DHGermanCharactersTex.utx
+++ b/DarkestHourDev/Textures/DHGermanCharactersTex.utx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a0f44484823ed5c92cf5f09933f45f8bd6c4a88ae3097daf1553cea6a0af10d6
-size 28067485
+oid sha256:82d919036e174f4093873c0df5678ab5645d337ddda74ecd3d96bf51a2abf1d2
+size 28067489


### PR DESCRIPTION
Renamed FJ_tan&water camo to FJ_TanAndWater in DHGermanCharactersTex package and DH_GermanArdennesFJPawn. The ampersand symbol in the previous name appeared to prevent this specific camo from ever spawning as intended.