### PR TITLE
[La Fiere Day Advance] Hand-tuned the Danger Zone

### DIFF
--- a/DarkestHourDev/Maps/DH-La_Fiere_Day_Advance.rom
+++ b/DarkestHourDev/Maps/DH-La_Fiere_Day_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0e2addcb7087ac4b27adad9db7ea84e40fac1caccdaed4a51fab59fb2129245
-size 70963701
+oid sha256:de5a7e40ff8eac1f179c297d41b46682322d1d02237926a082b3c1f06e130981
+size 70970509


### PR DESCRIPTION
## Description
The lines were set to be tight and close to the objectives to prevent
both teams from aggressive flanking, especially in the first half
of the map.

This should also give Allies (albeit minor) protection for reinforcing
the Church area, as their only safe access to it is through the narrow
causeway.

![lafiere-day-dz-0](https://user-images.githubusercontent.com/36604408/145118633-0567c399-de4f-4c8e-96fd-ea996b8c31d0.gif)

## Changes
* Enabled `bMainSpawn` on all main spawns.
* Set Danger Zone influences to:
    ```
    [0:La Fière]
    AxisInfluenceMoifier=0.00
    NeutralInfluenceMoifier=0.20
    [1:Estate Farm]
    AxisInfluenceMoifier=5.00
    NeutralInfluenceMoifier=0.10
    [2:Church]
    AxisInfluenceMoifier=6.00
    NeutralInfluenceMoifier=0.50
    [3:Causeway]
    AlliesInfluenceMoifier=2.00
    [4:Barn]
    [5:La Fière Manor]
    AxisInfluenceMoifier=4.00
    [6:Exit]
    AlliesInfluenceMoifier=5.00
    NeutralInfluenceMoifier=0.10
    ```
