### PR TITLE
Reworked AT gun ammo capacities and resupply intervals

### DIFF
--- a/DH_Guns/Classes/DH_17PounderGunCannon.uc
+++ b/DH_Guns/Classes/DH_17PounderGunCannon.uc
@@ -32,10 +32,10 @@ defaultproperties
     nProjectileDescriptions(0)="Mk.IV APC"
     nProjectileDescriptions(1)="Mk.I HE-T"
 
-    InitialPrimaryAmmo=20
-    InitialSecondaryAmmo=8
-    MaxPrimaryAmmo=60
-    MaxSecondaryAmmo=30
+    InitialPrimaryAmmo=15
+    InitialSecondaryAmmo=5
+    MaxPrimaryAmmo=20
+    MaxSecondaryAmmo=10
     SecondarySpread=0.00156
 
     // Weapon fire
@@ -71,4 +71,6 @@ defaultproperties
     RangeSettings(18)=1800
     RangeSettings(19)=1900
     RangeSettings(20)=2000
+
+    ResupplyInterval=7.5
 }

--- a/DH_Guns/Classes/DH_45mmM1937GunCannon.uc
+++ b/DH_Guns/Classes/DH_45mmM1937GunCannon.uc
@@ -33,10 +33,10 @@ defaultproperties
     nProjectileDescriptions(1)="O-240"
 
     InitialPrimaryAmmo=20
-    InitialSecondaryAmmo=20
+    InitialSecondaryAmmo=15
 
-    MaxPrimaryAmmo=60
-    MaxSecondaryAmmo=30
+    MaxPrimaryAmmo=40
+    MaxSecondaryAmmo=20
     //MaxTertiaryAmmo=6
     SecondarySpread=0.002
 

--- a/DH_Guns/Classes/DH_6PounderGunCannon.uc
+++ b/DH_Guns/Classes/DH_6PounderGunCannon.uc
@@ -21,12 +21,12 @@ defaultproperties
     nProjectileDescriptions(1)="Mk.I APDS"
     nProjectileDescriptions(2)="Mk.X HE-T"
 
-    InitialPrimaryAmmo=22
+    InitialPrimaryAmmo=20
     InitialSecondaryAmmo=3
     InitialTertiaryAmmo=8
-    MaxPrimaryAmmo=66
-    MaxSecondaryAmmo=10
-    MaxTertiaryAmmo=20
+    MaxPrimaryAmmo=30
+    MaxSecondaryAmmo=5
+    MaxTertiaryAmmo=15
     SecondarySpread=0.002 //become APDS instead of HE, was originally 0.006 but was found to be too much, APDS should have a half chance of hitting a frontal panther turret at 400 yards, it now does.
     TertiarySpread=0.00125
     WeaponFireOffset=19.0 // different from US 57mm AT gun due to 6 pdr's muzzle brake

--- a/DH_Guns/Classes/DH_AT57Cannon.uc
+++ b/DH_Guns/Classes/DH_AT57Cannon.uc
@@ -35,8 +35,8 @@ defaultproperties
 
     InitialPrimaryAmmo=20
     InitialSecondaryAmmo=8
-    MaxPrimaryAmmo=60
-    MaxSecondaryAmmo=25
+    MaxPrimaryAmmo=30
+    MaxSecondaryAmmo=15
     SecondarySpread=0.00125
 
     // Weapon fire
@@ -51,4 +51,6 @@ defaultproperties
     ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_2')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_3')
     ReloadStages(3)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_4')
+
+    ResupplyInterval=3.0
 }

--- a/DH_Guns/Classes/DH_Flak88Cannon.uc
+++ b/DH_Guns/Classes/DH_Flak88Cannon.uc
@@ -27,10 +27,10 @@ defaultproperties
     nProjectileDescriptions(0)="PzGr.39"
     nProjectileDescriptions(1)="Schw.Sprgr.Patr."
 
-    InitialPrimaryAmmo=20
-    InitialSecondaryAmmo=10
-    MaxPrimaryAmmo=50
-    MaxSecondaryAmmo=42
+    InitialPrimaryAmmo=10
+    InitialSecondaryAmmo=5
+    MaxPrimaryAmmo=15
+    MaxSecondaryAmmo=10
     SecondarySpread=0.00125
 
     // Weapon fire
@@ -72,4 +72,6 @@ defaultproperties
     RangeSettings(23)=2600
     RangeSettings(24)=2800
     RangeSettings(25)=3000
+
+    ResupplyInterval=12.0
 }

--- a/DH_Guns/Classes/DH_M5GunCannon.uc
+++ b/DH_Guns/Classes/DH_M5GunCannon.uc
@@ -29,10 +29,10 @@ defaultproperties
     nProjectileDescriptions(0)="M62 APC"
     nProjectileDescriptions(1)="M42A1 HE-T"
 
-    InitialPrimaryAmmo=20
-    InitialSecondaryAmmo=10
-    MaxPrimaryAmmo=60
-    MaxSecondaryAmmo=30
+    InitialPrimaryAmmo=15
+    InitialSecondaryAmmo=5
+    MaxPrimaryAmmo=20
+    MaxSecondaryAmmo=10
     SecondarySpread=0.00135
 
     // Weapon fire
@@ -47,4 +47,6 @@ defaultproperties
     ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_02')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_3')
     ReloadStages(3)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_4')
+
+    ResupplyInterval=5.0
 }

--- a/DH_Guns/Classes/DH_Pak38Cannon.uc
+++ b/DH_Guns/Classes/DH_Pak38Cannon.uc
@@ -36,13 +36,13 @@ defaultproperties
     nProjectileDescriptions(1)="PzGr.40"
     nProjectileDescriptions(2)="Sprgr.Patr.38"
 
-    InitialPrimaryAmmo=40
-    InitialSecondaryAmmo=6
-    InitialTertiaryAmmo=15
+    InitialPrimaryAmmo=20
+    InitialSecondaryAmmo=4
+    InitialTertiaryAmmo=10
 
-    MaxPrimaryAmmo=55
-    MaxSecondaryAmmo=10
-    MaxTertiaryAmmo=30
+    MaxPrimaryAmmo=40
+    MaxSecondaryAmmo=8
+    MaxTertiaryAmmo=20
 
     SecondarySpread=0.00165
     TertiarySpread=0.0013
@@ -58,7 +58,7 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'Vehicle_Weapons.Panzeriii.50mm_fire01'
     CannonFireSound(1)=SoundGroup'Vehicle_Weapons.Panzeriii.50mm_fire02'
     CannonFireSound(2)=SoundGroup'Vehicle_Weapons.Panzeriii.50mm_fire03'
-    ReloadStages(0)=(Sound=none) //~2.8 seconds reload for a lower caliber AT gun
+    ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_1') //~3 seconds reload for a lower caliber AT gun
     ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_2')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_3')
     ReloadStages(3)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_4')

--- a/DH_Guns/Classes/DH_Pak40Cannon.uc
+++ b/DH_Guns/Classes/DH_Pak40Cannon.uc
@@ -37,10 +37,10 @@ defaultproperties
 
     InitialTertiaryAmmo=2
     MaxTertiaryAmmo=2
-    InitialPrimaryAmmo=20
-    InitialSecondaryAmmo=10
-    MaxPrimaryAmmo=50
-    MaxSecondaryAmmo=42
+    InitialPrimaryAmmo=15
+    InitialSecondaryAmmo=5
+    MaxPrimaryAmmo=20
+    MaxSecondaryAmmo=10
     SecondarySpread=0.00127
 
     // Weapon fire
@@ -50,8 +50,8 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'Vehicle_Weapons.PanzerIV_F2.75mm_L_fire01'
     CannonFireSound(1)=SoundGroup'Vehicle_Weapons.PanzerIV_F2.75mm_L_fire02'
     CannonFireSound(2)=SoundGroup'Vehicle_Weapons.PanzerIV_F2.75mm_L_fire03'
-    ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_1') //3.5 seconds reload
-    ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_2')
+    ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_01') // 3.75 seconds reload
+    ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_02')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_3')
     ReloadStages(3)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_4')
 
@@ -76,4 +76,6 @@ defaultproperties
     RangeSettings(18)=1800
     RangeSettings(19)=1900
     RangeSettings(20)=2000
+
+    ResupplyInterval=7.5
 }

--- a/DH_Guns/Classes/DH_Pak43Cannon.uc
+++ b/DH_Guns/Classes/DH_Pak43Cannon.uc
@@ -30,10 +30,10 @@ defaultproperties
     nProjectileDescriptions(0)="PzGr.39/43"
     nProjectileDescriptions(1)="Sprgr.Patr."
 
-    InitialPrimaryAmmo=8
-    InitialSecondaryAmmo=4
-    MaxPrimaryAmmo=50
-    MaxSecondaryAmmo=42
+    InitialPrimaryAmmo=10
+    InitialSecondaryAmmo=5
+    MaxPrimaryAmmo=15
+    MaxSecondaryAmmo=10
     SecondarySpread=0.00135
 
     // Weapon fire
@@ -74,4 +74,6 @@ defaultproperties
     RangeSettings(23)=2600
     RangeSettings(24)=2800
     RangeSettings(25)=3000
+
+    ResupplyInterval=12.0
 }

--- a/DH_Guns/Classes/DH_ZiS2Cannon.uc
+++ b/DH_Guns/Classes/DH_ZiS2Cannon.uc
@@ -36,10 +36,10 @@ defaultproperties
     nProjectileDescriptions(2)="BR-271P"
 
     InitialPrimaryAmmo=15
-    InitialSecondaryAmmo=15
+    InitialSecondaryAmmo=5
     InitialTertiaryAmmo=4
-    MaxPrimaryAmmo=45
-    MaxSecondaryAmmo=45
+    MaxPrimaryAmmo=25
+    MaxSecondaryAmmo=15
     MaxTertiaryAmmo=6
     SecondarySpread=0.002
 
@@ -73,4 +73,6 @@ defaultproperties
     RangeSettings(18)=3600
     RangeSettings(19)=3800
     RangeSettings(20)=4000
+
+    ResupplyInterval=5.0
 }

--- a/DH_Guns/Classes/DH_ZiS3Cannon.uc
+++ b/DH_Guns/Classes/DH_ZiS3Cannon.uc
@@ -36,10 +36,10 @@ defaultproperties
     //nProjectileDescriptions(2)="BR-350P"
 
     InitialPrimaryAmmo=10
-    InitialSecondaryAmmo=20
+    InitialSecondaryAmmo=15
     //InitialTertiaryAmmo=0
-    MaxPrimaryAmmo=30
-    MaxSecondaryAmmo=60
+    MaxPrimaryAmmo=20
+    MaxSecondaryAmmo=25
     //MaxTertiaryAmmo=0  //no APCR for zis3 because the gun is available since 1942, but APCR was only adopted in 1943.
     //Ideally it should be available on `43-`45 maps but i dont know a proper way to do this, so zis2 kinda "replaces" 76mm APCR shells in terms of gameplay for now
     SecondarySpread=0.002
@@ -48,8 +48,8 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'Vehicle_Weapons.SU_76.76mm_fire01'
     CannonFireSound(1)=SoundGroup'Vehicle_Weapons.SU_76.76mm_fire02'
     CannonFireSound(2)=SoundGroup'Vehicle_Weapons.SU_76.76mm_fire03'
-    ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_1') //3.5 seconds reload
-    ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_2')
+    ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_01') // 3.75 seconds reload
+    ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_02')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_3')
     ReloadStages(3)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_4')
 
@@ -74,4 +74,6 @@ defaultproperties
     RangeSettings(18)=3600
     RangeSettings(19)=3800
     RangeSettings(20)=4000
+
+    ResupplyInterval=7.5
 }


### PR DESCRIPTION
- Decreased initial ammo by roughly 20-25% for all guns to better match quantities realistically carried by gun crews.
- Decreased maximum capacities by 50-60% (there is really no reason at all for a Pak 40 to be able to stock up nearly 100 shells, especially when this is stacked on top of ammo crates, giving effectively infinite ammo).
- Set custom resupply intervals for most AT guns. On average, interval is now 1.75x the reload speed of the gun. This is intended to reduce the usefulness spam firing, as you will now end up firing faster than shells can be replenished.
- Decreased the rate of fire on a few guns, namely Pak 38, Pak 40 and Zis 3. Reload times were increased by .25 seconds. Still faster than any tank cannon, but overtime slightly reduces the "machine gun" effect these guns currently have.