### PR TITLE
Increased GMC understeer to be consistent with other trucks

### DIFF
--- a/DH_Vehicles/Classes/DH_GMCTruck.uc
+++ b/DH_Vehicles/Classes/DH_GMCTruck.uc
@@ -65,7 +65,7 @@ defaultproperties
     FTScale=0.030000
     ChassisTorqueScale=0.095
     MinBrakeFriction=4.000000
-    MaxSteerAngleCurve=(Points=((OutVal=45.000000),(InVal=300.000000,OutVal=30.000000),(InVal=500.000000,OutVal=20.000000),(InVal=600.000000,OutVal=15.000000),(InVal=1000000000.000000,OutVal=10.000000)))
+    MaxSteerAngleCurve=(Points=((InVal=0.0,OutVal=45.0),(InVal=200.0,OutVal=35.0),(InVal=800.0,OutVal=6.0),(InVal=1000000000.0,OutVal=0.0)))
     SteerSpeed=70.0
     TurnDamping=25.0
     StopThreshold=100.000000


### PR DESCRIPTION
This reverts changes made to the steering curve done in ac8e8cbed0f1cecd439021ae8c4f5edba57d6a09, which made GMC significantly more maneuverable compared to the other trucks in the game