### PR TITLE
Les Champs de Losque Hotfix

### DIFF
--- a/DarkestHourDev/Maps/DH-Les_Champs_de_Losque_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Les_Champs_de_Losque_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b168ebc988a06d7f1c3556105b8fa38b5d50a77b359bbf2577955b2e0d2adfc
-size 67716537
+oid sha256:d0fe2c4af8deb9026e0083c739802ca71074df436231648752a76ffc2332e8f7
+size 67722466


### PR DESCRIPTION
Les Champs de Losque:

- Fixed various issues with spawn hints on the map.

- Fixed an issue with a fluid surface that was poking out of the terrain.

- Fixed a missing artillery trigger on a static radio.

- Replaced the Wirblewind static with a Panzer IVH.