### PR TITLE
La_Fiere_Advance advancing minefields

### DIFF
--- a/DarkestHourDev/Maps/DH-La_Fiere_Advance.rom
+++ b/DarkestHourDev/Maps/DH-La_Fiere_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c6d90e432f93a7a4a5a36e8f51a2b70c83b278ac697980088ba9544e628f1a1
-size 66937837
+oid sha256:468fda6d2f724164c65ee10db6298a1820dfad70e8255a8c8aac9cc5cac08135
+size 66980944


### PR DESCRIPTION
-added advancing minefields for both teams;
-fixed spawns at Causeway obj; //axis used allies hints and vice verca

-allies rifleman -handgun;
-allies sergeant thompson -> m1a1;

-axis mg count 3->2;
-axis SL role +kar98.