### PR TITLE
Misc. Fixes and Balance Changes to Various Maps

### DIFF
--- a/DH_Engine/Classes/DHMapDatabase.uc
+++ b/DH_Engine/Classes/DHMapDatabase.uc
@@ -405,4 +405,6 @@ defaultproperties
 	MapInfos(176)=(Name="DH-Dzerzhinsky_Tractor_Factory_Advance",AlliedNation=NATION_USSR,GameType=GAMETYPE_Advance,Size=SIZE_Medium)
 	MapInfos(177)=(Name="DH-Stavelot_Defence",AlliedNation=NATION_USA,GameType=GAMETYPE_Defence,Size=SIZE_Medium)
 	MapInfos(178)=(Name="DH-Targnon_Advance",AlliedNation=NATION_USA,GameType=GAMETYPE_Advance,Size=SIZE_Medium)
+    MapInfos(179)=(Name="DH-Kharkov_Advance",AlliedNation=NATION_USSR,GameType=GAMETYPE_Advance,Size=SIZE_Large)
+
 }

--- a/DarkestHourDev/Maps/DH-Champs_d'Agonie_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Champs_d'Agonie_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78f2740e1ac44e88435cff17d4cc74853319c8c3411f3ab9be437ad105a028fc
-size 63380951
+oid sha256:c8b4c379e69cf193f7c00b99e8635341cff2b71bad6f04249f01b5f2de572610
+size 63388188

--- a/DarkestHourDev/Maps/DH-Kharkov_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Kharkov_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9bdc6a65c022d1bec2b7aabd29310afdb5068c56f0f870c8aa47165bd3524f14
-size 67972491
+oid sha256:77da49ab8d6494102e1688bc13f348ab5d841f20831c355e7a26f19416da324b
+size 68269715

--- a/DarkestHourDev/Maps/DH-Klin1941_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Klin1941_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5ac04f9c06b3d105ae51b885e92ca2d46f5c2da52b9936328dcd1aa4423c7f3
-size 32697608
+oid sha256:aa0c4f883fa44252e17eec8c138e8e556bff376a462e8de65e4a285053bf89d3
+size 32697555

--- a/DarkestHourDev/Maps/DH-La_Fiere_Day_Advance.rom
+++ b/DarkestHourDev/Maps/DH-La_Fiere_Day_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb68e8e2cfe163edfa72fd85456ebeb56624a33a7ab6cd8706b66e710e32c879
-size 70288967
+oid sha256:5b270a151c505ba814e3ca83f2d1abf15a60703d32f449483158ed5c5b32ac4f
+size 70292747

--- a/DarkestHourDev/Maps/DH-Lyes_Krovy_Defence.rom
+++ b/DarkestHourDev/Maps/DH-Lyes_Krovy_Defence.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9f21a1bc7d1ab9c6707097c0b016a9eba89fb9a26bce85d90c252739350c367e
-size 20809080
+oid sha256:6627cb5b74c13e25af317b26ec8915d53e0a2730c04541fc195b05a86dc7dc86
+size 20809005

--- a/DarkestHourDev/Maps/DH-Ten_Aard_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Ten_Aard_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13498017b1e8977ea2292aaa7ecb8b31435aca5b75235aa40bdd0b123e04cedd
-size 76758968
+oid sha256:d79c516007814daa80c3689a1f38b396b29a4de9968880cfe25e8bc0d3b589f8
+size 76758983


### PR DESCRIPTION
Champs d'Agonie Advance:

- Added spawn protection minefields for Allies.
- Increased respawn timer for Panther and Jagdpanzer IV from 220 and 180 seconds to 300 and 220 respectively.
- Decreased respawn timer for M4A3 105mm and Sd.Kfz. 231/1 from 200 to 150 and 170 to 140 seconds.
- Reduced Allied respawn timer from 20 seconds to 15.
- Gave Allies a +1% team ratio advantage (more meant to prevent situations where Axis end up having more players, ideally they should stay around even with Allies having a small advantage).

Kharkov Advance:

- Fixed some BSP lighting bugs around the map.
- Fixed a few misc. floating objects.
- Fixed terrain holes.
- Increased Soviet tanks from 5 to 6.
- Reduced Axis ticket modifier significantly from 45 to 30.

Klin 1941 Advance:

- Fixed a bug where the German Opel Blitz Transport truck was counted against the tank limit.

La Fiere Day Advance:

- Fixed strange DZ behavior on the map by increasing neutral zone influence back to 1 for all objectives.
- Modified La Fiere objective to have 0 Axis influence until Church is captured, then normalized to 1.
- Added map description to the LevelInfo.

Lyes Krovy Defence:

- Fixed a bug where Soviet engineers could become unable to use their weapons.

Ten Aard Advance:

- Set max Jagdpanther and Churchill spawns to 5 each.
- Increased Jagdpanther respawn timer from 240 to 300 seconds.

Added infantry Kharkov to the map database.