### PR TITLE
Hotfix for US Winter and Tanker Pawns

### DIFF
--- a/DH_USPlayers/Classes/DH_USTankerPawn.uc
+++ b/DH_USPlayers/Classes/DH_USTankerPawn.uc
@@ -9,4 +9,8 @@ defaultproperties
 {
     Mesh=SkeletalMesh'DHCharactersUS_anm.US_tanker'
     Skins(1)=Texture'DHUSCharactersTex.743rdTank.US_743Armored_1'
+
+// Same texture declared twice as this role has only one texture variant, necessary due to AmericanPawn inheritance
+	BodySkins(0)=Texture'DHUSCharactersTex.743rdTank.US_743Armored_1'
+    BodySkins(1)=Texture'DHUSCharactersTex.743rdTank.US_743Armored_1'
 }

--- a/DH_USPlayers/Classes/DH_USWinterPawn.uc
+++ b/DH_USPlayers/Classes/DH_USWinterPawn.uc
@@ -21,6 +21,10 @@ defaultproperties
     Skins(0)=Texture'DHUSCharactersTex.us_heads.WinterFace2'
     Skins(1)=Texture'DHUSCharactersTex.Winter.GI_Variant_Jacket'
 
+// Same texture declared twice as this role has only one texture variant, necessary due to AmericanPawn inheritance
+	BodySkins(0)=Texture'DHUSCharactersTex.Winter.GI_Variant_Jacket'
+    BodySkins(1)=Texture'DHUSCharactersTex.Winter.GI_Variant_Jacket'
+
     bReversedSkinsSlots=true
 
     FaceSkins(0)=Texture'DHUSCharactersTex.us_heads.WinterFace1'


### PR DESCRIPTION
- Fixed a bug where US Tanker and Winter Pawns were inheriting incorrect bodyskin textures from AmericanPawn.