### PR TITLE
Tweaks for the Operation Veritable Event

### DIFF
--- a/DarkestHourDev/Maps/DH-Armored_Fruhlingserwachen_Clash.rom
+++ b/DarkestHourDev/Maps/DH-Armored_Fruhlingserwachen_Clash.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2536d8d460045030ce53c0f5b1aba7a48980b7636a9595729dad7e4fdc14cc80
-size 43884447
+oid sha256:24197491334f9e16bf4ef83c4f4553e1a1dd5c5ddb5e2291735e6b8d37dbe48e
+size 43885214

--- a/DarkestHourDev/Maps/DH-Armored_Suedwind_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Armored_Suedwind_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e80b5cede1f1fc45ff04102a63a8e0ae23760f3128de99489d867fc44318a17
-size 38521600
+oid sha256:5ca2138ab5b6d21b0729ce44b773a96952dc3e58a402f2738f031e33d5a87c4b
+size 38521420

--- a/DarkestHourDev/Maps/DH-Bridgehead_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Bridgehead_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29c636ce9a8947a3e25e2cab0a6670c707223a0313bd5afed2497f90ea4c2cc6
-size 44569351
+oid sha256:85cf35727d069baa168c5cac68fe0a3221f0055608ed48a66fc261f91babbd65
+size 44641342

--- a/DarkestHourDev/Maps/DH-Reichswald_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Reichswald_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dbd9b19e0261d6038258c7c67209f0125f2545491980d86506fd5ee6eaaab313
-size 34952152
+oid sha256:dd11453cfd30428160c0f6cfccc6296f93ae2d08a62bc44ef1e1a1cdb1ebbdac
+size 34953244


### PR DESCRIPTION
Bridgehead Advance:

- Generally reverted the map to its previous state.
- Removed pre-placed HQs for the Axis.
- Added Objective Spawns instead for both teams.
- Implemented AT gun restrictions.
- Added radios to the map.
- Implemented new anti-precap and spawn protection minefields for both teams.
- Rebalanced roles slightly.
- Rebalanced vehicle loadouts slightly.

Reichswald Advance:

- Implemented AT Gun Limits.
- Increased Allied tank availability.
- Rebalanced roles slightly.

Armored Fruhlingserwachen Clash:

- Changed game mode to Domination (victory will now be determined by who controls the most objectives).
- Fixed a bug where the Farm Lutzow objective had some incorrect properties set.

Armored Suedwind Advance:

- Significantly increased Allied ticket count to hopefully resolve the issue of Allies running out of tickets while still holding a large amount of objectives.