### PR TITLE
Level Updates

### DIFF
--- a/DarkestHourDev/Maps/DH-Dzerzhinsky_Tractor_Factory_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Dzerzhinsky_Tractor_Factory_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05b444bf9d80995e91a70fed568befb6c588cf736eba66c5aaab72e06c1e9b0c
-size 48589366
+oid sha256:e8b1ce4cc54fe41dd813ee0b6c299fb6bc1d95e1684a156d4255c0edb978339a
+size 48589875

--- a/DarkestHourDev/Maps/DH-Dzerzhinsky_Tractor_Factory_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Dzerzhinsky_Tractor_Factory_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77abcbd7aa50228e368be9c9a8227338673d1948f3064cba3a88d0dac638fc71
-size 48589609
+oid sha256:05b444bf9d80995e91a70fed568befb6c588cf736eba66c5aaab72e06c1e9b0c
+size 48589366

--- a/DarkestHourDev/Maps/DH-German_Village_Advance.rom
+++ b/DarkestHourDev/Maps/DH-German_Village_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ae991f3ec67dd2f256d56da6e30b328e0b31449d5e2c74ae64f7bed96fd167a
-size 31607911
+oid sha256:9d0c654b5aff81e9286f0acd80148d927cb4032e6bee9adabe0aa0209c5f0513
+size 31609090

--- a/DarkestHourDev/Maps/DH-Rabenheck_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Rabenheck_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:669beed0512b5d063517dbb7f7b1b2b4c9f4ea6bbd3a4ef7974f10b90631221d
-size 63083578
+oid sha256:3c7102955521faa1ec861ff2ab127b156a0e618fa85598d1333f73acc48dfb05
+size 63532531


### PR DESCRIPTION
Rabenheck Advance:

- Updated lighting and fog settings to hopefully improve visual fidelity and reduce eye strain.
- Fixed several bugged main spawn minefields for the Allies.
- Moved Axis Bridge anti-precap minefield to be less oppressive.
- Added some randomized AT guns.
- Added additional cover to the left side of the AT position objective.

Dzerzhinsky:

- Gave both teams +2 tickets.
- Fixed several potential spawn killing exploits.

German Village:

- Added a minefield to protect the Church objective before it becomes active.