### PR TITLE
A few hotfixes for half-tracks and half-track based vehicles

### DIFF
--- a/DH_Vehicles/Classes/DH_M3Halftrack.uc
+++ b/DH_Vehicles/Classes/DH_M3Halftrack.uc
@@ -48,6 +48,11 @@ defaultproperties
     TorqueCurve=(Points=((InVal=0.0,OutVal=16.0),(InVal=200.0,OutVal=8.0),(InVal=600.0,OutVal=5.0),(InVal=1200.0,OutVal=2.0),(InVal=2000.0,OutVal=0.5)))
     SteerSpeed=85.0
     MaxSteerAngleCurve=(Points=((InVal=0.0,OutVal=64.0),(InVal=200.0,OutVal=32.0),(InVal=600.0,OutVal=5.0),(InVal=1000000000.0,OutVal=0.0)))
+    ChangeUpPoint=2000.0
+    ChangeDownPoint=1000.0
+    ChassisTorqueScale=0.4
+    bSpecialTankTurning=false
+    TurnDamping=35.0
 
     // Physics wheels properties
     WheelLongFrictionScale=1.25

--- a/DH_Vehicles/Classes/DH_SdKfz2519DTransport.uc
+++ b/DH_Vehicles/Classes/DH_SdKfz2519DTransport.uc
@@ -25,15 +25,14 @@ defaultproperties
     DriverPositions(2)=(ViewPitchUpLimit=5000,ViewPitchDownLimit=55500,ViewPositiveYawLimit=12800,ViewNegativeYawLimit=-16000)
 
     PassengerWeapons(0)=(WeaponPawnClass=class'DH_Vehicles.DH_SdKfz2519DCannonPawn',WeaponBone="mg_base")
+    PassengerPawns(0)=(AttachBone="",DriveAnim="")
+    PassengerPawns(1)=(AttachBone="",DriveAnim="")
+    PassengerPawns(2)=(AttachBone="",DriveAnim="")
+    PassengerPawns(3)=(AttachBone="",DriveAnim="")
+    PassengerPawns(4)=(AttachBone="",DriveAnim="")
+    PassengerPawns(5)=(AttachBone="",DriveAnim="")
 
     ExitPositions(1)=(X=-240.0,Y=-30.0,Z=5.0) // pak gunner (same as driver - rear door, left side)
-
-    PassengerPawns(0)=None
-    PassengerPawns(1)=None
-    PassengerPawns(2)=None
-    PassengerPawns(3)=None
-    PassengerPawns(4)=None
-    PassengerPawns(5)=None
 
     Mesh=SkeletalMesh'DH_Sdkfz251Halftrack_anm.Sdkfz251_9_body_ext'
     Skins(0)=Texture'DH_VehiclesGE_tex.ext_vehicles.Halftrack_body_camo2'

--- a/DH_Vehicles/Classes/DH_SdKfz2519DTransport.uc
+++ b/DH_Vehicles/Classes/DH_SdKfz2519DTransport.uc
@@ -6,6 +6,26 @@
 
 class DH_SdKfz2519DTransport extends DH_Sdkfz251Transport;
 
+// Quick duct-tape hack for setting destroyed combiners.
+// TODO: Either refactor this or make packaged combiners for this vehicle.
+simulated event DestroyAppearance()
+{
+    local Combiner DestroyedSkin;
+    local int i;
+
+    for (i = 0; i < DestroyedMeshSkins.Length; ++i)
+    {
+        DestroyedSkin = Combiner(Level.ObjectPool.AllocateObject(class'Combiner'));
+        DestroyedSkin.Material1 = DestroyedMeshSkins[i];
+        DestroyedSkin.Material2 = Texture'DH_FX_Tex.Overlays.DestroyedVehicleOverlay';
+        DestroyedSkin.FallbackMaterial = DestroyedMeshSkins[i];
+        DestroyedSkin.CombineOperation = CO_Multiply;
+        DestroyedMeshSkins[i] = DestroyedSkin;
+    }
+
+    super(DHVehicle).DestroyAppearance();
+}
+
 defaultproperties
 {
     VehicleNameString="Sd.Kfz.251/9 Ausf.D Stummel"
@@ -37,8 +57,9 @@ defaultproperties
     Mesh=SkeletalMesh'DH_Sdkfz251Halftrack_anm.Sdkfz251_9_body_ext'
     Skins(0)=Texture'DH_VehiclesGE_tex.ext_vehicles.Halftrack_body_camo2'
     DestroyedVehicleMesh=StaticMesh'DH_German_vehicles_stc.Halftrack.SdKfz251_9D_Destro'
-    DestroyedMeshSkins(0)=Combiner'DH_VehiclesGE_tex8.Destroyed.stummel_ext_dest'
-    DestroyedMeshSkins(1)=Combiner'DH_VehiclesGE_tex.Destroyed.halftrack_camo2_dest'
+    DestroyedMeshSkins(0)=Texture'DH_VehiclesGE_tex8.ext_vehicles.stummel_ext'
+    DestroyedMeshSkins(1)=Texture'DH_VehiclesGE_tex.ext_vehicles.Halftrack_body_camo2'
+    bUsesCodedDestroyedSkins=false
 
     SpawnOverlay(0)=Texture'DH_InterfaceArt_tex.Vehicles.sdkfz_251_9d'
     VehicleHudImage=Texture'DH_InterfaceArt_tex.Tank_Hud.sdkfz2519d_body'

--- a/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
@@ -66,6 +66,11 @@ defaultproperties
     TorqueCurve=(Points=((InVal=0.0,OutVal=16.0),(InVal=200.0,OutVal=8.0),(InVal=600.0,OutVal=5.0),(InVal=1200.0,OutVal=2.0),(InVal=2000.0,OutVal=0.5)))
     SteerSpeed=85.0
     MaxSteerAngleCurve=(Points=((InVal=0.0,OutVal=64.0),(InVal=200.0,OutVal=32.0),(InVal=600.0,OutVal=5.0),(InVal=1000000000.0,OutVal=0.0)))
+    ChangeUpPoint=2000.0
+    ChangeDownPoint=1000.0
+    ChassisTorqueScale=0.4
+    bSpecialTankTurning=false
+    TurnDamping=35.0
 
     // Physics wheels properties
     WheelLongFrictionScale=1.25


### PR DESCRIPTION
- [x] Fix the bug where players could access passenger seats on Stummel.
- [x] Fix the bug where half-tracks became slower after ca9e0adda4c8851e9e81f7c74946bf992446a29f.
- [x] Fix textures on destroyed Stummel mesh