### PR TITLE
1919 slowfire fix

### DIFF
--- a/DH_Vehicles/Classes/DH_GreyhoundCannon.uc
+++ b/DH_Vehicles/Classes/DH_GreyhoundCannon.uc
@@ -72,8 +72,8 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'Inf_Weapons.PTRD.PTRD_fire01'
     CannonFireSound(1)=SoundGroup'Inf_Weapons.PTRD.PTRD_fire02'
     CannonFireSound(2)=SoundGroup'Inf_Weapons.PTRD.PTRD_fire03'
-    AltFireSoundClass=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
-    AltFireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
+    AltFireSoundClass=SoundGroup'DH_WeaponSounds.1919.1919_ShootLoop'
+    AltFireEndSound=SoundGroup'DH_WeaponSounds.1919.1919_ShootEnd'
     ReloadStages(0)=(Sound=Sound'DH_AlliedVehicleSounds.Sherman.ShermanReload01')
     ReloadStages(1)=(Sound=Sound'DH_AlliedVehicleSounds.Sherman.ShermanReload02')
     ReloadStages(2)=(Sound=Sound'DH_AlliedVehicleSounds.Sherman.ShermanReload03')

--- a/DH_Vehicles/Classes/DH_HigginsBoatMG.uc
+++ b/DH_Vehicles/Classes/DH_HigginsBoatMG.uc
@@ -36,8 +36,8 @@ defaultproperties
     // Weapon fire
     WeaponFireAttachmentBone="tip"
     AmbientEffectEmitterClass=class'DH_Vehicles.DH_Vehicle30CalMGEmitter'
-    FireSoundClass=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
-    FireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
+    FireSoundClass=SoundGroup'DH_WeaponSounds.1919.1919_ShootLoop'
+    FireEndSound=SoundGroup'DH_WeaponSounds.1919.1919_ShootEnd'
     ShakeRotMag=(X=25.0,Y=0.0,Z=10.0)
     ShakeRotRate=(X=5000.0,Y=5000.0,Z=5000.0)
     ShakeOffsetMag=(X=0.5,Y=0.0,Z=0.2)

--- a/DH_Vehicles/Classes/DH_LocustCannon.uc
+++ b/DH_Vehicles/Classes/DH_LocustCannon.uc
@@ -74,8 +74,8 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'Inf_Weapons.PTRD.PTRD_fire01'
     CannonFireSound(1)=SoundGroup'Inf_Weapons.PTRD.PTRD_fire02'
     CannonFireSound(2)=SoundGroup'Inf_Weapons.PTRD.PTRD_fire03'
-    AltFireSoundClass=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
-    AltFireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
+    AltFireSoundClass=SoundGroup'DH_WeaponSounds.1919.1919_ShootLoop'
+    AltFireEndSound=SoundGroup'DH_WeaponSounds.1919.1919_ShootEnd'
     ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_01')
     ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_02')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_03')

--- a/DH_Vehicles/Classes/DH_ShermanCannon.uc
+++ b/DH_Vehicles/Classes/DH_ShermanCannon.uc
@@ -90,8 +90,8 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'DH_AlliedVehicleSounds.75mm.DHM3-75mm'
     CannonFireSound(1)=SoundGroup'DH_AlliedVehicleSounds.75mm.DHM3-75mm'
     CannonFireSound(2)=SoundGroup'DH_AlliedVehicleSounds.75mm.DHM3-75mm'
-    AltFireSoundClass=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
-    AltFireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
+    AltFireSoundClass=SoundGroup'DH_WeaponSounds.1919.1919_ShootLoop'
+    AltFireEndSound=SoundGroup'DH_WeaponSounds.1919.1919_ShootEnd'
     ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_01')
     ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_02')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_03')

--- a/DH_Vehicles/Classes/DH_ShermanCannonA_76mm.uc
+++ b/DH_Vehicles/Classes/DH_ShermanCannonA_76mm.uc
@@ -92,8 +92,8 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'Vehicle_Weapons.T34_85.85mm_fire01'
     CannonFireSound(1)=SoundGroup'Vehicle_Weapons.T34_85.85mm_fire02'
     CannonFireSound(2)=SoundGroup'Vehicle_Weapons.T34_85.85mm_fire03'
-    AltFireSoundClass=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
-    AltFireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
+    AltFireSoundClass=SoundGroup'DH_WeaponSounds.1919.1919_ShootLoop'
+    AltFireEndSound=SoundGroup'DH_WeaponSounds.1919.1919_ShootEnd'
     ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_01')
     ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_02')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_02s_03')

--- a/DH_Vehicles/Classes/DH_ShermanCannon_M4A3105_Howitzer.uc
+++ b/DH_Vehicles/Classes/DH_ShermanCannon_M4A3105_Howitzer.uc
@@ -75,8 +75,8 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'Vehicle_Weapons.Tiger.88mm_fire01'
     CannonFireSound(1)=SoundGroup'Vehicle_Weapons.Tiger.88mm_fire02'
     CannonFireSound(2)=SoundGroup'Vehicle_Weapons.Tiger.88mm_fire03'
-    AltFireSoundClass=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
-    AltFireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
+    AltFireSoundClass=SoundGroup'DH_WeaponSounds.1919.1919_ShootLoop'
+    AltFireEndSound=SoundGroup'DH_WeaponSounds.1919.1919_ShootEnd'
     ReloadStages(0)=(Sound=Sound'Vehicle_reloads.Reloads.Pz_IV_F2_Reload_01')
     ReloadStages(1)=(Sound=Sound'Vehicle_reloads.Reloads.Pz_IV_F2_Reload_02')
     ReloadStages(2)=(Sound=Sound'Vehicle_reloads.Reloads.Pz_IV_F2_Reload_03')

--- a/DH_Vehicles/Classes/DH_ShermanCannon_M4A3E2_Jumbo.uc
+++ b/DH_Vehicles/Classes/DH_ShermanCannon_M4A3E2_Jumbo.uc
@@ -75,8 +75,8 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'DH_AlliedVehicleSounds.75mm.DHM3-75mm'
     CannonFireSound(1)=SoundGroup'DH_AlliedVehicleSounds.75mm.DHM3-75mm'
     CannonFireSound(2)=SoundGroup'DH_AlliedVehicleSounds.75mm.DHM3-75mm'
-    AltFireSoundClass=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
-    AltFireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
+    AltFireSoundClass=SoundGroup'DH_WeaponSounds.1919.1919_ShootLoop'
+    AltFireEndSound=SoundGroup'DH_WeaponSounds.1919.1919_ShootEnd'
     ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_01')
     ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_02')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_03')

--- a/DH_Vehicles/Classes/DH_ShermanFireFlyCannon.uc
+++ b/DH_Vehicles/Classes/DH_ShermanFireFlyCannon.uc
@@ -75,8 +75,8 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'DH_AlliedVehicleSounds.17pounder.DH17pounder'
     CannonFireSound(1)=SoundGroup'DH_AlliedVehicleSounds.17pounder.DH17pounder'
     CannonFireSound(2)=SoundGroup'DH_AlliedVehicleSounds.17pounder.DH17pounder'
-    AltFireSoundClass=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
-    AltFireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
+    AltFireSoundClass=SoundGroup'DH_WeaponSounds.1919.1919_ShootLoop'
+    AltFireEndSound=SoundGroup'DH_WeaponSounds.1919.1919_ShootEnd'
     ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_02s_01')
     ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_02s_02')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_02s_03')

--- a/DH_Vehicles/Classes/DH_ShermanMountedMG.uc
+++ b/DH_Vehicles/Classes/DH_ShermanMountedMG.uc
@@ -32,8 +32,8 @@ defaultproperties
 
     // Weapon fire
     WeaponFireOffset=5.0
-    FireSoundClass=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
-    FireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
+    FireSoundClass=SoundGroup'DH_WeaponSounds.1919.1919_ShootLoop'
+    FireEndSound=SoundGroup'DH_WeaponSounds.1919.1919_ShootEnd'
     ShakeRotMag=(X=20.0,Y=20.0,Z=20.0)
     ShakeOffsetMag=(X=0.01,Y=0.01,Z=0.01)
 

--- a/DH_Vehicles/Classes/DH_StuartCannon.uc
+++ b/DH_Vehicles/Classes/DH_StuartCannon.uc
@@ -71,8 +71,8 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'DH_CC_Vehicle_Weapons.37mm.37mmAT_fire_02'
     CannonFireSound(1)=SoundGroup'DH_CC_Vehicle_Weapons.37mm.37mmAT_fire_02'
     CannonFireSound(2)=SoundGroup'DH_CC_Vehicle_Weapons.37mm.37mmAT_fire_02'
-    AltFireSoundClass=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
-    AltFireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
+    AltFireSoundClass=SoundGroup'DH_WeaponSounds.1919.1919_ShootLoop'
+    AltFireEndSound=SoundGroup'DH_WeaponSounds.1919.1919_ShootEnd'
     ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_01')
     ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_02')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_03')

--- a/DH_Weapons/Classes/DH_30calFire.uc
+++ b/DH_Weapons/Classes/DH_30calFire.uc
@@ -3,10 +3,50 @@
 // Darklight Games (c) 2008-2023
 //==============================================================================
 
-class DH_30calFire extends DHMGAutomaticFire;
+class DH_30calFire extends DHAutomaticFire; //not using the MG or fast-auto here because we dont need "packing" for such a slow firing gun
+
+// Modified to make rounds disappear from the visible ammo belt when nearly out of ammo
+event ModeDoFire()
+{
+    super.ModeDoFire();
+
+    if (Level.NetMode != NM_DedicatedServer && DHMGWeapon(Weapon) != none)
+    {
+        DHMGWeapon(Weapon).UpdateAmmoBelt();
+    }
+}
+
+// Modified to apply PctHipMGPenalty if player is hip-firing the MG (bUsingSights signifies this)
+simulated function float CustomHandleRecoil()
+{
+    // Added to apply PctHipMGPenalty if player is hip-firing the MG (bUsingSights signifies this)
+    if (Weapon != none && Weapon.bUsingSights)
+    {
+        return PctHipMGPenalty;
+    }
+    
+    return 1.0;
+}
+
+// Modified to support ironsight mode (bUsingSights) being hipped-fire mode for MGs
+function CalcSpreadModifiers()
+{
+    super.CalcSpreadModifiers();
+
+    if (Instigator != none && !Instigator.bBipodDeployed)
+    {
+        Spread *= HipSpreadModifier;
+    }
+}
+
+// Modified because for MGs ironsight mode (bUsingSights) signifies the MG is being hip fired
+simulated function bool IsPlayerHipFiring()
+{
+    return Weapon != none && Weapon.bUsingSights;
+}
 
 defaultproperties
-{
+{  
     ProjectileClass=class'DH_Weapons.DH_30calBullet'
     TracerProjectileClass=class'DH_Weapons.DH_30CalTracerBullet'
     AmmoClass=class'DH_Weapons.DH_30CalAmmo'
@@ -27,8 +67,10 @@ defaultproperties
     RecoilFallOffExponent=4.0
     RecoilFallOffFactor=30.0
 
-    AmbientFireSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
-    FireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
+    FireSounds(0)=SoundGroup'DH_WeaponSounds.1919.1919_ShotA'
+    FireSounds(1)=SoundGroup'DH_WeaponSounds.1919.1919_ShotB'
+    FireSounds(2)=SoundGroup'DH_WeaponSounds.1919.1919_ShotC'
+
     ShellEjectClass=class'DH_Weapons.DH_30cal1stLinkEject'
     ShellIronSightOffset=(X=30,Z=-3)
     ShellRotOffsetIron=(Pitch=-1500)
@@ -45,4 +87,16 @@ defaultproperties
     ShakeRotTime=1.2
 
     PctHipMGPenalty=1.5
+    CrouchSpreadModifier=1.0
+    ProneSpreadModifier=1.0
+    BipodDeployedSpreadModifier=1.0
+    RestDeploySpreadModifier=1.0
+    AimError=1800.0
+    
+    PctStandIronRecoil=1.0
+    bUsesTracers=true
+    FlashEmitterClass=class'ROEffects.MuzzleFlash1stMG'
+    NoAmmoSound=Sound'Inf_Weapons_Foley.Misc.dryfire_rifle'
+    BlurTime=0.04
+    BlurTimeIronsight=0.04
 }

--- a/DarkestHourDev/Sounds/DH_WeaponSounds.uax
+++ b/DarkestHourDev/Sounds/DH_WeaponSounds.uax
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f002c789608d79a6f4a7b10fd415829bd0d077ce70cbd79df25df1761e048dac
-size 31168957
+oid sha256:a7a6a527a40304243825e5a6e857eea1788fa69817fed239bd0f44ae8bd16fd4
+size 31158923

--- a/DarkestHourDev/Sounds/DH_WeaponSounds.uax
+++ b/DarkestHourDev/Sounds/DH_WeaponSounds.uax
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6d35ce3e2a9793e35e3f1252fb85e0b7f998ccd694936e164bd7cc0dd4d491e
-size 31168550
+oid sha256:f002c789608d79a6f4a7b10fd415829bd0d077ce70cbd79df25df1761e048dac
+size 31168957


### PR DESCRIPTION
- changed 1919A6 fire class to non-fast auto because its a slow firing gun (~500 RPM), so all the shot "packing" functionality is completely redundant here and only introduces visual bugs 
- applied new firing sounds