### PR TITLE
Fixed a bug where AT launchers could fail to spawn a projectile

### DIFF
--- a/DH_Engine/Classes/DHRocketFire.uc
+++ b/DH_Engine/Classes/DHRocketFire.uc
@@ -15,7 +15,16 @@ var     class<DamageType>   ExhaustDamageType;       // damage type for exhaust
 // Modified to prevent firing if RocketWeapon's CanFire() says no
 simulated function bool AllowFire()
 {
-    return DHRocketWeapon(Weapon) != none && DHRocketWeapon(Weapon).CanFire() && super.AllowFire();
+    // Skip CanFire() check on the server to avoid situations where a client
+    // can get a green light to fire before the server does
+    if (Weapon != none && Weapon.Role == ROLE_Authority)
+    {
+        return super.AllowFire();
+    }
+
+    return DHRocketWeapon(Weapon) != none &&
+           DHRocketWeapon(Weapon).CanFire() &&
+           super.AllowFire();
 }
 
 // Modified to add exhaust damage & to call PostFire() on the Weapon


### PR DESCRIPTION
The bug can be reproduced by firing a rocket launcher shortly after
stopping into a standstill with a high enough ping.

Since it's tricky to reproduce on a local server, this was tested by
forcing `AllowFire()` to always fail on a server, which gives similar results.