### PR TITLE
SMDM tiny fixes and adjustments.

### DIFF
--- a/DarkestHourDev/Maps/DH-St_Marie_du_Mont_Advance.rom
+++ b/DarkestHourDev/Maps/DH-St_Marie_du_Mont_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:092eb5ab98d7b7909807f8c838d1483db16f09a1243f1e71a46f51d3bfeb9acc
-size 77163872
+oid sha256:090b98dbe34e6ddaee241b51f23d19da37990839bda0350532e1f730492562c4
+size 77163860

--- a/DarkestHourDev/Maps/DH-St_Marie_du_Mont_Advance.rom
+++ b/DarkestHourDev/Maps/DH-St_Marie_du_Mont_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9bcbc56b1e239be86d6896d68f295bc298c3ff8945097e57cf32a3b261d590f9
-size 77153387
+oid sha256:092eb5ab98d7b7909807f8c838d1483db16f09a1243f1e71a46f51d3bfeb9acc
+size 77163872


### PR DESCRIPTION
-fixed reported floaters;
-both teams +1 at role count;
-axis sl and at role gain access to k98; //had only mp40
-removed gl from axis ce;
-removed colt handgun from allies rifleman role; //ALL other roles still had it
-added 2 riflemans with springfield bolt action; //since usuall role kits ce/at don't have it as choise
-added 2 active m3a1 on 90s cd;
-added 1 active sdkfz251 transport on 90s cd;
-added 1 active opel transport 60s cd;
-arty redone(or restored) from axis/allies 3 calls BAT_15 SALVO 2_3 30s CD to
allies: 19 calls BAT 8_2 SALVO 2_3 CD 1min Normal Pattern
axis: 13 calls BAT 8_2 SALVO 2_3 CD 3min Loose Pattern. //salvo 2_3 is really pain free