### PR TITLE
Removed code that reduces damage for air-bursting explosives

### DIFF
--- a/DH_Engine/Classes/DHThrowableExplosiveProjectile.uc
+++ b/DH_Engine/Classes/DHThrowableExplosiveProjectile.uc
@@ -595,17 +595,7 @@ function BlowUp(vector HitLocation)
 {
     if (Role == ROLE_Authority)
     {
-        if (bBounce)
-        {
-            // If the grenade hasn't landed, do 1/3 less damage
-            // This isn't supposed to be realistic, its supposed to make airbursts less effective so players are more apt to throw grenades more authentically
-            DelayedHurtRadius(Damage * 0.75, DamageRadius, MyDamageType, MomentumTransfer, HitLocation);
-        }
-        else
-        {
-            DelayedHurtRadius(Damage, DamageRadius, MyDamageType, MomentumTransfer, HitLocation);
-        }
-
+        DelayedHurtRadius(Damage, DamageRadius, MyDamageType, MomentumTransfer, HitLocation);
         MakeNoise(1.0);
     }
 }

--- a/DH_Weapons/Classes/DH_SatchelCharge10lb10sProjectile.uc
+++ b/DH_Weapons/Classes/DH_SatchelCharge10lb10sProjectile.uc
@@ -45,17 +45,7 @@ simulated function BlowUp(vector HitLocation)
 
     if (Role == ROLE_Authority)
     {
-        if (bBounce)
-        {
-            // If the grenade hasn't landed, do 1/3 less damage
-            // This isn't supposed to be realistic, its supposed to make airbursts less effective so players are more apt to throw grenades more authentically
-            DelayedHurtRadius(Damage * 0.75, DamageRadius, MyDamageType, MomentumTransfer, HitLocation);
-        }
-        else
-        {
-            DelayedHurtRadius(Damage, DamageRadius, MyDamageType, MomentumTransfer, HitLocation);
-        }
-
+        DelayedHurtRadius(Damage, DamageRadius, MyDamageType, MomentumTransfer, HitLocation);
         HandleObjSatchels(HitLocation);
         HandleVehicles(HitLocation);
         HandleObstacles(HitLocation);


### PR DESCRIPTION
It was introduced in 7dd0ffd413939c0aa24ab8962de14202fdc24456.

- Air-bursting grenades on purpose does not impair the overall feel
  of the game or its "authenticity".

- This logic only works if players know about it, which they most
  assuredly don't. Unless they were unfortunate enough to read about it
  in the patch notes half a decade ago.