### PR TITLE
Fixed displaying of the "No available artillery targets" text

### DIFF
--- a/DH_Engine/Classes/DHArtillerySpottingScope.uc
+++ b/DH_Engine/Classes/DHArtillerySpottingScope.uc
@@ -604,8 +604,8 @@ function DrawTargets(DHPlayer PC, Canvas C, DHVehicleWeaponPawn VWP, array<STarg
         // and not by the index of the marker in the actual array of targets.
         for (i = 0; i < ArtilleryMarkers.Length; ++i)
         {
-            if (ArtilleryMarkers[i].SquadIndex == PC.ArtillerySupportSquadIndex
-                && (ArtilleryMarkers[i].ExpiryTime > GRI.ElapsedTime))
+            if (ArtilleryMarkers[i].SquadIndex == PC.ArtillerySupportSquadIndex &&
+                ArtilleryMarkers[i].ExpiryTime > GRI.ElapsedTime)
             {
                 bSelectedMarkerAvailable = true;
                 break;
@@ -1071,4 +1071,3 @@ defaultproperties
     GradientOverlayX=Texture'DH_InterfaceArt2_tex.Artillery.dials_gradient_x'
     GradientOverlayY=Texture'DH_InterfaceArt2_tex.Artillery.dials_gradient_y'
 }
-


### PR DESCRIPTION
 - Fixed displaying of the "No available artillery targets" text when the selected target expired and there are no more targets available
 - renamed the `bSelectedMarkerNotAvailable` into `bSelectedMarkerAvailable`