### PR TITLE
Team score totals are now displayed at the end of the round

### DIFF
--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -63,6 +63,15 @@ enum EArtilleryTypeError
     ERROR_Cancellable
 };
 
+struct STeamScores
+{
+    var int Kills;
+    var int Deaths;
+    var int CategoryScores[2];
+};
+
+var STeamScores         TeamScores[2];
+
 var class<DHGameType>   GameType;
 
 var SupplyPoint         SupplyPoints[SUPPLY_POINTS_MAX];
@@ -266,7 +275,8 @@ replication
         bOffMapArtilleryEnabled,
         bOnMapArtilleryEnabled,
         DHMineVolumeIsActives,
-        DHNoArtyVolumeIsActives;
+        DHNoArtyVolumeIsActives,
+        TeamScores;
 
     reliable if (bNetInitial && Role == ROLE_Authority)
         AlliedNationID, ConstructionClasses, MapMarkerClasses;
@@ -2254,6 +2264,38 @@ simulated function array<SAvailableArtilleryInfoEntry> GetTeamOffMapFireSupportC
     }
 
     return Result;
+}
+
+function AddKillForTeam(int TeamIndex)
+{
+    if (TeamIndex >= 0 && TeamIndex < arraycount(TeamScores))
+    {
+        ++TeamScores[TeamIndex].Kills;
+    }
+}
+
+function AddDeathForTeam(int TeamIndex)
+{
+    if (TeamIndex >= 0 && TeamIndex < arraycount(TeamScores))
+    {
+        ++TeamScores[TeamIndex].Deaths;
+    }
+}
+
+function ResetTeamScores()
+{
+    local int i, j;
+
+    for (i = 0; i < arraycount(TeamScores); ++i)
+    {
+        TeamScores[i].Kills = 0;
+        TeamScores[i].Deaths = 0;
+
+        for (j = 0; j < arraycount(TeamScores[i].CategoryScores); ++j)
+        {
+            TeamScores[i].CategoryScores[j] = 0;
+        }
+    }
 }
 
 defaultproperties

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -281,7 +281,7 @@ simulated event PostBeginPlay()
 
     if (Role == ROLE_Authority)
     {
-        ScoreManager = Spawn(class'DHScoreManager', self);
+        ScoreManager = new class'DHScoreManager';
 
         if (DarkestHourGame(Level.Game) != none && DarkestHourGame(Level.Game).bBigBalloony)
         {
@@ -661,6 +661,7 @@ function bool AllowTextMessage(string Msg)
     {
         return true;
     }
+
     if (Level.Pauser == none && Level.TimeSeconds - LastBroadcastTime < 2 || bIsGagged)
     {
         return false;
@@ -3119,6 +3120,7 @@ function ServerSetPlayerInfo(byte newTeam, byte newRole, byte NewWeapon1, byte N
 function OnTeamChanged()
 {
     local DarkestHourGame G;
+    local int TeamIndex;
 
     G = DarkestHourGame(Level.Game);
 
@@ -3128,6 +3130,22 @@ function OnTeamChanged()
         if (bSurrendered)
         {
             G.VoteManager.RemoveNomination(self, class'DHVoteInfo_TeamSurrender');
+        }
+    }
+
+    // Update the player's linked score manager to their new team's score manager.
+    if (ScoreManager != none)
+    {
+        TeamIndex = GetTeamNum();
+
+        if (TeamIndex >= 0 && TeamIndex < arraycount(G.TeamScoreManagers))
+        {
+            ScoreManager.NextScoreManager = G.TeamScoreManagers[TeamIndex];
+        }
+        else
+        {
+            // Player joined spectators, clear the next score manager.
+            ScoreManager.NextScoreManager = none;
         }
     }
 }
@@ -6670,9 +6688,15 @@ function ServerCancelArtillery(DHRadio Radio, int ArtilleryTypeIndex)
 // Scoring
 function ReceiveScoreEvent(DHScoreEvent ScoreEvent)
 {
-    if (ScoreManager != none)
+    local DHGameReplicationInfo GRI;
+    local DarkestHourGame G;
+    local int TeamIndex;
+
+    GRI = DHGameReplicationInfo(GameReplicationInfo);
+
+    if (ScoreManager != none && GRI != none)
     {
-        ScoreManager.HandleScoreEvent(ScoreEvent);
+        ScoreManager.HandleScoreEvent(ScoreEvent, GRI);
     }
 }
 
@@ -6764,10 +6788,7 @@ simulated function Destroyed()
 
     if (Role == ROLE_Authority)
     {
-        if (ScoreManager != none)
-        {
-            ScoreManager.Destroy();
-        }
+        ScoreManager = none;
 
         if (IQManager != none)
         {

--- a/DH_Engine/Classes/DarkestHourGame.uc
+++ b/DH_Engine/Classes/DarkestHourGame.uc
@@ -3249,6 +3249,7 @@ function ResetScores()
 {
     local DHPlayerReplicationInfo   PRI;
     local Controller                C;
+    local int i;
 
     RemainingTime = 60 * TimeLimit;
     ElapsedTime = 0;
@@ -3265,6 +3266,11 @@ function ResetScores()
             PRI = DHPlayerReplicationInfo(C.PlayerReplicationInfo);
             PRI.Score = 0;
         }
+    }
+
+    for (i = 0; i < arraycount(TeamScoreManagers); ++i)
+    {
+        TeamScoreManagers[i].Reset();
     }
 
     GRI.ResetTeamScores();

--- a/DH_Engine/Classes/DarkestHourGame.uc
+++ b/DH_Engine/Classes/DarkestHourGame.uc
@@ -2466,18 +2466,22 @@ function UpdatePlayerScore(Controller C)
     local DHPlayer PC;
     local int i;
 
-    PRI = DHPlayerReplicationInfo(C.PlayerReplicationInfo);
     PC = DHPlayer(C);
 
-    if (PRI != none && PC != none)
+    if (PC != none)
     {
-        PRI.Score = PC.ScoreManager.TotalScore;
-        PRI.TotalScore = PC.ScoreManager.TotalScore;
-        PRI.DHKills = PRI.Kills;    // Update the replicated variable kills variable here!
+        PRI = DHPlayerReplicationInfo(PC.PlayerReplicationInfo);
 
-        for (i = 0; i < arraycount(PC.ScoreManager.CategoryScores); ++i)
+        if (PRI != none)
         {
-            PRI.CategoryScores[i] = PC.ScoreManager.CategoryScores[i];
+            PRI.Score = PC.ScoreManager.TotalScore;
+            PRI.TotalScore = PC.ScoreManager.TotalScore;
+            PRI.DHKills = PRI.Kills;    // Update the replicated variable kills variable here!
+
+            for (i = 0; i < arraycount(PC.ScoreManager.CategoryScores); ++i)
+            {
+                PRI.CategoryScores[i] = PC.ScoreManager.CategoryScores[i];
+            }
         }
     }
 }
@@ -3249,6 +3253,7 @@ function ResetScores()
 {
     local DHPlayerReplicationInfo   PRI;
     local Controller                C;
+    local DHPlayer                  PC;
     local int i;
 
     RemainingTime = 60 * TimeLimit;
@@ -3261,12 +3266,15 @@ function ResetScores()
 
     for (C = Level.ControllerList; C != none; C = C.NextController)
     {
-        if (DHPlayerReplicationInfo(C.PlayerReplicationInfo) != none)
+        PC = DHPlayer(C);
+
+        if (PC != none && PC.ScoreManager != none)
         {
-            PRI = DHPlayerReplicationInfo(C.PlayerReplicationInfo);
-            PRI.Score = 0;
+            PC.ScoreManager.Reset();
         }
     }
+
+    UpdateAllPlayerScores();
 
     for (i = 0; i < arraycount(TeamScoreManagers); ++i)
     {

--- a/DH_Engine/Classes/DarkestHourGame.uc
+++ b/DH_Engine/Classes/DarkestHourGame.uc
@@ -106,6 +106,8 @@ var()   config bool                 bBigBalloony;
 // DEBUG
 var     bool                        bDebugConstructions;
 
+var     DHScoreManager              TeamScoreManagers[2];
+
 // The response types for requests.
 enum EArtilleryResponseType
 {
@@ -430,6 +432,13 @@ function PostBeginPlay()
         {
             break;
         }
+    }
+
+    // Set up the score managers for each team.
+    for (i = 0; i < arraycount(TeamScoreManagers); ++i)
+    {
+        TeamScoreManagers[i] = new class'DHScoreManager';
+        TeamScoreManagers[i].bSkipLimits = true;
     }
 
     foreach AllActors(class'ROMineVolume', MV)
@@ -1151,6 +1160,7 @@ function ScoreFireSupportSpottingAssist(Controller Spotter)
 function ScoreKill(Controller Killer, Controller Other)
 {
     local DHPlayerReplicationInfo PRI;
+    local int TeamIndex;
 
     if (Killer == Other || Killer == none)
     {
@@ -1169,7 +1179,9 @@ function ScoreKill(Controller Killer, Controller Other)
         if (PRI != none)
         {
             ++PRI.Kills;
-            ++PRI.DHKills;
+
+            // Also add the kill to the team score.
+            GRI.AddKillForTeam(Killer.GetTeamNum());
         }
     }
 
@@ -2093,13 +2105,19 @@ function Killed(Controller Killer, Controller Killed, Pawn KilledPawn, class<Dam
     local DHPlayer   DHKilled, DHKiller;
     local Controller P;
     local float      FFPenalty;
-    local int        i;
+    local int        i, TeamIndex;
     local bool       bHasAPlayerAlive, bInformedKillerOfWeaponLock;
     local array<DHGameReplicationInfo.MapMarker> FireSupportMapMarkers;
 
     if (Killed == none)
     {
         return;
+    }
+
+    // Add the death to the team score in GRI.
+    if (GRI != none)
+    {
+        GRI.AddDeathForTeam(Killed.GetTeamNum());
     }
 
     if (Killer != none && Killer.bIsPlayer && Killed.bIsPlayer && DamageType != none)
@@ -2417,6 +2435,21 @@ function UpdateArtilleryAvailability()
     }
 }
 
+function UpdateTeamScores()
+{
+    local int i, j;
+
+    for (i = 0; i < arraycount(TeamScoreManagers); ++i)
+    {
+        // TODO: we should have the kills updated here, only once, to save network traffic
+
+        for (j = 0; j < arraycount(TeamScoreManagers[i].CategoryScores); ++j)
+        {
+            GRI.TeamScores[i].CategoryScores[j] = TeamScoreManagers[i].CategoryScores[j];
+        }
+    }
+}
+
 function UpdateAllPlayerScores()
 {
     local Controller C;
@@ -2440,6 +2473,7 @@ function UpdatePlayerScore(Controller C)
     {
         PRI.Score = PC.ScoreManager.TotalScore;
         PRI.TotalScore = PC.ScoreManager.TotalScore;
+        PRI.DHKills = PRI.Kills;    // Update the replicated variable kills variable here!
 
         for (i = 0; i < arraycount(PC.ScoreManager.CategoryScores); ++i)
         {
@@ -2954,6 +2988,7 @@ state RoundInPlay
         RoundCount++;
 
         UpdateAllPlayerScores();
+        UpdateTeamScores();
 
         if (RoundLimit != 0 && RoundCount >= RoundLimit)
         {
@@ -3231,6 +3266,8 @@ function ResetScores()
             PRI.Score = 0;
         }
     }
+
+    GRI.ResetTeamScores();
 }
 
 state RoundOver
@@ -5853,7 +5890,7 @@ defaultproperties
     RussianNames(6)="Jeff Duquette"
     RussianNames(7)="Chris Young"
     RussianNames(8)="Kenneth Kjeldsen"
-    RussianNames(9)="John Wayne"
+    RussianNames(9)="Gibson Drukenmiller"
     RussianNames(10)="Clint Eastwood"
     RussianNames(11)="Tom Hanks"
     RussianNames(12)="Leroy Jenkins"

--- a/DH_Interface/Classes/DHScoreBoard.uc
+++ b/DH_Interface/Classes/DHScoreBoard.uc
@@ -1019,12 +1019,9 @@ function DHDrawTeam(Canvas C, int TeamIndex, array<DHPlayerReplicationInfo> Team
 
 function GetScoreboardTotalColumnRenderInfo(int TeamIndex, int ColumnIndex, out CellRenderInfo CRI)
 {
-    local DHGameReplicationInfo GRI;
     local int i, Score;
 
-    GRI = DHGameReplicationInfo(Level.Game.GameReplicationInfo);
-
-    if (GRI != none)
+    if (DHGRI != none)
     {
         CRI.Icon = none;
         CRI.bDrawBacking = true;
@@ -1036,23 +1033,23 @@ function GetScoreboardTotalColumnRenderInfo(int TeamIndex, int ColumnIndex, out 
         {
             case COLUMN_Score:
                 Score = 0;
-                for (i = 0; i < arraycount(GRI.TeamScores[TeamIndex].CategoryScores); ++i)
+                for (i = 0; i < arraycount(DHGRI.TeamScores[TeamIndex].CategoryScores); ++i)
                 {
-                    Score += GRI.TeamScores[TeamIndex].CategoryScores[i];
+                    Score += DHGRI.TeamScores[TeamIndex].CategoryScores[i];
                 }
                 CRI.Text = string(Score);
                 break;
             case COLUMN_Kills:
-                CRI.Text = string(GRI.TeamScores[TeamIndex].Kills);
+                CRI.Text = string(DHGRI.TeamScores[TeamIndex].Kills);
                 break;
             case COLUMN_PointsCombat:
-                CRI.Text = string(GRI.TeamScores[TeamIndex].CategoryScores[class'DHScoreCategory_Combat'.default.CategoryIndex]);
+                CRI.Text = string(DHGRI.TeamScores[TeamIndex].CategoryScores[class'DHScoreCategory_Combat'.default.CategoryIndex]);
                 break;
             case COLUMN_PointsSupport:
-                CRI.Text = string(GRI.TeamScores[TeamIndex].CategoryScores[class'DHScoreCategory_Support'.default.CategoryIndex]);
+                CRI.Text = string(DHGRI.TeamScores[TeamIndex].CategoryScores[class'DHScoreCategory_Support'.default.CategoryIndex]);
                 break;
             case COLUMN_Deaths:
-                CRI.Text = string(GRI.TeamScores[TeamIndex].Deaths);
+                CRI.Text = string(DHGRI.TeamScores[TeamIndex].Deaths);
                 break;
             default:
                 CRI.Text = "";


### PR DESCRIPTION
This PR adds the display of a team's score totals (kills, deaths, combat score/support etc.) on the scoreboard at the end of a round.

To achieve this, I assigned each team its own `DHScoreManager`. When a player joins a team, their own `DHScoreManager` is linked to their respective team's (via a `NextScoreManager` variable, effectively a linked list), and all evaluated scoring events are passed through to the team's. Team scoring managers ignore any sort of rate-limiters for scoring events that apply to individual players. In theory, this type of chaining would allow us to do the same thing for tracking squad scores as well, if we want to go down that route later.

![image](https://user-images.githubusercontent.com/5035660/148910948-d411251d-d5df-4af3-aa64-305c02b3ca41.png)

Note that the scores above will appear strange because I got a bunch of kills against bots on both teams.

Additional changes:

* Your own player's name will now appear in *white*, instead of just merely having a different highlight (making it easier to find yourself)
* Logged-in admins are displayed in *orange*.
* Fixed a bug where the Allied team's score card would have incorrect line heights and would be misaligned.
* `DHScoreManager` now directly subclasses `Object` instead of `Actor` since it doesn't need to actually exist in the level.