### PR TITLE
MG42 hipfire recoil increase

### DIFF
--- a/DH_Weapons/Classes/DH_MG42Fire.uc
+++ b/DH_Weapons/Classes/DH_MG42Fire.uc
@@ -14,7 +14,7 @@ defaultproperties
     TracerFrequency=7
     Spread=90.0
     RecoilRate=0.03125
-    PctHipMGPenalty=1.0
+    PctHipMGPenalty=1.5
 
     // Recoil
     MaxVerticalRecoilAngle=475

--- a/DH_Weapons/Classes/DH_MG42Fire.uc
+++ b/DH_Weapons/Classes/DH_MG42Fire.uc
@@ -14,7 +14,7 @@ defaultproperties
     TracerFrequency=7
     Spread=90.0
     RecoilRate=0.03125
-    PctHipMGPenalty=1.5
+    PctHipMGPenalty=1.25
 
     // Recoil
     MaxVerticalRecoilAngle=475


### PR DESCRIPTION
-Hipfire penalty raised from 1 to 1.5

MG42 recoil was too controllable, raised from 1 to 1.5 to ensure people cannot "snipe" with a heavy machine-gun