### PR TITLE
Extended Resupply Radius of Logistics Trucks

### DIFF
--- a/DH_Engine/Classes/DHResupplyAttachment_Vehicle.uc
+++ b/DH_Engine/Classes/DHResupplyAttachment_Vehicle.uc
@@ -1,0 +1,11 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2022
+//==============================================================================
+
+class DHResupplyAttachment_Vehicle extends DHResupplyAttachment;
+
+defaultproperties
+{
+    CollisionRadius=350
+}

--- a/DH_Engine/Classes/DHVehicle.uc
+++ b/DH_Engine/Classes/DHVehicle.uc
@@ -4187,7 +4187,7 @@ defaultproperties
     CollisionHeight=40.0
     VehicleNameString="ADD VehicleNameString !!"
     TouchMessageClass=class'DHVehicleTouchMessage'
-    ResupplyAttachmentClass=class'DHResupplyAttachment'
+    ResupplyAttachmentClass=class'DHResupplyAttachment_Vehicle'
     FirstRiderPositionIndex=255 // unless overridden in subclass, 255 means the value is set automatically when PassengerPawns array is added to the PassengerWeapons
     VehiclePoolIndex=-1
     MinRunOverSpeed=586.75 // increased from 0 to 35km/h so players don't get run over so easily by vehicles


### PR DESCRIPTION
- Created new DHResupplyAttachment_Vehicle class with extended radius of 350 (default is 300).
- Updated DHVehicle to use this attachment class instead. (purpose is to extend the resupply radius of logi trucks).