### PR TITLE
winter_stalemate_advance-qol

### DIFF
--- a/DarkestHourDev/Maps/DH-Winter_Stalemate_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Winter_Stalemate_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd42ad2cd5e3fef603f23d93d4b1fd3c04c0effc2f3b3a62adcb3cd1eb2dfd11
-size 44712824
+oid sha256:0792539e8d4bc47fc9130ec45f5a1147560745c345fc786e4ae9dedfe780cc8c
+size 44026717


### PR DESCRIPTION
-fixed emitter render on normal/low world detail settngs;
-added cover for allies at last cap;
-increased center cap requirement 4->6 players;
-moved setup phase black box closer to cap for allies;
-removed supply cache from allowed buildings;
-moved endgame camera.