### PR TITLE
Kriegstadt Hotfix

### DIFF
--- a/DarkestHourDev/Maps/DH-Kriegstadt_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Kriegstadt_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:454d72156091000d6201fcf1653e073de485c9ca6d88aa97d1cabb83894757de
-size 74051996
+oid sha256:44e89dcfc89add3aa1f1772169ede8569f66f05113f1edd9a4819ba723700b90
+size 74052382

--- a/DarkestHourDev/Maps/DH-Kriegstadt_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Kriegstadt_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e8a97a06fd27469a69c199d860dd15a4ebc0cc5693d7ae380c5534bd78583ff
-size 74048567
+oid sha256:454d72156091000d6201fcf1653e073de485c9ca6d88aa97d1cabb83894757de
+size 74051996


### PR DESCRIPTION
Kriegstadt Advance:

- Removed bad reference to EH-BerlinTanksMod4 in a blocking volume. 
- Fixed broken Axis objective spawnhints on the Bank objective.