### PR TITLE
Tank fixes1

### DIFF
--- a/DH_Guns/Classes/DH_45mmM1937GunCannonShell.uc
+++ b/DH_Guns/Classes/DH_45mmM1937GunCannonShell.uc
@@ -14,7 +14,7 @@ defaultproperties
     BallisticCoefficient=0.7 // TODO: try to find an accurate BC (this is from AHZ)
 
     //Damage
-    ImpactDamage=265 //30 gramms TNT filler
+    ImpactDamage=295 //30 gramms TNT filler
     Damage=700.0 //"regular" damage is only changed so that AT guns are one-shot killed reliably, so the radius is small
     DamageRadius=150.0
     ShellImpactDamage=class'DH_Engine.DHShellAPGunImpactDamageType'

--- a/DH_Guns/Classes/DH_45mmM1942GunCannonShell.uc
+++ b/DH_Guns/Classes/DH_45mmM1942GunCannonShell.uc
@@ -11,7 +11,7 @@ defaultproperties
     MaxSpeed=52506.0
 
     //Damage
-    ImpactDamage=285  //30 gramms TNT filler
+    ImpactDamage=315  //30 gramms TNT filler
     Damage=700.0 //"regular" damage is only changed so that AT guns are one-shot killed reliably, so the radius is small
     DamageRadius=150.0
 

--- a/DH_Vehicles/Classes/DH_AchillesCannonShell.uc
+++ b/DH_Vehicles/Classes/DH_AchillesCannonShell.uc
@@ -11,7 +11,7 @@ defaultproperties
     MaxSpeed=53346.0
     ShellDiameter=7.62
     BallisticCoefficient=2.45
-    
+
     // Damage
     ImpactDamage=580  //solid shell
     ShellImpactDamage=class'DH_Engine.DHShellAPGunImpactDamageType'

--- a/DH_Vehicles/Classes/DH_AchillesCannonShell.uc
+++ b/DH_Vehicles/Classes/DH_AchillesCannonShell.uc
@@ -11,9 +11,10 @@ defaultproperties
     MaxSpeed=53346.0
     ShellDiameter=7.62
     BallisticCoefficient=2.45
-
-    //Damage
+    
+    // Damage
     ImpactDamage=580  //solid shell
+    ShellImpactDamage=class'DH_Engine.DHShellAPGunImpactDamageType'
     HullFireChance=0.35
     EngineFireChance=0.75
 

--- a/DH_Vehicles/Classes/DH_BT7CannonShell.uc
+++ b/DH_Vehicles/Classes/DH_BT7CannonShell.uc
@@ -14,7 +14,7 @@ defaultproperties
     BallisticCoefficient=0.7 // TODO: try to find an accurate BC (this is from AHZ)
 
     //Damage
-    ImpactDamage=265 //30 gramms TNT filler
+    ImpactDamage=295 //30 gramms TNT filler
     Damage=700.0 //"regular" damage is only changed so that AT guns are one-shot killed reliably, so the radius is small
     DamageRadius=150.0
     ShellImpactDamage=class'DH_Vehicles.DH_StuartCannonShellDamageAP'

--- a/DH_Vehicles/Classes/DH_BT7Tank.uc
+++ b/DH_Vehicles/Classes/DH_BT7Tank.uc
@@ -76,8 +76,8 @@ defaultproperties
     // cons:
     //- 3 men crew, who are quite close to each other
     //- petrol fuel
-    Health=460
-    HealthMax=460.0
+    Health=380
+    HealthMax=380.0
     EngineHealth=300
     AmmoIgnitionProbability=0.33  // 0.75 default
     EngineToHullFireChance=0.1  //increased from 0.05 for all petrol engines

--- a/DH_Vehicles/Classes/DH_ShermanFireFlyCannonShell.uc
+++ b/DH_Vehicles/Classes/DH_ShermanFireFlyCannonShell.uc
@@ -12,10 +12,11 @@ defaultproperties
     ShellDiameter=7.62
     BallisticCoefficient=2.45 //TODO: pls check
 
-    //Damage
-    ImpactDamage=580  //solid shot
-    HullFireChance=0.31
-    EngineFireChance=0.62
+    // Damage
+    ImpactDamage=580  //solid shell
+    ShellImpactDamage=class'DH_Engine.DHShellAPGunImpactDamageType'
+    HullFireChance=0.35
+    EngineFireChance=0.75
 
     //Penetration
     DHPenetrationTable(0)=18.5

--- a/DH_Vehicles/Classes/DH_StuartCannonShell.uc
+++ b/DH_Vehicles/Classes/DH_StuartCannonShell.uc
@@ -13,7 +13,7 @@ defaultproperties
     BallisticCoefficient=1.52 //Correct - verified on range at 1000 yards
 
     //Damage
-    ImpactDamage=215  //solid shell
+    ImpactDamage=245  //solid shell
     Damage=980.0 //"regular" damage is only changed so that AT guns can be killed more reliably, so the radius is very small
     DamageRadius=70.0
     ShellImpactDamage=class'DH_Vehicles.DH_StuartCannonShellDamageAP'

--- a/DH_Vehicles/Classes/DH_StuartTank.uc
+++ b/DH_Vehicles/Classes/DH_StuartTank.uc
@@ -55,8 +55,8 @@ defaultproperties
     // Damage
 	// pros: 37mm ammo is less likely to explode; 
 	// cons: tightly placed 4 men crew; petrol fuel; 
-    Health=500
-    HealthMax=500.0
+    Health=420
+    HealthMax=420.0
 	EngineHealth=300
 	AmmoIgnitionProbability=0.27  // 0.75 default
     TurretDetonationThreshold=4000.0 // increased from 1750

--- a/DH_Vehicles/Classes/DH_StuartTank.uc
+++ b/DH_Vehicles/Classes/DH_StuartTank.uc
@@ -53,12 +53,12 @@ defaultproperties
     TransRatio=0.13
 
     // Damage
-	// pros: 37mm ammo is less likely to explode; 
-	// cons: tightly placed 4 men crew; petrol fuel; 
+    // pros: 37mm ammo is less likely to explode;
+    // cons: tightly placed 4 men crew; petrol fuel;
     Health=420
     HealthMax=420.0
-	EngineHealth=300
-	AmmoIgnitionProbability=0.27  // 0.75 default
+    EngineHealth=300
+    AmmoIgnitionProbability=0.27  // 0.75 default
     TurretDetonationThreshold=4000.0 // increased from 1750
     EngineToHullFireChance=0.1  //increased from 0.05 for all petrol engines
     DisintegrationHealth=-800.0 //petrol

--- a/DH_Vehicles/Classes/DH_T60Tank.uc
+++ b/DH_Vehicles/Classes/DH_T60Tank.uc
@@ -65,8 +65,8 @@ defaultproperties
     // Damage
     // pros: 20mm ammo is very unlikely to explode
     // cons: 2 men crew; petrol fuel
-    Health=400
-    HealthMax=400.0
+    Health=300
+    HealthMax=300.0
     AmmoIgnitionProbability=0.2  // 0.75 default
     TurretDetonationThreshold=5000.0 // increased from 1750
     EngineHealth=300

--- a/DH_Vehicles/Classes/DH_TigerCannon.uc
+++ b/DH_Vehicles/Classes/DH_TigerCannon.uc
@@ -16,7 +16,7 @@ defaultproperties
     HighDetailOverlayIndex=1
 
     // Turret armor
-    FrontArmorFactor=17.1
+    FrontArmorFactor=12.5
     RightArmorFactor=8.7
     LeftArmorFactor=8.7
     RearArmorFactor=8.7


### PR DESCRIPTION
- fixed tiger 1 turret front armor to a more accureate value (125, used to be 171 which is completely wrong, IRL it varied between 100 and 150)
- fixed inconsistency between identical shells (firefly)
- reduced health for T-60, BT-7 and stuart tanks as they were too survivable for small and light tanks
- slightly buffed damage for 37mm and 45mm shells