### PR TITLE
Event Version of Dom Pavlova

### DIFF
--- a/DarkestHourDev/Maps/DH-Dom-Pavlova_Event.rom
+++ b/DarkestHourDev/Maps/DH-Dom-Pavlova_Event.rom
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37ab8ac3419d5a503a1aa547f89d9c584ac4d51737afec22221a3a5667b4f881
+size 35481453


### PR DESCRIPTION
Event version of Dom Pavlova with objectives removed, DZ disabled, minefields altered, roles changed, a few new interiors/small tweaks to existing ones and pre-placed HQs added (these will be fortified during the round and used as bases for the team commanders/targets).