### PR TITLE
bridgehead-advance-qol

### DIFF
--- a/DarkestHourDev/Maps/DH-Bridgehead_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Bridgehead_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85cf35727d069baa168c5cac68fe0a3221f0055608ed48a66fc261f91babbd65
-size 44641342
+oid sha256:cd768578276d028672b05f4fb3cc6870c60265c52f9cb9789806fb4bcc98f013
+size 44661051


### PR DESCRIPTION
Added blocking volume around AP/no terrain zone
![image](https://user-images.githubusercontent.com/67280527/154719617-af449f08-7c16-419d-949c-b4d77e4fd7b0.png)
