### PR TITLE
Armored Advance Game Mode

### DIFF
--- a/DH_Engine/Classes/DHGameType_Armored_Advance.uc
+++ b/DH_Engine/Classes/DHGameType_Armored_Advance.uc
@@ -1,0 +1,23 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2022
+//==============================================================================
+
+class DHGameType_Armored_Advance extends DHGameType
+    abstract;
+
+defaultproperties
+{
+    GameTypeName="Armored Advance"
+
+    bAreObjectiveSpawnsEnabled=true
+    bAreRallyPointsEnabled=true
+    bAreConstructionsEnabled=true
+
+	bUseInfiniteReinforcements=true
+    bSquadSpecialRolesOnly=true
+    bHasTemporarySpawnVehicles=true
+
+    ObjSpawnMinimumDepth=1
+}
+

--- a/DarkestHourDev/Maps/DH-Armored_Freyneux_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Armored_Freyneux_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3d7c2d0b6e2d74c9e5744bdc838bb5078d12ed7e66447aa845545c8cd8be692
-size 23327404
+oid sha256:39bc64cd7e86ece414cebcf94da142e42ecf1875e837d7fc58cf5abb51f4c762
+size 23327437


### PR DESCRIPTION
New Game Mode:

- Armored Advance, uses time instead of tickets to help with balancing tank maps.

- Converted Armored Freyneux Advance to use this game mode.