### PR TITLE
Kriegstadt improvements

### DIFF
--- a/DarkestHourDev/Maps/DH-Kriegstadt_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Kriegstadt_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:faa4a5da353d8ff00872afaba8572e8d617e57fe759fbc09faea03a49046aba3
-size 74052421
+oid sha256:22ecd010f615a3e4b6d28a78d616e758ef675f5f4afe544d38de999216c2412e
+size 74106421


### PR DESCRIPTION
- moved axis vehicle spawn to the end of the central street and restricted all vehicles from entering that abusive camping spot behind p4 wreck, where german tank cannot be seen from the other side at all due to fog range and being covered by a building.
- in order to prevent continuous meatgrinders at the beginning of the map (between kaschade and the first street, where the space to move around is scarce), axis respawn time is increased by 10 seconds for the first 2 objectives
- made the first objective faster capping
- restricted axis from entering the first street in prep phase
- reduced allied reinforcements by 2 points, axis by 1
- removed team ratio difference (axis were at disadvantage)
- increased axis bleed in the end in 2 times
- upped german WH rifleman limit from 8 to 13
- added more uniform variety for axis
- placed a bunch of weapon pickups (not fausts)
- reduced german gunner from 3 to 2
- fixed soviet fireteam leader having wrong earlywar insignia