### PR TITLE
Fixes for Winter Manor Push

### DIFF
--- a/DarkestHourDev/Maps/DH-Winter_Manor_1941_Push.rom
+++ b/DarkestHourDev/Maps/DH-Winter_Manor_1941_Push.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d960f63d2d1c0b828f441bee44bce3c3ff1ca7d62bd50a12acf39867e4e6700e
-size 59987102
+oid sha256:b72bcc8b117f75ac67984304e2b21037b6eaf39f2c3024581f4f6b8e65d7b73b
+size 71383840


### PR DESCRIPTION
- improved manor exterior
- added terrain decolayers
- removed ba64
- removed g41
- fixed bt7 activating
- fixed soviet engineer

Author: kashash