### PR TITLE
Artillery spotters can now also see the hit markers for artillery hits within range of their marked targets

### DIFF
--- a/DH_Engine/Classes/DHMapMarker_ArtilleryHit.uc
+++ b/DH_Engine/Classes/DHMapMarker_ArtilleryHit.uc
@@ -18,7 +18,7 @@ defaultproperties
     OverwritingRule=UNIQUE_PER_GROUP
     Scope=PERSONAL
     LifetimeSeconds=15
-    Permissions_CanSee(0)=(LevelSelector=TEAM,RoleSelector=ERS_ARTILLERY_OPERATOR)
+    Permissions_CanSee(0)=(LevelSelector=TEAM,RoleSelector=ERS_ALL)
     Permissions_CanPlace(0)=ERS_ALL
     VisibilityRange=150
 }


### PR DESCRIPTION
This is accomplished by simply sending the author (spotter) of the fire support target the same message to also add the artillery hit marker. I set the `CanSee` permission to `ERS_ALL` since these are personal map markers anyways, so if you get told to add one, there's no reason why you shouldn't see it.