### PR TITLE
Increased resistance to shoveling for hedgehogs and dragon teeth

### DIFF
--- a/DH_Construction/Classes/DHConstruction_DragonsTooth.uc
+++ b/DH_Construction/Classes/DHConstruction_DragonsTooth.uc
@@ -23,6 +23,7 @@ defaultproperties
     TatteredStaticMesh=StaticMesh'DH_Construction_stc.Obstacles.dragon_tooth_damaged'
     Stages(0)=(Progress=0,StaticMesh=StaticMesh'DH_Construction_stc.Obstacles.dragon_tooth_unassembled',Sound=none,Emitter=none)
     ProgressMax=7
+    TakeDownProgressInterval=0.2187 // 32 hits
     MenuIcon=Texture'DH_InterfaceArt2_tex.icons.dragon_teeth'
     bAcceptsProjectors=false
 

--- a/DH_Construction/Classes/DHConstruction_Hedgehog.uc
+++ b/DH_Construction/Classes/DHConstruction_Hedgehog.uc
@@ -24,5 +24,6 @@ defaultproperties
     ProgressMax=3
     GroupClass=class'DHConstructionGroup_Obstacles'
     bShouldSwitchToLastWeaponOnPlacement=false
+    TakeDownProgressInterval=0.1071 // 28 hits
     MinDamagetoHurt=180.0
 }

--- a/DH_Engine/Classes/DHConstruction.uc
+++ b/DH_Engine/Classes/DHConstruction.uc
@@ -143,7 +143,7 @@ var     bool    bCanBeTornDownWhenConstructed;      // Whether or not players ca
 var     bool    bCanBeTornDownByFriendlies;         // Whether or not friendly players can tear down the construction (e.g. to stop griefing of important constructions)
 var     bool    bBreakOnTearDown;                   // If true, the construction breaks when torn down
 var     float   TearDownProgress;
-var     float   TakeDownProgressInterval;
+var     float   TakeDownProgressInterval;           // ProgressMax / Desired Hits
 
 // Broken
 var     float           BrokenLifespan;             // How long does the actor stay around after it's been killed?


### PR DESCRIPTION
The obstacles were too easily dismantled by anyone with a shovel, and it
was inconsistent with the buff that concertina wire received in the past.

Hits required to take down an obstacle with a shovel:
- Concertina Wire: 24
- Hedgehog: 28
- Dragon Tooth: 32