### PR TITLE
Level designers can now limit the number of constructions available per round

### DIFF
--- a/DH_Construction/Classes/DHCommandMenu_ConstructionGroup.uc
+++ b/DH_Construction/Classes/DHCommandMenu_ConstructionGroup.uc
@@ -187,6 +187,10 @@ function GetOptionRenderInfo(int OptionIndex, out OptionRenderInfo ORI)
             case ERROR_Exhausted:
                 ORI.InfoIcon = Texture'DH_GUI_tex.DeployMenu.spawn_point_disabled';
                 ORI.InfoText = default.ExhaustedText;
+                if (E.OptionalInteger >= 0)
+                {
+                    ORI.InfoText @= "(" $ class'TimeSpan'.static.ToString(E.OptionalInteger - GRI.ElapsedTime) $ ")";
+                }
                 break;
             case ERROR_SquadTooSmall:
                 if (PC != none && PC.SquadReplicationInfo != none)

--- a/DH_Construction/Classes/DHCommandMenu_ConstructionGroup.uc
+++ b/DH_Construction/Classes/DHCommandMenu_ConstructionGroup.uc
@@ -13,6 +13,8 @@ var Material SuppliesIcon;
 var localized string NotAvailableText;
 var localized string TeamLimitText;
 var localized string BusyText;
+var localized string ExhaustedText;
+var localized string RemainingText;
 
 var class<DHConstructionGroup> GroupClass;
 var DHActorProxy.Context Context;
@@ -143,7 +145,8 @@ function GetOptionRenderInfo(int OptionIndex, out OptionRenderInfo ORI)
     local class<DHConstruction> ConstructionClass;
     local DHConstruction.ConstructionError E;
     local DHPlayer PC;
-    local int SquadMemberCount;
+    local int SquadMemberCount, TeamLimit;
+    local DHGameReplicationInfo GRI;
 
     super.GetOptionRenderInfo(OptionIndex, ORI);
 
@@ -153,6 +156,7 @@ function GetOptionRenderInfo(int OptionIndex, out OptionRenderInfo ORI)
     if (ConstructionClass != none && PC != none)
     {
         E = ConstructionClass.static.GetPlayerError(Context);
+        GRI = DHGameReplicationInfo(PC.GameReplicationInfo);
 
         ORI.OptionName = ConstructionClass.static.GetMenuName(Context);
 
@@ -180,6 +184,10 @@ function GetOptionRenderInfo(int OptionIndex, out OptionRenderInfo ORI)
                 ORI.InfoIcon = Texture'DH_GUI_tex.DeployMenu.spawn_point_disabled';
                 ORI.InfoText = default.TeamLimitText;
                 break;
+            case ERROR_Exhausted:
+                ORI.InfoIcon = Texture'DH_GUI_tex.DeployMenu.spawn_point_disabled';
+                ORI.InfoText = default.ExhaustedText;
+                break;
             case ERROR_SquadTooSmall:
                 if (PC != none && PC.SquadReplicationInfo != none)
                 {
@@ -196,6 +204,16 @@ function GetOptionRenderInfo(int OptionIndex, out OptionRenderInfo ORI)
         }
 
         ORI.DescriptionText = ConstructionClass.default.MenuDescription;
+
+        if (GRI != none && ORI.DescriptionText == "")
+        {
+            TeamLimit = GRI.GetTeamConstructionLimit(PC.GetTeamNum(), ConstructionClass);
+
+            if (TeamLimit != -1)
+            {
+                ORI.DescriptionText = string(TeamLimit) @ default.RemainingText;
+            }
+        }
     }
 }
 
@@ -212,6 +230,8 @@ defaultproperties
     SuppliesIcon=Texture'DH_InterfaceArt2_tex.Icons.supply_cache'
     NotAvailableText="Not Available"
     TeamLimitText="Limit Reached"
+    ExhaustedText="Exhausted"
+    RemainingText="Remaining"
     BusyText="Busy"
     SlotCountOverride=8
 }

--- a/DH_Construction/Classes/DH_ConstructionWeapon.uc
+++ b/DH_Construction/Classes/DH_ConstructionWeapon.uc
@@ -213,6 +213,7 @@ function ServerCreateConstruction(class<DHConstruction> ConstructionClass, Actor
         }
 
         C.UpdateAppearance();
+        C.OnSpawnedByPlayer();
     }
 }
 

--- a/DH_Engine/Classes/DHConstructionErrorMessage.uc
+++ b/DH_Engine/Classes/DHConstructionErrorMessage.uc
@@ -91,5 +91,6 @@ defaultproperties
     ErrorMessages(23)="Too close to an uncontrolled objective ({string}), it must be {integer}m further away."
     ErrorMessages(24)="You must {verb} a {name} within {integer}m of a friendly {string}";
     ErrorMessages(25)="You cannot {verb} a {name} in enemy territory";
+    ErrorMessages(26)="There are no more {name} available";
 }
 

--- a/DH_Engine/Classes/DHConstructionManager.uc
+++ b/DH_Engine/Classes/DHConstructionManager.uc
@@ -54,6 +54,11 @@ function Register(DHConstruction C)
 {
     local int i;
 
+    if (C == none)
+    {
+        return;
+    }
+
     for (i = 0; i < Constructions.Length; ++i)
     {
         if (Constructions[i] == C)
@@ -68,6 +73,11 @@ function Register(DHConstruction C)
 function Unregister(DHConstruction C)
 {
     local int i;
+
+    if (C == none)
+    {
+        return;
+    }
 
     for (i = Constructions.Length - 1; i >= 0; --i)
     {

--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -143,6 +143,15 @@ var private array<string>   ConstructionClassNames;
 var class<DHConstruction>   ConstructionClasses[CONSTRUCTION_CLASSES_MAX];
 var DHConstructionManager   ConstructionManager;
 
+struct STeamConstruction
+{
+    var class<DHConstruction> ConstructionClass;
+    var byte TeamIndex;
+    var byte Limit;
+};
+
+var array<STeamConstruction> TeamConstructions[16];
+
 var bool                bAreConstructionsEnabled;
 var bool                bAllChatEnabled;
 
@@ -245,7 +254,8 @@ replication
         DangerZoneBalance,
         RoundWinnerTeamIndex,
         bIsSurrenderVoteEnabled,
-        SurrenderVotesInProgress;
+        SurrenderVotesInProgress,
+        TeamConstructions;
 
     reliable if (bNetInitial && Role == ROLE_Authority)
         AlliedNationID, ConstructionClasses, MapMarkerClasses;
@@ -315,7 +325,35 @@ simulated function PostBeginPlay()
                 MapMarkerClasses[j++] = MapMarkerClass;
             }
         }
+
+        for (i = 0; i < LI.TeamConstructions.Length; ++i)
+        {
+            TeamConstructions[i].TeamIndex = LI.TeamConstructions[i].TeamIndex;
+            TeamConstructions[i].ConstructionClass = LI.TeamConstructions[i].ConstructionClass;
+            TeamConstructions[i].Limit = LI.TeamConstructions[i].Limit;
+        }
     }
+}
+
+simulated function int GetTeamConstructionLimit(int TeamIndex, class<DHConstruction> ConstructionClass)
+{
+    local int i;
+
+    for (i = 0; i < arraycount(TeamConstructions); ++i)
+    {
+        if (TeamConstructions[i].ConstructionClass == none)
+        {
+            continue;
+        }
+
+        if (TeamConstructions[i].TeamIndex == TeamIndex &&
+            TeamConstructions[i].ConstructionClass == ConstructionClass)
+        {
+            return TeamConstructions[i].Limit;
+        }
+    }
+
+    return -1;
 }
 
 simulated function PostNetBeginPlay()
@@ -1988,10 +2026,8 @@ defaultproperties
     ConstructionClassNames(17)="DH_Construction.DHConstruction_Sandbags_Bunker"
     ConstructionClassNames(18)="DH_Construction.DHConstruction_Watchtower"
     ConstructionClassNames(19)="DH_Construction.DHConstruction_GrenadeCrate"
-    //ConstructionClassNames(17)="DH_Construction.DHConstruction_MortarPit"
     ConstructionClassNames(20)="DH_Construction.DHConstruction_DragonsTooth"
     ConstructionClassNames(21)="DH_Construction.DHConstruction_AntiTankCrate"
-    //ConstructionClassNames(19)="DH_Construction.DHConstruction_WoodFence"
 
     // Map Markers
     MapMarkerClassNames(0)="DH_Engine.DHMapMarker_Squad_Move"

--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -325,13 +325,6 @@ simulated function PostBeginPlay()
                 MapMarkerClasses[j++] = MapMarkerClass;
             }
         }
-
-        for (i = 0; i < LI.TeamConstructions.Length; ++i)
-        {
-            TeamConstructions[i].TeamIndex = LI.TeamConstructions[i].TeamIndex;
-            TeamConstructions[i].ConstructionClass = LI.TeamConstructions[i].ConstructionClass;
-            TeamConstructions[i].Limit = LI.TeamConstructions[i].Limit;
-        }
     }
 }
 

--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -148,6 +148,7 @@ struct STeamConstruction
     var class<DHConstruction> ConstructionClass;
     var byte TeamIndex;
     var byte Limit;
+    var int NextIncrementTimeSeconds;
 };
 
 var array<STeamConstruction> TeamConstructions[16];
@@ -328,7 +329,7 @@ simulated function PostBeginPlay()
     }
 }
 
-simulated function int GetTeamConstructionLimit(int TeamIndex, class<DHConstruction> ConstructionClass)
+simulated function int GetTeamConstructionIndex(int TeamIndex, class<DHConstruction> ConstructionClass)
 {
     local int i;
 
@@ -342,11 +343,47 @@ simulated function int GetTeamConstructionLimit(int TeamIndex, class<DHConstruct
         if (TeamConstructions[i].TeamIndex == TeamIndex &&
             TeamConstructions[i].ConstructionClass == ConstructionClass)
         {
-            return TeamConstructions[i].Limit;
+            return i;
         }
     }
 
     return -1;
+}
+
+simulated function int GetTeamConstructionNextIncrementTimeSeconds(int TeamIndex, class<DHConstruction> ConstructionClass)
+{
+    local int i;
+    local DH_LevelInfo LI;
+
+    i = GetTeamConstructionIndex(TeamIndex, ConstructionClass);
+
+    if (i == -1)
+    {
+       return -1;
+    }
+
+    LI = class'DH_LevelInfo'.static.GetInstance(Level);
+
+    if (LI != none && LI.TeamConstructions[i].ReplenishPeriodSeconds > 0)
+    {
+        return TeamConstructions[i].NextIncrementTimeSeconds;
+    }
+
+    return -1;
+}
+
+simulated function int GetTeamConstructionLimit(int TeamIndex, class<DHConstruction> ConstructionClass)
+{
+    local int i;
+
+    i = GetTeamConstructionIndex(TeamIndex, ConstructionClass);
+
+    if (i == -1)
+    {
+       return -1;
+    }
+
+    return TeamConstructions[i].Limit;
 }
 
 simulated function PostNetBeginPlay()

--- a/DH_Engine/Classes/DH_LevelInfo.uc
+++ b/DH_Engine/Classes/DH_LevelInfo.uc
@@ -104,6 +104,7 @@ struct STeamConstruction
     var() class<DHConstruction> ConstructionClass;
     var() int TeamIndex;
     var() int Limit;
+    var() int ReplenishPeriodSeconds;   // How long it takes, in seconds, for the limit to be increased by one
 };
 var(DH_Constructions) array<STeamConstruction> TeamConstructions;
 

--- a/DH_Engine/Classes/DH_LevelInfo.uc
+++ b/DH_Engine/Classes/DH_LevelInfo.uc
@@ -99,7 +99,13 @@ var() material              LoadingScreenRef;        // Used to stop loading scr
 
 var const bool              bDHDebugMode;            // flag for whether debug commands can be run
 
-
+struct STeamConstruction
+{
+    var() class<DHConstruction> ConstructionClass;
+    var() int TeamIndex;
+    var() int Limit;
+};
+var(DH_Constructions) array<STeamConstruction> TeamConstructions;
 
 singular static function bool DHDebugMode()
 {

--- a/DH_Engine/Classes/DarkestHourGame.uc
+++ b/DH_Engine/Classes/DarkestHourGame.uc
@@ -2471,6 +2471,14 @@ state RoundInPlay
             GRI.AxisHelpRequests[i].RequestType = 255;
         }
 
+        // Team constructions
+        for (i = 0; i < DHLevelInfo.TeamConstructions.Length; ++i)
+        {
+            GRI.TeamConstructions[i].TeamIndex = DHLevelInfo.TeamConstructions[i].TeamIndex;
+            GRI.TeamConstructions[i].ConstructionClass = DHLevelInfo.TeamConstructions[i].ConstructionClass;
+            GRI.TeamConstructions[i].Limit = DHLevelInfo.TeamConstructions[i].Limit;
+        }
+
         for (i = 0; i < arraycount(bDidSendEnemyTeamWeakMessage); ++i)
         {
             bDidSendEnemyTeamWeakMessage[i] = 0;

--- a/DH_Engine/Classes/DarkestHourGame.uc
+++ b/DH_Engine/Classes/DarkestHourGame.uc
@@ -2920,6 +2920,8 @@ state RoundInPlay
             }
         }
 
+        UpdateTeamConstructions();
+
         // If round time is up, decide the winner
         if (GRI.DHRoundDuration != 0 && GRI.ElapsedTime > GRI.RoundEndTime)
         {
@@ -2930,6 +2932,23 @@ state RoundInPlay
         if (DHPlayer(Level.GetLocalPlayerController()) != none)
         {
             DHPlayer(Level.GetLocalPlayerController()).CheckUnlockWeapons();
+        }
+    }
+}
+
+function UpdateTeamConstructions()
+{
+    local int i;
+
+    // Check for if we can replenish any team constructions
+    for (i = 0; i < DHLevelInfo.TeamConstructions.Length; i++)
+    {
+        if (GRI.TeamConstructions[i].Limit < DHLevelInfo.TeamConstructions[i].Limit &&
+            DHLevelInfo.TeamConstructions[i].ReplenishPeriodSeconds > 0 &&
+            GRI.ElapsedTime >= GRI.TeamConstructions[i].NextIncrementTimeSeconds)
+        {
+            GRI.TeamConstructions[i].Limit += 1;
+            GRI.TeamConstructions[i].NextIncrementTimeSeconds = GRI.ElapsedTime + DHLevelInfo.TeamConstructions[i].ReplenishPeriodSeconds;
         }
     }
 }


### PR DESCRIPTION
This branch implements the ability for levelers to determine a maximum # of certain types of constructions to be built over the duration of a round. This is meant to be used specifically for AT guns to reduce the incidence of AT gun spam.