### PR TITLE
Invisible players no longer overrun rally points

### DIFF
--- a/DH_Engine/Classes/DHSpawnPointBase.uc
+++ b/DH_Engine/Classes/DHSpawnPointBase.uc
@@ -386,7 +386,7 @@ function GetPlayerCountsWithinRadius(float RadiusInMeters, optional int SquadInd
 
     foreach RadiusActors(class'Pawn', P, class'DHUnits'.static.MetersToUnreal(RadiusInMeters))
     {
-        if (P != none && !P.bDeleteMe && P.Health > 0 && P.PlayerReplicationInfo != none)
+        if (P != none && !P.bHidden && !P.bDeleteMe && P.Health > 0 && P.PlayerReplicationInfo != none)
         {
             if (P.GetTeamNum() == TeamIndex)
             {


### PR DESCRIPTION
Bogeyman mode makes the character hidden and invincible so I can run around and film, unfortunately this means I also can overrun enemy rally points. This makes it so that I can't!