### PR TITLE
set tiger front turret armor to a more accurate value

### DIFF
--- a/DH_Vehicles/Classes/DH_TigerCannon.uc
+++ b/DH_Vehicles/Classes/DH_TigerCannon.uc
@@ -16,7 +16,7 @@ defaultproperties
     HighDetailOverlayIndex=1
 
     // Turret armor
-    FrontArmorFactor=17.1
+    FrontArmorFactor=13.0
     RightArmorFactor=8.7
     LeftArmorFactor=8.7
     RearArmorFactor=8.7


### PR DESCRIPTION
tiger's turret front armor was varying between 100-150 mm; current value of 171 is completely wrong. It should be changed to at least somewhere in the range of 100-150