### PR TITLE
quick fix - deprecated WIP classes of KV-1 (base model).

### DIFF
--- a/DH_Vehicles/Classes/DH_KV1Tank.uc
+++ b/DH_Vehicles/Classes/DH_KV1Tank.uc
@@ -3,11 +3,11 @@
 // Darklight Games (c) 2008-2022
 //==============================================================================
 
-class DH_KV1Tank extends DH_KV1ETank;  //WIP class, do not use it yet!
+class DH_KV1Tank extends DHDeprecated;  //WIP class, do not use it yet!
 
 defaultproperties
 {
-    // Vehicle properties
+/*    // Vehicle properties
     VehicleNameString="KV-1"
     VehicleTeam=1
     VehicleMass=15.7
@@ -98,6 +98,6 @@ defaultproperties
     VehicleHudOccupantsX(6)=0.57
     VehicleHudOccupantsY(6)=0.72
     SpawnOverlay(0)=Material'DH_InterfaceArt_tex.Vehicles.KV1'
-
+*/
 
 }

--- a/DH_Vehicles/Classes/DH_KV1Tank_Snow.uc
+++ b/DH_Vehicles/Classes/DH_KV1Tank_Snow.uc
@@ -7,11 +7,11 @@ class DH_KV1Tank_Snow extends DH_KV1Tank; //wip class
 
 
 defaultproperties
-{
+{  /*
     bIsWinterVariant=true
     Skins(0)=Texture'DH_VehiclesSOV_tex.ext_vehicles.KV1_body_snow'
     Skins(1)=Texture'GUP_vehicles_tex.WELT_kv1_treads' // this is a snowy treads version (name is misleading)
     Skins(2)=Texture'GUP_vehicles_tex.WELT_kv1_treads'
     CannonSkins(0)=Texture'DH_VehiclesSOV_tex.ext_vehicles.KV1_body_snow'
-    DestroyedMeshSkins(0)=Combiner'DH_VehiclesSOV_tex.destroyed.KV1_body_dest'
+    DestroyedMeshSkins(0)=Combiner'DH_VehiclesSOV_tex.destroyed.KV1_body_dest'  */
 }


### PR DESCRIPTION
deprecated WIP classes of KV-1 (base model). These classes were not intended  to be used on maps, it was even said so in the comments. They use wrong armor values and wrong models/textures. Some mapper, however, decided to put them on maps regardless.