### PR TITLE
Changes to constructions: danger zone placement and visibility

### DIFF
--- a/DH_Engine/Classes/DHConstruction.uc
+++ b/DH_Engine/Classes/DHConstruction.uc
@@ -467,7 +467,7 @@ function TearDown(int InstigatorTeamIndex)
     {
         RefundSupplies(InstigatorTeamIndex);
     }
-    
+
     // Update the construction counts remaining in the GRI
     GRI = DHGameReplicationInfo(Level.Game.GameReplicationInfo);
     LI = class'DH_LevelInfo'.static.GetInstance(Level);
@@ -1317,7 +1317,6 @@ defaultproperties
     bShouldAlignToGround=true
     ArcLengthTraceIntervalInMeters=1.0
     bShouldSwitchToLastWeaponOnPlacement=true
-    bCanBePlacedInDangerZone=true
 
     // Stagnation
     bCanDieOfStagnation=true

--- a/DH_Engine/Classes/DHMapIconAttachment_Resupply.uc
+++ b/DH_Engine/Classes/DHMapIconAttachment_Resupply.uc
@@ -35,7 +35,7 @@ function EVisibleFor GetVisibility()
 
 function EVisibleFor GetVisibilityInDangerZone()
 {
-    return VISIBLE_None;
+    return VISIBLE_All;
 }
 
 simulated function Material GetIconMaterial(DHPlayer PC)
@@ -70,5 +70,5 @@ defaultproperties
     IconScale=0.05
 
     IconMaterialVehicle=Texture'DH_InterfaceArt2_tex.Icons.munitions_vehicle'
-    IconScaleVehicle=0.038
+    IconScaleVehicle=0.05
 }

--- a/DarkestHourDev/Textures/DH_InterfaceArt2_tex.utx
+++ b/DarkestHourDev/Textures/DH_InterfaceArt2_tex.utx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ceac43fd0f39710cf7d1bc50698bd47262aad4eca901721759291392940ce0fb
+oid sha256:7b3fefbab52c596181f277bd628e69ad6003a3ff7870a604ff916750baf22552
 size 1132819


### PR DESCRIPTION
- Disabled placement of all constructions within the danger zone to curb spawn camping, blocking entrances, and other unfair play involving logistics deep behind the lines.
- Ammo crates are made visible to the enemy team when inside the danger zone.
- Replaced vehicle ammo icon (smaller to avoid visual clutter and more consistent with the infantry ammo icon).