### PR TITLE
Feature vehicle hitpoints revert

### DIFF
--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -3307,7 +3307,7 @@ function DrawVehiclePointSphere()
                 }
                 else
                 {
-                    c = WhiteColor;
+                    C = WhiteColor;
                 }
 
                 AV.DrawDebugSphere(HitPointLocation, AV.NewVehHitpoints[i].PointRadius, 10, C.R, C.G, C.B);

--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -3293,7 +3293,7 @@ function DrawVehiclePointSphere()
 
                 HitPointLocation = HitPointCoords.Origin + (AV.NewVehHitpoints[i].PointOffset >> rotator(HitPointCoords.XAxis));
 
-                if (AV.NewVehHitpoints[i].NewHitPointType == NHP_Traverse || AV.NewVehHitpoints[i].NewHitPointType == NHP_GunPitch)
+                if (AV.NewVehHitpoints[i].NewHitPointType == NHP_Traverse)
                 {
                     C = GoldColor;
                 }
@@ -3301,9 +3301,13 @@ function DrawVehiclePointSphere()
                 {
                     C = PurpleColor;
                 }
+                else if (AV.NewVehHitpoints[i].NewHitPointType == NHP_GunPitch) //changed so they are easier to differenciate between pitch and traverse
+                {
+                    C = GreenColor;
+                }
                 else
                 {
-                    C = WhiteColor;
+                    c = WhiteColor;
                 }
 
                 AV.DrawDebugSphere(HitPointLocation, AV.NewVehHitpoints[i].PointRadius, 10, C.R, C.G, C.B);

--- a/DH_Vehicles/Classes/DH_BT7Tank.uc
+++ b/DH_Vehicles/Classes/DH_BT7Tank.uc
@@ -90,6 +90,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=30,Y=0,Z=10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=28,Y=-45.0,Z=15.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=28,Y=45.0,Z=15.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=50.00,Y=-7.00,Z=0.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-30.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=7.0,PointBone="turret",PointOffset=(X=40.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=-3.25
     TreadDamageThreshold=0.15
     DamagedEffectOffset=(X=-78.0,Y=0.0,Z=25.0)

--- a/DH_Vehicles/Classes/DH_ChurchillMkVIITank.uc
+++ b/DH_Vehicles/Classes/DH_ChurchillMkVIITank.uc
@@ -106,7 +106,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="Turret",PointOffset=(X=20.0,Y=20.0,Z=-30.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore) // turret ready rack
     VehHitpoints(2)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=20.0,Y=-65.0,Z=65.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)   // left pannier
     VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=20.0,Y=65.0,Z=65.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)    // right pannier
-    NewVehHitpoints(0)=(PointRadius=15.0,PointBone="Turret",PointOffset=(X=48.0,Y=0.0,Z=19.0),NewHitPointType=NHP_GunPitch)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=61.00,Y=-17.00,Z=18.80),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-10.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret",PointOffset=(X=50.00,Y=-3.00,Z=18.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=37.0
     DamagedTrackStaticMeshLeft=StaticMesh'DH_Churchill_stc.Churchill_DamagedTrack_left'
     DamagedTrackStaticMeshRight=StaticMesh'DH_Churchill_stc.Churchill_DamagedTrack_right'

--- a/DH_Vehicles/Classes/DH_CromwellTank.uc
+++ b/DH_Vehicles/Classes/DH_CromwellTank.uc
@@ -83,6 +83,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=-20.0,Y=40.0,Z=3.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=-20.0,Y=-40.0,Z=3.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=40.0,Z=-8.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=60.00,Y=-17.40,Z=0.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-15.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret",PointOffset=(X=50.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=58.0
     DamagedEffectScale=0.9
     DamagedEffectOffset=(X=-130.0,Y=0.0,Z=85.0)

--- a/DH_Vehicles/Classes/DH_HellcatTank.uc
+++ b/DH_Vehicles/Classes/DH_HellcatTank.uc
@@ -71,6 +71,10 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=-100.0,Z=4.0)) // engine
     VehHitpoints(1)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=30.0,Y=-30.0,Z=4.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=30.0,Y=30.0,Z=4.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=74.00,Y=-16.00,Z=30.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=0.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret",PointOffset=(X=55.00,Y=-0.00,Z=30.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=8.0
     DamagedEffectOffset=(X=-140.0,Y=0.0,Z=35.0)
     DestroyedVehicleMesh=StaticMesh'DH_allies_vehicles_stc3.Hellcat.Hellcat_dest'

--- a/DH_Vehicles/Classes/DH_IS2Tank.uc
+++ b/DH_Vehicles/Classes/DH_IS2Tank.uc
@@ -75,6 +75,10 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=-100.0,Y=0.0,Z=0.0)) // engine
     VehHitpoints(1)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=16.0,Y=-25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=16.0,Y=25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=97.00,Y=-19.50,Z=8.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=23.0,PointBone="turret",PointOffset=(X=0.00,Y=-0.00,Z=-30.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=16.0,PointBone="turret",PointOffset=(X=80.00,Y=-0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=8.0
     DamagedEffectOffset=(X=-135.0,Y=0.0,Z=35.0) // repositioned to engine deck grille
     FireAttachBone="Body"

--- a/DH_Vehicles/Classes/DH_ISU152Destroyer.uc
+++ b/DH_Vehicles/Classes/DH_ISU152Destroyer.uc
@@ -78,6 +78,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-70.0,Y=50.0,Z=40.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-20.0,Y=50.0,Z=40.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(X=-20.0,Y=10.0,Z=-20.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret_placement",PointOffset=(X=25.00,Y=-10.00,Z=8.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret_placement",PointOffset=(X=0.00,Y=0.00,Z=0.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=20.0,PointBone="turret_placement",PointOffset=(X=0.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=-5.0
     DamagedEffectOffset=(X=-210.0,Y=0.0,Z=40.0) // adjusted from original
     FireAttachBone="Body"

--- a/DH_Vehicles/Classes/DH_JacksonTank.uc
+++ b/DH_Vehicles/Classes/DH_JacksonTank.uc
@@ -69,10 +69,14 @@ defaultproperties
     PlayerFireDamagePer2Secs=12.0 // reduced from 15 for all diesels
     FireDetonationChance=0.045  //reduced from 0.07 for all diesels
     DisintegrationHealth=-1200.0 //diesel
-    VehHitpoints(0)=(PointRadius=35.0,PointBone="Jackson_body_ext",PointOffset=(X=-90.0,Z=-35.0)) // engine
-    VehHitpoints(1)=(PointRadius=15.0,PointScale=1.0,PointBone="Jackson_body_ext",PointOffset=(X=20.0,Y=55.0,Z=-8.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
-    VehHitpoints(2)=(PointRadius=15.0,PointScale=1.0,PointBone="Jackson_body_ext",PointOffset=(X=20.0,Y=-55.0,Z=-8.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
-    VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="Jackson_body_ext",PointOffset=(X=-20.0,Z=-20.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    VehHitpoints(0)=(PointRadius=35.0,PointBone="Jackson_body_ext",PointOffset=(X=-110,y=0.00,Z=-100.0)) // engine //jacksons origin points are awfully messed up, may need to fix at some point
+    VehHitpoints(1)=(PointRadius=15.0,PointScale=1.0,PointBone="Jackson_body_ext",PointOffset=(X=20.0,Y=55.0,Z=-0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)  //jacksons origin points are awfully messed up, may need to fix at some point
+    VehHitpoints(2)=(PointRadius=15.0,PointScale=1.0,PointBone="Jackson_body_ext",PointOffset=(X=20.0,Y=-55.0,Z=-0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore) //jacksons origin points are awfully messed up, may need to fix at some point
+    VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="Jackson_body_ext",PointOffset=(X=-20.0,Z=-20.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)     //jacksons origin points are awfully messed up, may need to fix at some point
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=71.00,Y=31.00,Z=6.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-30.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=50.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=65.0
     DamagedEffectOffset=(X=-126.0,Y=20.0,Z=105.0)
     DestroyedVehicleMesh=StaticMesh'DH_allies_vehicles_stc2.Jackson.Jackson_Dest'

--- a/DH_Vehicles/Classes/DH_JagdpantherTank.uc
+++ b/DH_Vehicles/Classes/DH_JagdpantherTank.uc
@@ -80,8 +80,8 @@ defaultproperties
     VehHitpoints(3)=(PointRadius=15.0,PointHeight=10.0,PointScale=1.0,PointBone="body",PointOffset=(Y=45.0,Z=50.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(4)=(PointRadius=15.0,PointHeight=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=35.0,Y=45.0,Z=50.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     NewVehHitpoints(0)=(PointRadius=8.0,PointBone="body",PointOffset=(X=55.0,Y=-40.0,Z=77.0),NewHitPointType=NHP_GunOptics)
-    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="Turret_placement",PointOffset=(X=72.0,Z=45.0),NewHitPointType=NHP_Traverse)
-    NewVehHitpoints(2)=(PointRadius=15.0,PointBone="Turret_placement",PointOffset=(X=72.0,Z=45.0),NewHitPointType=NHP_GunPitch)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="Turret_placement",PointOffset=(X=0.00,y=0.00,Z=0.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=15.0,PointBone="Turret_placement",PointOffset=(X=0.00,y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
     GunOpticsHitPointIndex=0
     TreadHitMaxHeight=60.0
     TreadDamageThreshold=0.85

--- a/DH_Vehicles/Classes/DH_JagdtigerTank.uc
+++ b/DH_Vehicles/Classes/DH_JagdtigerTank.uc
@@ -72,10 +72,10 @@ defaultproperties
     TurretDetonationThreshold=1300.0 // reduced from 1750 (this vehicle is turretless though? i am not sure how this works so put it here just in case)
 
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=-150.0,Z=-20.0)) // engine
-    VehHitpoints(1)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(X=-55.0,Y=-65.0,Z=4.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
-    VehHitpoints(2)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(X=-55.0,Y=65.0,Z=4.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
-    VehHitpoints(3)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(Y=-65.0,Z=4.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
-    VehHitpoints(4)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(Y=65.0,Z=4.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-55.0,Y=-65.0,Z=4.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    VehHitpoints(2)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-55.0,Y=65.0,Z=4.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    VehHitpoints(3)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(Y=-65.0,Z=4.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    VehHitpoints(4)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(Y=65.0,Z=4.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore) //these are 128mm ammo racks
     NewVehHitpoints(0)=(PointRadius=6.0,PointBone="body",PointOffset=(X=50.0,Y=-37.0,Z=98.0),NewHitPointType=NHP_GunOptics)
     NewVehHitpoints(1)=(PointRadius=25.0,PointBone="body",PointOffset=(X=50.0,Z=55.0),NewHitPointType=NHP_Traverse)
     NewVehHitpoints(2)=(PointRadius=25.0,PointBone="body",PointOffset=(X=50.0,Z=55.0),NewHitPointType=NHP_GunPitch)

--- a/DH_Vehicles/Classes/DH_KV1ETank.uc
+++ b/DH_Vehicles/Classes/DH_KV1ETank.uc
@@ -81,6 +81,10 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=-100.0,Y=0.0,Z=0.0)) // engine // TODO: check position of all hit points
     VehHitpoints(1)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=13.0,Y=-25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=13.0,Y=25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=73.00,Y=-10.00,Z=5.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-25.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=57.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=26.0
     DamagedEffectOffset=(X=-90.0,Y=0.0,Z=40.0)
     DestroyedVehicleMesh=StaticMesh'DH_soviet_vehicles_stc.Kv1.KV1_Dest'

--- a/DH_Vehicles/Classes/DH_KV1sTank.uc
+++ b/DH_Vehicles/Classes/DH_KV1sTank.uc
@@ -82,6 +82,10 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=-100.0,Y=0.0,Z=0.0)) // engine // TODO: check position of all hit points
     VehHitpoints(1)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=13.0,Y=-25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=13.0,Y=25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=87.00,Y=-12.40,Z=-2.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-30.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret",PointOffset=(X=78.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=26.0
     DamagedEffectOffset=(X=-90.0,Y=0.0,Z=40.0)
     DestroyedVehicleMesh=StaticMesh'allies_vehicles_stc.Kv1_Destroyed'

--- a/DH_Vehicles/Classes/DH_PantherDTank.uc
+++ b/DH_Vehicles/Classes/DH_PantherDTank.uc
@@ -85,7 +85,9 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=15.0,PointHeight=30.0,PointScale=1.0,PointBone="body",PointOffset=(X=20.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=15.0,PointHeight=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=-20.0,Y=-40.0,Z=40.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=15.0,PointHeight=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=-20.0,Y=40.0,Z=40.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
-    NewVehHitpoints(0)=(PointRadius=8.0,PointBone="turret",PointOffset=(X=88.00,Y=-27.00,Z=7.00),NewHitPointType=NHP_GunOptics) 
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=88.00,Y=-27.00,Z=7.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-30.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret",PointOffset=(X=70.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
     GunOpticsHitPointIndex=0
     TreadHitMaxHeight=0.0
     TreadDamageThreshold=0.85

--- a/DH_Vehicles/Classes/DH_PantherDTank.uc
+++ b/DH_Vehicles/Classes/DH_PantherDTank.uc
@@ -87,7 +87,7 @@ defaultproperties
     VehHitpoints(3)=(PointRadius=15.0,PointHeight=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=-20.0,Y=40.0,Z=40.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=88.00,Y=-27.00,Z=7.00),NewHitPointType=NHP_GunOptics)
     NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-30.00),NewHitPointType=NHP_Traverse)
-    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret",PointOffset=(X=70.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    NewVehHitpoints(2)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=70.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
     GunOpticsHitPointIndex=0
     TreadHitMaxHeight=0.0
     TreadDamageThreshold=0.85

--- a/DH_Vehicles/Classes/DH_PantherDTank.uc
+++ b/DH_Vehicles/Classes/DH_PantherDTank.uc
@@ -85,6 +85,8 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=15.0,PointHeight=30.0,PointScale=1.0,PointBone="body",PointOffset=(X=20.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=15.0,PointHeight=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=-20.0,Y=-40.0,Z=40.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=15.0,PointHeight=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=-20.0,Y=40.0,Z=40.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=8.0,PointBone="turret",PointOffset=(X=88.00,Y=-27.00,Z=7.00),NewHitPointType=NHP_GunOptics) 
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=0.0
     TreadDamageThreshold=0.85
     DamagedEffectOffset=(X=-100.0,Y=20.0,Z=26.0)

--- a/DH_Vehicles/Classes/DH_PanzerIIIJTank.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIIIJTank.uc
@@ -41,7 +41,7 @@ defaultproperties
     DriverPositions(2)=(PositionMesh=SkeletalMesh'DH_Panzer3_anm.Panzer3J_body_int',TransitionDownAnim="Overlay_Out",ViewPitchUpLimit=6000,ViewPitchDownLimit=63000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-6000)
     bDrawDriverInTP=false
     PeriscopeOverlay=Texture'Vehicle_Optic.Scopes.MG_sight'
-    PeriscopeSize=0.765 //65° FOV 1x magnification KFF2 driver's scope
+    PeriscopeSize=0.765 //65ï¿½ FOV 1x magnification KFF2 driver's scope
 
     // Hull armor
     FrontArmor(0)=(Thickness=5.0,Slope=-20.0,MaxRelativeHeight=5.7,LocationName="lower nose")
@@ -75,6 +75,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=10.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=50.0,Y=-25.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=10.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=50.0,Y=25.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=15.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-30.0,Y=25.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=1.50,PointBone="turret",PointOffset=(X=58.00,Y=-22.00,Z=1.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-20.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret",PointOffset=(X=53.00,Y=-2.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=20.0
     TreadDamageThreshold=0.5
     DamagedEffectScale=0.85

--- a/DH_Vehicles/Classes/DH_PanzerIIILTank.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIIILTank.uc
@@ -40,7 +40,7 @@ defaultproperties
     DriverPositions(2)=(PositionMesh=SkeletalMesh'DH_Panzer3_anm.Panzer3n_body_int',TransitionDownAnim="Overlay_Out",ViewPitchUpLimit=6000,ViewPitchDownLimit=63000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-6000)
     bDrawDriverInTP=false
     PeriscopeOverlay=Texture'Vehicle_Optic.Scopes.MG_sight'
-    PeriscopeSize=0.765 //65° FOV 1x magnification KFF2 driver's scope
+    PeriscopeSize=0.765 //65ï¿½ FOV 1x magnification KFF2 driver's scope
 
     // Hull armor
     FrontArmor(0)=(Thickness=5.0,Slope=-20.0,MaxRelativeHeight=5.7,LocationName="lower nose")
@@ -74,6 +74,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=10.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=50.0,Y=-25.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=10.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=50.0,Y=25.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=15.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-30.0,Y=25.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=1.50,PointBone="turret",PointOffset=(X=58.00,Y=-22.00,Z=1.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-20.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret",PointOffset=(X=53.00,Y=-2.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=20.0
     TreadDamageThreshold=0.5
     DamagedEffectScale=0.85

--- a/DH_Vehicles/Classes/DH_PanzerIVF1Tank.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIVF1Tank.uc
@@ -63,6 +63,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=10.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=50.0,Y=-27.0,Z=-10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=10.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=50.0,Y=27.0,Z=-10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=15.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-30.0,Y=25.0,Z=10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=1.5,PointBone="turret",PointOffset=(X=59.00,Y=-28.00,Z=3.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-20.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=13.0,PointBone="turret",PointOffset=(X=55.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=14.0
     DamagedEffectScale=0.9
     DamagedEffectOffset=(X=-110.0,Y=0.0,Z=60.0)

--- a/DH_Vehicles/Classes/DH_PanzerIVGEarlyTank.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIVGEarlyTank.uc
@@ -64,6 +64,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=10.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=50.0,Y=-27.0,Z=-10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=10.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=50.0,Y=27.0,Z=-10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=15.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-30.0,Y=25.0,Z=10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=1.5,PointBone="turret",PointOffset=(X=59.00,Y=-28.00,Z=3.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-20.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=14.0,PointBone="turret",PointOffset=(X=55.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=14.0
     DamagedEffectScale=0.9
     DamagedEffectOffset=(X=-110.0,Y=0.0,Z=60.0)

--- a/DH_Vehicles/Classes/DH_PanzerIVGLateTank.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIVGLateTank.uc
@@ -63,6 +63,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=10.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=50.0,Y=-27.0,Z=-10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=10.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=50.0,Y=27.0,Z=-10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=15.0,PointHeight=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-30.0,Y=25.0,Z=10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=1.5,PointBone="turret",PointOffset=(X=59.00,Y=-28.00,Z=3.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-20.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=14.0,PointBone="turret",PointOffset=(X=55.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=14.0
     DamagedEffectScale=0.9
     DamagedEffectOffset=(X=-110.0,Y=0.0,Z=60.0)

--- a/DH_Vehicles/Classes/DH_PanzerIVHTank.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIVHTank.uc
@@ -19,6 +19,11 @@ defaultproperties
     DestroyedMeshSkins(0)=none // remove skins inherited from ausf G, as the inherited DestroyedVehicleMesh is correct for this vehicle & we don't want it changed
     DestroyedMeshSkins(2)=none
 
+    NewVehHitpoints(0)=(PointRadius=1.30,PointBone="turret",PointOffset=(X=59.00,Y=-27.00,Z=7.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-20.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=14.0,PointBone="turret",PointOffset=(X=55.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    
+
     DriverPositions(0)=(PositionMesh=SkeletalMesh'DH_PanzerIV_anm.Panzer4H_body_int')
     DriverPositions(1)=(PositionMesh=SkeletalMesh'DH_PanzerIV_anm.Panzer4H_body_int')
     DriverPositions(2)=(PositionMesh=SkeletalMesh'DH_PanzerIV_anm.Panzer4H_body_int')

--- a/DH_Vehicles/Classes/DH_SU76Destroyer.uc
+++ b/DH_Vehicles/Classes/DH_SU76Destroyer.uc
@@ -87,6 +87,10 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=9.0,PointHeight=0.0,PointScale=1.0,PointBone=driver_player,PointOffset=(X=-13.0,Y=-3.0,Z=-8.0),bPenetrationPoint=true,HitPointType=HP_Driver)
     VehHitpoints(1)=(PointRadius=35.0,PointHeight=0.0,PointScale=1.0,PointBone=body,PointOffset=(X=25.0,Y=45.0,Z=-10.0),bPenetrationPoint=false,DamageMultiplier=1.0,HitPointType=HP_Engine)
     VehHitpoints(2)=(PointRadius=25.0,PointHeight=0.0,PointScale=1.0,PointBone=body,PointOffset=(X=-80.0,Y=-40.0,Z=5.0),bPenetrationPoint=false,DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret_placement",PointOffset=(X=20.00,Y=-10.00,Z=0.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=10.0,PointBone="turret_placement",PointOffset=(X=0.00,Y=0.00,Z=0.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret_placement",PointOffset=(X=0.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     //below is from isu152
     //TreadHitMaxHeight=-5.0
     //DamagedEffectOffset=(X=-210.0,Y=0.0,Z=40.0)

--- a/DH_Vehicles/Classes/DH_ShermanFireflyTank.uc
+++ b/DH_Vehicles/Classes/DH_ShermanFireflyTank.uc
@@ -67,6 +67,10 @@ defaultproperties
     VehHitpoints(2)=(PointRadius=20.0,PointScale=1.0,PointBone="Body",PointOffset=(X=67.0,Y=-55.0,Z=31.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=20.0,PointScale=1.0,PointBone="Body",PointOffset=(X=67.0,Y=55.0,Z=31.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(4)=(PointRadius=30.0,PointScale=1.0,PointBone="Body",PointOffset=(X=-15.0,Y=0.0,Z=0.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=52.00,Y=23.30,Z=8.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-25.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=13.0,PointBone="turret",PointOffset=(X=40.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=70.15
     DamagedTrackStaticMeshLeft=StaticMesh'DH_allies_vehicles_stc.Sherman.Firefly_DamagedTrack_left'
     DamagedTrackStaticMeshRight=StaticMesh'DH_allies_vehicles_stc.Sherman.Firefly_DamagedTrack_right'

--- a/DH_Vehicles/Classes/DH_ShermanTank.uc
+++ b/DH_Vehicles/Classes/DH_ShermanTank.uc
@@ -68,6 +68,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-15.0,Y=40.0,Z=87.0),DamageMultiplier=4.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-15.0,Y=-40.0,Z=87.0),DamageMultiplier=4.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(Z=55.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=62.00,Y=15.00,Z=0.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-20.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=30.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=66.0
     DamagedTrackStaticMeshLeft=StaticMesh'DH_allies_vehicles_stc.Sherman.M4A1_DamagedTrack_left'
     DamagedTrackStaticMeshRight=StaticMesh'DH_allies_vehicles_stc.Sherman.M4A1_DamagedTrack_right'

--- a/DH_Vehicles/Classes/DH_ShermanTankA_M4A176W.uc
+++ b/DH_Vehicles/Classes/DH_ShermanTankA_M4A176W.uc
@@ -16,4 +16,9 @@ defaultproperties
     VehicleHudTurret=TexRotator'DH_InterfaceArt_tex.Tank_Hud.Sherman76_turret_rot'
     VehicleHudTurretLook=TexRotator'DH_InterfaceArt_tex.Tank_Hud.Sherman76_turret_look'
     SpawnOverlay(0)=Material'DH_InterfaceArt_tex.Vehicles.sherman_m4a1_76_a'
+
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=65.00,Y=22.00,Z=30.50),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=10.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=35.00,Y=0.00,Z=20.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
 }

--- a/DH_Vehicles/Classes/DH_ShermanTank_British.uc
+++ b/DH_Vehicles/Classes/DH_ShermanTank_British.uc
@@ -11,4 +11,5 @@ defaultproperties
     Skins(0)=Texture'DH_VehiclesUK_tex.ext_vehicles.Brit_Sherman_body_ext'
     CannonSkins(0)=Texture'DH_VehiclesUK_tex.ext_vehicles.Brit_Sherman_body_ext'
     DestroyedVehicleMesh=StaticMesh'DH_allies_vehicles_stc.Sherman.Brit_Sherman_Dest'
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=58.00,Y=26.50,Z=9.00),NewHitPointType=NHP_GunOptics)
 }

--- a/DH_Vehicles/Classes/DH_ShermanTank_M4A276W_Soviet.uc
+++ b/DH_Vehicles/Classes/DH_ShermanTank_M4A276W_Soviet.uc
@@ -49,6 +49,10 @@ defaultproperties
     FireDetonationChance=0.045  //reduced from 0.07 for all diesels
     DisintegrationHealth=-1400.0 //diesel and wet stowage
 
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=65.00,Y=22.00,Z=30.50),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=10.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=35.00,Y=0.00,Z=20.00),NewHitPointType=NHP_GunPitch)
+
 	//to do: destroyed textures
 }
 

--- a/DH_Vehicles/Classes/DH_ShermanTank_M4A3105_Howitzer.uc
+++ b/DH_Vehicles/Classes/DH_ShermanTank_M4A3105_Howitzer.uc
@@ -19,4 +19,9 @@ defaultproperties
 	// Compared to M4A375W: 105mm ammo is more likely to explode
 	AmmoIgnitionProbability=0.88  // 0.75 default
 
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=57.00,Y=20.00,Z=0.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-30.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=30.00,Y=0.00,Z=-10.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
+
 }

--- a/DH_Vehicles/Classes/DH_ShermanTank_M4A375W.uc
+++ b/DH_Vehicles/Classes/DH_ShermanTank_M4A375W.uc
@@ -69,6 +69,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-15.0,Y=25.0,Z=20.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-15.0,Y=-25.0,Z=20.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(Z=15.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=62.00,Y=15.00,Z=0.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-20.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=30.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=65.0
     DamagedTrackStaticMeshLeft=StaticMesh'DH_allies_vehicles_stc3.ShermanM4A3.M4A3_DamagedTrack_left'
     DamagedTrackStaticMeshRight=StaticMesh'DH_allies_vehicles_stc3.ShermanM4A3.M4A3_DamagedTrack_right'

--- a/DH_Vehicles/Classes/DH_ShermanTank_M4A376W.uc
+++ b/DH_Vehicles/Classes/DH_ShermanTank_M4A376W.uc
@@ -14,5 +14,10 @@ defaultproperties
     VehicleHudTurret=TexRotator'DH_InterfaceArt_tex.Tank_Hud.Sherman76_turret_rot'
     VehicleHudTurretLook=TexRotator'DH_InterfaceArt_tex.Tank_Hud.Sherman76_turret_look'
     SpawnOverlay(0)=Material'DH_InterfaceArt_tex.Vehicles.sherman_m4a3_76w'
+
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=65.00,Y=22.00,Z=30.50),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=10.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=35.00,Y=0.00,Z=20.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
 }
 

--- a/DH_Vehicles/Classes/DH_ShermanTank_M4A3E2_Jumbo.uc
+++ b/DH_Vehicles/Classes/DH_ShermanTank_M4A3E2_Jumbo.uc
@@ -24,6 +24,10 @@ defaultproperties
     RightArmor(1)=(Thickness=5.8,LocationName="upper")
     LeftArmor(0)=(Thickness=3.81,MaxRelativeHeight=69.7,LocationName="lower")
     LeftArmor(1)=(Thickness=5.8,LocationName="upper")
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=83.00,Y=23.00,Z=5.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-30.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=55.00,Y=0.00,Z=-5.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     DestroyedVehicleMesh=StaticMesh'DH_allies_vehicles_stc3.ShermanM4A3.M4A3E2_dest'
     GearRatios(4)=0.67
     TransRatio=0.07

--- a/DH_Vehicles/Classes/DH_ShermanTank_M4A3E8.uc
+++ b/DH_Vehicles/Classes/DH_ShermanTank_M4A3E8.uc
@@ -146,6 +146,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-15.0,Y=25.0,Z=70.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-15.0,Y=-25.0,Z=70.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(Z=65.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=75.00,Y=21.50,Z=36.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=0.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=55.00,Y=0.00,Z=25.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
 
     LeftWheelBones(0)="wheel.L.001"
     LeftWheelBones(1)="wheel.L.002"

--- a/DH_Vehicles/Classes/DH_StuartTank.uc
+++ b/DH_Vehicles/Classes/DH_StuartTank.uc
@@ -66,6 +66,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(Z=10.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=10.0,PointScale=1.0,PointBone="body",PointOffset=(Y=-45.0,Z=30.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=10.0,PointScale=1.0,PointBone="body",PointOffset=(Y=45.0,Z=30.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=1.5,PointBone="turret",PointOffset=(X=45.00,Y=-9.00,Z=7.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-15.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret",PointOffset=(X=30.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=59.0
     TreadDamageThreshold=0.5
     DamagedEffectOffset=(X=-78.5,Y=20.0,Z=100.0)

--- a/DH_Vehicles/Classes/DH_T3476Tank.uc
+++ b/DH_Vehicles/Classes/DH_T3476Tank.uc
@@ -73,6 +73,10 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=-90.0,Y=0.0,Z=0.0)) // engine
     VehHitpoints(1)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=13.0,Y=-25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=13.0,Y=25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=68.00,Y=-11.00,Z=8.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-25.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=55.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=5.0
     DamagedEffectScale=0.9
     DamagedEffectOffset=(X=-105.0,Y=0.0,Z=40.0) // adjusted from original

--- a/DH_Vehicles/Classes/DH_T3476_42Tank.uc
+++ b/DH_Vehicles/Classes/DH_T3476_42Tank.uc
@@ -88,6 +88,10 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=-90.0,Y=0.0,Z=0.0)) // engine
     VehHitpoints(1)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=13.0,Y=-25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=13.0,Y=25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=68.00,Y=-12.50,Z=4.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-25.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=55.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch))
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=5.0
     DamagedEffectScale=0.9
     DamagedEffectOffset=(X=-105.0,Y=0.0,Z=40.0) // adjusted from original

--- a/DH_Vehicles/Classes/DH_T3476_43Tank.uc
+++ b/DH_Vehicles/Classes/DH_T3476_43Tank.uc
@@ -86,6 +86,10 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=-90.0,Y=0.0,Z=0.0)) // engine
     VehHitpoints(1)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=13.0,Y=-25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=13.0,Y=25.0,Z=-5.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=68.00,Y=-12.50,Z=4.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-25.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=55.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=5.0
     DamagedEffectScale=0.9
     DamagedEffectOffset=(X=-105.0,Y=0.0,Z=40.0) // adjusted from original

--- a/DH_Vehicles/Classes/DH_T3485Tank.uc
+++ b/DH_Vehicles/Classes/DH_T3485Tank.uc
@@ -32,6 +32,11 @@ defaultproperties
     HealthMax=525
     EngineHealth=300
 
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=90.00,Y=-12.50,Z=4.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-25.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=16.0,PointBone="turret",PointOffset=(X=75.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
+
     PlayerFireDamagePer2Secs=12.0 // reduced from 15 for all diesels
     FireDetonationChance=0.045  //reduced from 0.07 for all diesels
     DisintegrationHealth=-1200.0 //diesel

--- a/DH_Vehicles/Classes/DH_T60Tank.uc
+++ b/DH_Vehicles/Classes/DH_T60Tank.uc
@@ -76,6 +76,10 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=40.0,PointHeight=0.0,PointScale=1.0,PointBone=body,PointOffset=(X=-90.0,Y=0.0,Z=0.0),bPenetrationPoint=false,DamageMultiplier=1.0,HitPointType=HP_Engine)
     VehHitpoints(1)=(PointRadius=25.0,PointHeight=0.0,PointScale=1.0,PointBone=body,PointOffset=(X=13.0,Y=-25.0,Z=-5.0),bPenetrationPoint=false,DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=25.0,PointHeight=0.0,PointScale=1.0,PointBone=body,PointOffset=(X=13.0,Y=25.0,Z=-5.0),bPenetrationPoint=false,DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=1.5,PointBone="turret",PointOffset=(X=42.00,Y=-2.00,Z=-1.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-15.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret",PointOffset=(X=35.00,Y=10.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=15.0
     TreadDamageThreshold=0.15
     DamagedEffectOffset=(X=-100,Y=20,Z=26)

--- a/DH_Vehicles/Classes/DH_Tiger2BTank.uc
+++ b/DH_Vehicles/Classes/DH_Tiger2BTank.uc
@@ -66,10 +66,14 @@ defaultproperties
     EngineToHullFireChance=0.1  //increased from 0.05 for all petrol engines
     DisintegrationHealth=-800.0 //petrol
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=-115.0,Z=-22.0)) // engine
-    VehHitpoints(1)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(X=-55.0,Y=-65.0,Z=4.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)
-    VehHitpoints(2)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(X=-55.0,Y=65.0,Z=4.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)
-    VehHitpoints(3)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(Y=-65.0,Z=4.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)
-    VehHitpoints(4)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(Y=65.0,Z=4.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)
+    VehHitpoints(1)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=-55.0,Y=-65.0,Z=4.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)//were smaller than the tiger 1 for some reason, were 15 now 25
+    VehHitpoints(2)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=-55.0,Y=65.0,Z=4.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)//were smaller than the tiger 1 for some reason, were 15 now 25
+    VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(Y=-65.0,Z=4.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)//were smaller than the tiger 1 for some reason, were 15 now 25
+    VehHitpoints(4)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(Y=65.0,Z=4.0),DamageMultiplier=3.0,HitPointType=HP_AmmoStore)//were smaller than the tiger 1 for some reason, were 15 now 25
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=109.00,Y=-29.00,Z=26.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=30.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=0.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=25.0,PointBone="turret",PointOffset=(X=90.00,Y=0.00,Z=26.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=-38.3
     TreadDamageThreshold=1.0
     DamagedEffectScale=1.25

--- a/DH_Vehicles/Classes/DH_TigerTank.uc
+++ b/DH_Vehicles/Classes/DH_TigerTank.uc
@@ -75,6 +75,10 @@ defaultproperties
     VehHitpoints(2)=(PointRadius=25.0,PointHeight=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=-5.0,Y=-50.0,Z=35.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=25.0,PointHeight=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=50.0,Y=50.0,Z=35.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(4)=(PointRadius=25.0,PointHeight=10.0,PointScale=1.0,PointBone="body",PointOffset=(X=-5.0,Y=50.0,Z=35.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=94.00,Y=-29.00,Z=2.50),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=25.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-25.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=20.0,PointBone="turret",PointOffset=(X=75.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=-2.0
     TreadDamageThreshold=1.0
     DamagedEffectOffset=(X=-100.0,Y=20.0,Z=26.0)

--- a/DH_Vehicles/Classes/DH_WirbelwindTank.uc
+++ b/DH_Vehicles/Classes/DH_WirbelwindTank.uc
@@ -14,7 +14,10 @@ defaultproperties
     SpawnOverlay(0)=Texture'DH_InterfaceArt_tex.Vehicles.wirbelwind'
 
     DestroyedVehicleMesh=StaticMesh'DH_German_vehicles_stc4.wirbelwind.Wirbelwind_destro'
-
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=60.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=35.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-15.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=35.0,PointBone="turret",PointOffset=(X=70.00,Y=0.00,Z=20.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
 	// Damage
 	// compared to pz4: 20mm ammo was unlikely to explode
 	AmmoIgnitionProbability=0.2  // 0.75 default

--- a/DH_Vehicles/Classes/DH_WolverineTank.uc
+++ b/DH_Vehicles/Classes/DH_WolverineTank.uc
@@ -72,6 +72,10 @@ defaultproperties
     VehHitpoints(1)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(X=20.0,Y=55.0,Z=-8.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(2)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(X=20.0,Y=-55.0,Z=-8.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
     VehHitpoints(3)=(PointRadius=15.0,PointScale=1.0,PointBone="body",PointOffset=(Z=-8.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
+    NewVehHitpoints(0)=(PointRadius=2.0,PointBone="turret",PointOffset=(X=80.00,Y=-27.00,Z=9.00),NewHitPointType=NHP_GunOptics)
+    NewVehHitpoints(1)=(PointRadius=15.0,PointBone="turret",PointOffset=(X=0.00,Y=0.00,Z=-30.00),NewHitPointType=NHP_Traverse)
+    NewVehHitpoints(2)=(PointRadius=10.0,PointBone="turret",PointOffset=(X=70.00,Y=0.00,Z=0.00),NewHitPointType=NHP_GunPitch)
+    GunOpticsHitPointIndex=0
     TreadHitMaxHeight=62.0
     DamagedEffectOffset=(X=-100.0,Y=0.0,Z=95.0)
     DestroyedVehicleMesh=StaticMesh'DH_allies_vehicles_stc.M10.M10_Dest'


### PR DESCRIPTION
All vehicle now have individual hit points for traverse, gun elevation and optics, as well as this, minor changes to the existing hit points like the Tiger 2s ammo boxes being too small, and jagdtiger being too small.

[x]Hit-points reverted
[x]NHP_GunPitch now shows up as blue instead of gold (easier to differentiate)
[x]Minor tweaks to some of the hit-points
[x]All tanks have NHP_GunOptics allowing their optics to be damaged by penetrating shots to the direct point
[x]All tanks have NHP_Traverse and NHP_GunPitch allowing penetrating hits to damage their traverse and elevation
