### PR TITLE
BT-7 Periscope

### DIFF
--- a/DH_Vehicles/Classes/DH_BT7CannonPawn.uc
+++ b/DH_Vehicles/Classes/DH_BT7CannonPawn.uc
@@ -13,18 +13,23 @@ defaultproperties
     //Driver's positions and anims
     DriverPositions(0)=(ViewLocation=(X=8,Y=-8,Z=5),ViewFOV=30,PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',ViewPitchUpLimit=6000,ViewPitchDownLimit=64500,ViewPositiveYawLimit=19000,ViewNegativeYawLimit=-20000,bDrawOverlays=true,bExposed=false)
     DriverPositions(1)=(ViewLocation=(X=8.5,Y=45,Z=3),PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',ViewPitchUpLimit=10,ViewPitchDownLimit=65535,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536)
-    DriverPositions(2)=(ViewLocation=(X=7.4,Y=-9,Z=3),PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',DriverTransitionAnim="stand_idlehip_binoc",TransitionUpAnim=com_open,ViewPitchUpLimit=10,ViewPitchDownLimit=65535,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536)
-    DriverPositions(3)=(PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',DriverTransitionAnim="stand_idlehip_binoc",TransitionDownAnim=com_close,ViewPitchUpLimit=5000,ViewPitchDownLimit=62000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-10000,bDrawOverlays=false,bExposed=true)
-    DriverPositions(4)=(ViewFOV=12.0,PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',DriverTransitionAnim="stand_idleiron_binoc",ViewPitchUpLimit=5000,ViewPitchDownLimit=62000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-10000,bDrawOverlays=true,bExposed=true)
+    DriverPositions(2)=(ViewLocation=(X=7.4,Y=-9,Z=3),PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',ViewPitchUpLimit=10,ViewPitchDownLimit=65535,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536)
+	DriverPositions(3)=(ViewLocation=(X=25,Y=-13,Z=23),ViewFOV=34.0,PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',DriverTransitionAnim="stand_idlehip_binoc",TransitionUpAnim=com_open,ViewPitchUpLimit=1,ViewPitchDownLimit=65535,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536,bDrawOverlays=true)
+    DriverPositions(4)=(PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',DriverTransitionAnim="stand_idlehip_binoc",TransitionDownAnim=com_close,ViewPitchUpLimit=5000,ViewPitchDownLimit=62000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-10000,bDrawOverlays=false,bExposed=true)
+    DriverPositions(5)=(ViewFOV=12.0,PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',DriverTransitionAnim="stand_idleiron_binoc",ViewPitchUpLimit=5000,ViewPitchDownLimit=62000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-10000,bDrawOverlays=true,bExposed=true)
 
     DrivePos=(X=10.0,Y=6.0,Z=-10.0)
     DriveRot=(Yaw=1222)
     DriveAnim="VPanther_driver_idle_close"
     bLockCameraDuringTransition=true
 
-    UnbuttonedPositionIndex=3
-    BinocPositionIndex=4
+	PeriscopePositionIndex=3
+    UnbuttonedPositionIndex=4
+    BinocPositionIndex=5
 
+	PeriscopeOverlay=Texture'DH_VehicleOptics_tex.General.MG_sight' //emulating the PT-1 periscope 2.5x 26' FOV
+    PeriscopeSize=0.76
+	
     bManualTraverseOnly=true
 
     //Gunsight

--- a/DH_Vehicles/Classes/DH_BT7CannonPawn.uc
+++ b/DH_Vehicles/Classes/DH_BT7CannonPawn.uc
@@ -7,14 +7,14 @@ class DH_BT7CannonPawn extends DHSovietCannonPawn;
 
 defaultproperties
 {
-    //Gun Class
+    // Gun Class
     GunClass=class'DH_Vehicles.DH_BT7Cannon'
 
-    //Driver's positions and anims
+    // Driver's positions and anims
     DriverPositions(0)=(ViewLocation=(X=8,Y=-8,Z=5),ViewFOV=30,PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',ViewPitchUpLimit=6000,ViewPitchDownLimit=64500,ViewPositiveYawLimit=19000,ViewNegativeYawLimit=-20000,bDrawOverlays=true,bExposed=false)
     DriverPositions(1)=(ViewLocation=(X=8.5,Y=45,Z=3),PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',ViewPitchUpLimit=10,ViewPitchDownLimit=65535,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536)
     DriverPositions(2)=(ViewLocation=(X=7.4,Y=-9,Z=3),PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',ViewPitchUpLimit=10,ViewPitchDownLimit=65535,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536)
-	DriverPositions(3)=(ViewLocation=(X=25,Y=-13,Z=23),ViewFOV=34.0,PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',DriverTransitionAnim="stand_idlehip_binoc",TransitionUpAnim=com_open,ViewPitchUpLimit=1,ViewPitchDownLimit=65535,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536,bDrawOverlays=true)
+	  DriverPositions(3)=(ViewLocation=(X=25,Y=-13,Z=23),ViewFOV=34.0,PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',DriverTransitionAnim="stand_idlehip_binoc",TransitionUpAnim=com_open,ViewPitchUpLimit=1,ViewPitchDownLimit=65535,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536,bDrawOverlays=true)
     DriverPositions(4)=(PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',DriverTransitionAnim="stand_idlehip_binoc",TransitionDownAnim=com_close,ViewPitchUpLimit=5000,ViewPitchDownLimit=62000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-10000,bDrawOverlays=false,bExposed=true)
     DriverPositions(5)=(ViewFOV=12.0,PositionMesh=Mesh'DH_BT7_anm.BT7_turret_int',DriverTransitionAnim="stand_idleiron_binoc",ViewPitchUpLimit=5000,ViewPitchDownLimit=62000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-10000,bDrawOverlays=true,bExposed=true)
 
@@ -23,16 +23,16 @@ defaultproperties
     DriveAnim="VPanther_driver_idle_close"
     bLockCameraDuringTransition=true
 
-	PeriscopePositionIndex=3
+	  PeriscopePositionIndex=3
     UnbuttonedPositionIndex=4
     BinocPositionIndex=5
 
-	PeriscopeOverlay=Texture'DH_VehicleOptics_tex.General.MG_sight' //emulating the PT-1 periscope 2.5x 26' FOV
+	  PeriscopeOverlay=Texture'DH_VehicleOptics_tex.General.MG_sight' // emulating the PT-1 periscope 2.5x 26' FOV
     PeriscopeSize=0.76
-	
+
     bManualTraverseOnly=true
 
-    //Gunsight
+    // Gunsight
     GunsightOverlay=Texture'DH_VehicleOptics_tex.Soviet.45mmATGun_sight_background'
     CannonScopeCenter=Texture'Vehicle_Optic.Scopes.T3476_sight_mover'
     GunsightSize=0.5// 15 degrees visible FOV at 2.5x magnification (PP-1 sight)
@@ -41,7 +41,7 @@ defaultproperties
     ScopeCenterScaleY=2.0
     DestroyedGunsightOverlay=Texture'DH_VehicleOpticsDestroyed_tex.German.PZ4_sight_destroyed'
 
-    //HUD
+    // HUD
     AmmoShellTexture=Texture'InterfaceArt_ahz_tex.Tank_Hud.45mmShell' // TODO: get new ammo icons made so the "X" text matches the position of the ammo count
     AmmoShellReloadTexture=Texture'InterfaceArt_ahz_tex.Tank_Hud.45mmShell_reload'
 }

--- a/DH_Vehicles/Classes/DH_BT7Tank.uc
+++ b/DH_Vehicles/Classes/DH_BT7Tank.uc
@@ -84,9 +84,9 @@ defaultproperties
     DisintegrationHealth=-800.0 //petrol
     TurretDetonationThreshold=3000.0 // increased from 1750
     VehHitpoints(0)=(PointRadius=28.0,PointOffset=(X=-73.0,Z=-5.0)) // engine
-    VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(Z=10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
-    VehHitpoints(2)=(PointRadius=10.0,PointScale=1.0,PointBone="body",PointOffset=(Y=-45.0,Z=30.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
-    VehHitpoints(3)=(PointRadius=10.0,PointScale=1.0,PointBone="body",PointOffset=(Y=45.0,Z=30.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=30,Y=0,Z=10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    VehHitpoints(2)=(PointRadius=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=28,Y=-45.0,Z=15.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    VehHitpoints(3)=(PointRadius=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=28,Y=45.0,Z=15.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     TreadHitMaxHeight=-3.25
     TreadDamageThreshold=0.15
     DamagedEffectOffset=(X=-78.0,Y=0.0,Z=25.0)


### PR DESCRIPTION
BT7:

- Added missing periscope to the BT-7 gunner's position (currently uses the same periscope overlay as the T-34, both of which need to be replaced in the future).
- Fixed broken ammo hit points on the BT-7. 