### PR TITLE
Level Updates and Fixes

### DIFF
--- a/DH_Engine/Classes/DHMapDatabase.uc
+++ b/DH_Engine/Classes/DHMapDatabase.uc
@@ -402,4 +402,5 @@ defaultproperties
 	MapInfos(173)=(Name="DH-Lazur_Chemical_Plant_Defence",AlliedNation=NATION_USSR,GameType=GAMETYPE_Defence,Size=SIZE_Small)
 	MapInfos(174)=(Name="DH-Donner_Bolts",AlliedNation=NATION_Britain,GameType=GAMETYPE_Stalemate,Size=SIZE_ExtraSmall)
 	MapInfos(175)=(Name="DH-Lutremange_Domination",AlliedNation=NATION_USA,GameType=GAMETYPE_Domination,Size=SIZE_Large)
+	MapInfos(176)=(Name="DH-Dzerzhinsky_Tractor_Factory_Advance",AlliedNation=NATION_USSR,GameType=GAMETYPE_Advance,Size=SIZE_Medium)
 }

--- a/DarkestHourDev/Maps/DH-Dzerzhinsky_Tractor_Factory_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Dzerzhinsky_Tractor_Factory_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8fbf07fa891aaf688d5f66abe04ae6607be939d713c05253b89ac51653f2aaa0
-size 48535595
+oid sha256:77abcbd7aa50228e368be9c9a8227338673d1948f3064cba3a88d0dac638fc71
+size 48589609

--- a/DarkestHourDev/Maps/DH-Rabenheck_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Rabenheck_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29dd32c793e731170d216d4613b40f1d64efe2b0a345f9b8d62d5aaeefd663ec
-size 63000842
+oid sha256:669beed0512b5d063517dbb7f7b1b2b4c9f4ea6bbd3a4ef7974f10b90631221d
+size 63083578

--- a/DarkestHourDev/Maps/DH-Varaville_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Varaville_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9044dcfd78fea19d28d77e4cf29c3ace9cd307bd58081952241a0c734dadb215
-size 79301620
+oid sha256:95bd9a8a03fec1c8fa15e58803326006e9019998e883ee491d2db3a31753566a
+size 79300223

--- a/DarkestHourDev/Maps/DH-Varaville_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Varaville_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e818356afcd65eab2b0ac9cb1e4a659850e8198f9f7605fb6100c6d40843e64
-size 79299345
+oid sha256:9044dcfd78fea19d28d77e4cf29c3ace9cd307bd58081952241a0c734dadb215
+size 79301620

--- a/DarkestHourDev/StaticMeshes/DH_Vegetation4_stc.usx
+++ b/DarkestHourDev/StaticMeshes/DH_Vegetation4_stc.usx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e984aed4d89a4ce12d074c019deef6f04f427f4b14fcc930f58d4902ca9a3b8
-size 2712498
+oid sha256:c48c7f68dcc44018ada1ffe0ffd2a7ec4f9a57852476883eefaf248a4546c4e0
+size 2711120


### PR DESCRIPTION
Dzerzhinsky:

- Opened an additional side route for Axis to advance on the first street.
- Added a breach in the wall near south commons.
- Increased Axis respawn timer to 10 seconds (was 5).
- Moved some of the Soviet objective spawn hints to have more cover.
- Replaced anachronistic AK47 posters on the map.
- Added some additional details and cover in a few areas.
- Fixed collision issues with tree branches.
- Increased cooldown timer on Allied artillery.
- Implemented gun limits.
- Removed floating cups outside of apartment building objective.

Rabenheck:

- Added some additional trenches and pillboxes around the map.
- Set all main spawns to have the main spawn flag = true and configured DZs.
- Adjusted Allied DZ influence on all objectives.
- Added minimum player capture requirements and changed unlock timers on all objectives to 90 seconds.
- Fixed some bugs with fluid surfaces.
- Fixed some terrain bugs.

Varaville:

- Added objectives spawns to the Allied team.
- Reduced starting Allied tickets by 1 and increased Axis by 2.
- Removed G41 from German Corporal roles (Germans had a significant firepower advantage compared to the attacking Allies).
- Increased capture requirement on the Bridge to 5 players.
- Increased lockdown on all objectives when captured by Allies to 5.5 minutes.

Map Database: 

- Added Dzerzhinsky to the map database as a "Medium" map. 

Vegetation 4 Package:

- Disabled collision on Tree4 branches material. (part of fix for Dzerzhinsky). 