### PR TITLE
Squad leaders now spawn instantly on rally points if they have one spawn remaining

### DIFF
--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -2661,6 +2661,12 @@ simulated function int GetNextSpawnTime(int SpawnPointIndex, DHRoleInfo RI, int 
         return 0;
     }
 
+    if (GRI.SpawnPoints[SpawnPointIndex].CanPlayerSpawnImmediately(self))
+    {
+        // Spawn point is allowing this player to spawn immediately!
+        return -1;
+    }
+
     // If player was spawn killed, set the respawn time to be the spawn kill respawn time
     if (bSpawnedKilled)
     {

--- a/DH_Engine/Classes/DHSpawnPointBase.uc
+++ b/DH_Engine/Classes/DHSpawnPointBase.uc
@@ -433,6 +433,11 @@ final function SetTeamIndex(int TeamIndex)
     }
 }
 
+simulated function bool CanPlayerSpawnImmediately(DHPlayer PC)
+{
+    return false;
+}
+
 function OnTeamIndexChanged();
 
 defaultproperties

--- a/DH_Engine/Classes/DHSpawnPoint_SquadRallyPoint.uc
+++ b/DH_Engine/Classes/DHSpawnPoint_SquadRallyPoint.uc
@@ -575,7 +575,11 @@ function Destroyed()
 
 simulated function bool CanPlayerSpawnImmediately(DHPlayer PC)
 {
-    return PC != none && PC.IsSquadLeader() && SpawnsRemaining == 1;
+    return PC != none
+        && PC.IsSquadLeader()
+        && SpawnsRemaining == 1
+        && PC.SquadReplicationInfo != none
+        && PC.SquadReplicationInfo.GetMemberCount(PC.GetTeamNum(), PC.GetSquadIndex()) > 1;
 }
 
 defaultproperties

--- a/DH_Engine/Classes/DHSpawnPoint_SquadRallyPoint.uc
+++ b/DH_Engine/Classes/DHSpawnPoint_SquadRallyPoint.uc
@@ -573,6 +573,11 @@ function Destroyed()
     }
 }
 
+simulated function bool CanPlayerSpawnImmediately(DHPlayer PC)
+{
+    return PC != none && PC.IsSquadLeader() && SpawnsRemaining == 1;
+}
+
 defaultproperties
 {
     SpawnPointStyle="DHRallyPointButtonStyle"


### PR DESCRIPTION
Squad leaders now spawn instantly on rally points if they have one spawn remaining. The squad must have more than one member for this behavior to work.

This was done to eliminate the behavior where players would hold spawn until the squad leader could use the rally point (usually failing to do so and the whole squad being disappointed in one another).