### PR TITLE
New map hotfixes

### DIFF
--- a/DarkestHourDev/Maps/DH-German_Village_Advance.rom
+++ b/DarkestHourDev/Maps/DH-German_Village_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e52db4cf658bacc69eaaeccbbc970126015cbc27a7a7dbe7c9f7f68614dee358
-size 31352205
+oid sha256:22d7e7ddfbbf721bbc18073f879dab0f0eb5f92c3a137776b29f87f5c6b1b1eb
+size 31607342

--- a/DarkestHourDev/Maps/DH-Lazur_Chemical_Plant_Defence.rom
+++ b/DarkestHourDev/Maps/DH-Lazur_Chemical_Plant_Defence.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c6cf844bac74c8681382266348daf2004cda993c1098fd28f0204d07b8279b9
-size 42680062
+oid sha256:22f890e69aa4fff3dfe7ddec17b208fea7ac60b600378f9726fb47fde5ed3ae6
+size 43150333

--- a/DarkestHourDev/Maps/DH-Lazur_Chemical_Plant_Defence.rom
+++ b/DarkestHourDev/Maps/DH-Lazur_Chemical_Plant_Defence.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:22f890e69aa4fff3dfe7ddec17b208fea7ac60b600378f9726fb47fde5ed3ae6
-size 43150333
+oid sha256:73f0f8038b75b4056d61ec59d0224d521c48c8d8617a4c48cf3014dbb72226c4
+size 43146811

--- a/DarkestHourDev/Maps/DH-Lutremange_Domination.rom
+++ b/DarkestHourDev/Maps/DH-Lutremange_Domination.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc1efe678f7d8f85e2d07159cdd1020102ede560a725ff0739b40e3f3a4a8cde
-size 36290579
+oid sha256:7f7ec35213c122c0a9489637bafeef9c8aad1c96ec1a63df2be4c4a4b9572609
+size 36296512

--- a/DarkestHourDev/Maps/DH-Rhine_River_Clash.rom
+++ b/DarkestHourDev/Maps/DH-Rhine_River_Clash.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:855791cc022cccc0f0fcc734799a735343cbbcb370404923df8881e3806353ad
-size 39349905
+oid sha256:577b93e5ed451a520e2e2f7f0d7cffc710dc0df71a8afc1fc9a0cb0e01a28d46
+size 39404223

--- a/DarkestHourDev/Maps/DH-Rhine_River_Clash.rom
+++ b/DarkestHourDev/Maps/DH-Rhine_River_Clash.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:577b93e5ed451a520e2e2f7f0d7cffc710dc0df71a8afc1fc9a0cb0e01a28d46
-size 39404223
+oid sha256:a513cf4c392fadc1f5e99e685774c54c952fb3528ef6c3900ea82f5af6c7bade
+size 39403109


### PR DESCRIPTION
Lutremange Domination:

- Added DZ to both main spawns to allow for vehicle spawning.
- Replaced Greyhound with Stuart and Easy 8 Sherman with M4A3 76w.
- Reduced intensity of artillery for both teams.

Lazur Chemical Plant:

- Fixed incorrect materials on myLevel package textures (used pretty heavily on the map, so many walls, windows, signs, etc., will now have correct impact FX)
- Expanded protection minefield for AlliedSpawn2A to prevent spawn killing (caused by addition of mantling in DH that allowed access to areas not possible in RO).
- Fixed bugged lighting in some areas.
- Increased tickets for both teams significantly.
- Fixed bugged satchel doors.

German Village Advance:

- Fixed issues with NoArty volumes blocking most of the map.
- Fixed exploit that could allow users to get outside of the map bounds.
- Increased Allied tickets slightly.
- Replaced flag statics on the map with new models from Matty.

Rhine River:

- Fixed a BSP issue near the refueling area objective.
- Fixed incorrect US engineer role.