### PR TITLE
#1307 Artillery kill feed is visible only for the killer and the victim

### DIFF
--- a/DH_Engine/Classes/DarkestHourGame.uc
+++ b/DH_Engine/Classes/DarkestHourGame.uc
@@ -2442,24 +2442,6 @@ function BroadcastDeathMessage(Controller Killer, Controller Killed, class<Damag
     local PlayerReplicationInfo KillerPRI, KilledPRI;
     local Controller C;
 
-    // Special case handling for artillery kills. Send message only to the killer & victim.
-    if (class<DHArtilleryKillDamageType>(DamageType) != none && (DeathMessageMode == DM_Personal || DeathMessageMode == DM_OnDeath))
-    {
-        // Send DM to a killed human player
-        if (DHPlayer(Killed) != none)
-        {
-            DHPlayer(Killed).ClientAddHudDeathMessage(KillerPRI, KilledPRI, DamageType);
-        }
-
-        // If mode is Personal, also send DM to the killer (if human)
-        if (DeathMessageMode == DM_Personal && DHPlayer(Killer) != none)
-        {
-            DHPlayer(Killer).ClientAddHudDeathMessage(KillerPRI, KilledPRI, DamageType);
-        }
-
-        return;
-    }
-
     // (Message mode is none Or Killed doesn't exist) AND DamageType is not type DHInstantObituaryDamageTypes, then return
     if ((DeathMessageMode == DM_None || Killed == none) && class<DHInstantObituaryDamageTypes>(DamageType) == none)
     {
@@ -2472,6 +2454,22 @@ function BroadcastDeathMessage(Controller Killer, Controller Killed, class<Damag
     }
 
     KilledPRI = Killed.PlayerReplicationInfo;
+
+    // Special case handling for artillery kills. Send message only to the killer & victim.
+    if (class<DHArtilleryKillDamageType>(DamageType) != none)
+    {
+        if (DHPlayer(Killed) != none)
+        {
+            DHPlayer(Killed).ClientAddHudDeathMessage(KillerPRI, KilledPRI, DamageType);
+        }
+
+        if (DHPlayer(Killer) != none)
+        {
+            DHPlayer(Killer).ClientAddHudDeathMessage(KillerPRI, KilledPRI, DamageType);
+        }
+
+        return;
+    }
 
     // OnDeath means only send DM to player who is killed, Personal means send DM to both killed & killer
     // (If message mode is OnDeath or Personal) AND DamageType is not type DHInstantObituaryDamageTypes
@@ -2493,7 +2491,7 @@ function BroadcastDeathMessage(Controller Killer, Controller Killed, class<Damag
         return;
     }
 
-    // If we made it to this point we can assume DeathMessageMode is DM_All or it was a DHInstantObituaryDamageTypes
+    // If we made it to this point we can assume DeathMessageMode is DM_All or it was a DHInstantObituaryDamageTypes (spawn kill)
     // Loop through all controllers & DM each human player
     for (C = Level.ControllerList; C != none; C = C.NextController)
     {


### PR DESCRIPTION
The artillery kill feed was visible for everyone because checks of `DeathMessageMode` were failing & `DHArtilleryKillDamageType` was treated as spawn killing as it inherits from `DHInstantObituaryDamageTypes`. Also `KillerPRI` and `KilledPRI` passed to `ClientAddHudDeathMessage()` were `none`.

Just got rid of all `DeathMessageMode` and rearanged code so PRIs are not `none`.