### PR TITLE
"Sepp Window" Static Collision

### DIFF
--- a/DarkestHourDev/StaticMeshes/DH_Buildings.usx
+++ b/DarkestHourDev/StaticMeshes/DH_Buildings.usx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:360688da5d1ec7c984d9d3cbf11b76ad3eb3cdc7140b7f25c4a8e5e45a294013
-size 16236786
+oid sha256:e490927fb1c228e7e9c7b73cec355fbe1e80591a26c93ed3b0fd99470df2da0b
+size 16238066


### PR DESCRIPTION
- Fixed collision mesh for "Sepp Window" static that was causing server log spam.