### PR TITLE
Barashka german combat engineer satchel fix

### DIFF
--- a/DarkestHourDev/Maps/DH-Barashka_Clash.rom
+++ b/DarkestHourDev/Maps/DH-Barashka_Clash.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:115e7d25b9c6afd98e5fd9e19215711f9ea3ee6a3e17bb54cbc7cd819dbfdec9
-size 25302224
+oid sha256:f187ba9b4c767726f871fa5ab4e36eda2b1f6467b6c1e4375188bb5bb6dc6d8e
+size 25301801


### PR DESCRIPTION
-german combat engineer was using the deprecated "small satchel" class

fixed to allow the german engineer a satchel