### PR TITLE
Feature 76 hvap refactor

### DIFF
--- a/DH_Vehicles/Classes/DH_HellcatCannonShellHVAP.uc
+++ b/DH_Vehicles/Classes/DH_HellcatCannonShellHVAP.uc
@@ -19,6 +19,7 @@ defaultproperties
     EngineFireChance=0.61
 
     //Penetration
+<<<<<<< Updated upstream
     DHPenetrationTable(0)=24.6
     DHPenetrationTable(1)=24.0
     DHPenetrationTable(2)=23.3
@@ -30,5 +31,18 @@ defaultproperties
     DHPenetrationTable(8)=19.3
     DHPenetrationTable(9)=18.5
     DHPenetrationTable(10)=17.9 
+=======
+    DHPenetrationTable(0)=24.0
+    DHPenetrationTable(1)=22.9
+    DHPenetrationTable(2)=21.3
+    DHPenetrationTable(3)=19.6
+    DHPenetrationTable(4)=17.9
+    DHPenetrationTable(5)=16.3
+    DHPenetrationTable(6)=14.9
+    DHPenetrationTable(7)=13.8
+    DHPenetrationTable(8)=12.4
+    DHPenetrationTable(9)=10.1
+    DHPenetrationTable(10)=7.6
+>>>>>>> Stashed changes
 }
 

--- a/DH_Vehicles/Classes/DH_HellcatCannonShellHVAP.uc
+++ b/DH_Vehicles/Classes/DH_HellcatCannonShellHVAP.uc
@@ -19,19 +19,6 @@ defaultproperties
     EngineFireChance=0.61
 
     //Penetration
-<<<<<<< Updated upstream
-    DHPenetrationTable(0)=24.6
-    DHPenetrationTable(1)=24.0
-    DHPenetrationTable(2)=23.3
-    DHPenetrationTable(3)=22.6
-    DHPenetrationTable(4)=21.9
-    DHPenetrationTable(5)=21.3
-    DHPenetrationTable(6)=20.7
-    DHPenetrationTable(7)=20.0
-    DHPenetrationTable(8)=19.3
-    DHPenetrationTable(9)=18.5
-    DHPenetrationTable(10)=17.9 
-=======
     DHPenetrationTable(0)=24.0
     DHPenetrationTable(1)=22.9
     DHPenetrationTable(2)=21.3
@@ -43,6 +30,5 @@ defaultproperties
     DHPenetrationTable(8)=12.4
     DHPenetrationTable(9)=10.1
     DHPenetrationTable(10)=7.6
->>>>>>> Stashed changes
-}
+
 

--- a/DH_Vehicles/Classes/DH_HellcatCannonShellHVAP.uc
+++ b/DH_Vehicles/Classes/DH_HellcatCannonShellHVAP.uc
@@ -19,16 +19,16 @@ defaultproperties
     EngineFireChance=0.61
 
     //Penetration
-    DHPenetrationTable(0)=19.2
-    DHPenetrationTable(1)=17.7
-    DHPenetrationTable(2)=16.5
-    DHPenetrationTable(3)=14.6
-    DHPenetrationTable(4)=13.7
-    DHPenetrationTable(5)=12.5
-    DHPenetrationTable(6)=11.3
-    DHPenetrationTable(7)=10.6
-    DHPenetrationTable(8)=9.4
-    DHPenetrationTable(9)=8.0
-    DHPenetrationTable(10)=6.7
+    DHPenetrationTable(0)=24.6
+    DHPenetrationTable(1)=24.0
+    DHPenetrationTable(2)=23.3
+    DHPenetrationTable(3)=22.6
+    DHPenetrationTable(4)=21.9
+    DHPenetrationTable(5)=21.3
+    DHPenetrationTable(6)=20.7
+    DHPenetrationTable(7)=20.0
+    DHPenetrationTable(8)=19.3
+    DHPenetrationTable(9)=18.5
+    DHPenetrationTable(10)=17.9 
 }
 

--- a/DH_Vehicles/Classes/DH_ShermanM4A176WCannonShellHVAP.uc
+++ b/DH_Vehicles/Classes/DH_ShermanM4A176WCannonShellHVAP.uc
@@ -18,6 +18,7 @@ defaultproperties
     HullFireChance=0.31
     EngineFireChance=0.61
 
+<<<<<<< Updated upstream
     //Penetration
     DHPenetrationTable(0)=24.6
     DHPenetrationTable(1)=24.0
@@ -30,4 +31,18 @@ defaultproperties
     DHPenetrationTable(8)=19.3
     DHPenetrationTable(9)=18.5 
     DHPenetrationTable(10)=17.9 
+=======
+     //Penetration
+    DHPenetrationTable(0)=24.0
+    DHPenetrationTable(1)=22.9
+    DHPenetrationTable(2)=21.3
+    DHPenetrationTable(3)=19.6
+    DHPenetrationTable(4)=17.9
+    DHPenetrationTable(5)=16.3
+    DHPenetrationTable(6)=14.9
+    DHPenetrationTable(7)=13.8
+    DHPenetrationTable(8)=12.4
+    DHPenetrationTable(9)=10.1
+    DHPenetrationTable(10)=7.6
+>>>>>>> Stashed changes
 }

--- a/DH_Vehicles/Classes/DH_ShermanM4A176WCannonShellHVAP.uc
+++ b/DH_Vehicles/Classes/DH_ShermanM4A176WCannonShellHVAP.uc
@@ -19,15 +19,15 @@ defaultproperties
     EngineFireChance=0.61
 
     //Penetration
-    DHPenetrationTable(0)=19.2
-    DHPenetrationTable(1)=17.7
-    DHPenetrationTable(2)=16.5
-    DHPenetrationTable(3)=14.6
-    DHPenetrationTable(4)=13.7
-    DHPenetrationTable(5)=12.5
-    DHPenetrationTable(6)=11.3
-    DHPenetrationTable(7)=10.6
-    DHPenetrationTable(8)=9.4
-    DHPenetrationTable(9)=8.0
-    DHPenetrationTable(10)=6.7
+    DHPenetrationTable(0)=24.6
+    DHPenetrationTable(1)=24.0
+    DHPenetrationTable(2)=23.3
+    DHPenetrationTable(3)=22.6 
+    DHPenetrationTable(4)=21.9 
+    DHPenetrationTable(5)=21.3
+    DHPenetrationTable(6)=20.7
+    DHPenetrationTable(7)=20.0
+    DHPenetrationTable(8)=19.3
+    DHPenetrationTable(9)=18.5 
+    DHPenetrationTable(10)=17.9 
 }

--- a/DH_Vehicles/Classes/DH_ShermanM4A176WCannonShellHVAP.uc
+++ b/DH_Vehicles/Classes/DH_ShermanM4A176WCannonShellHVAP.uc
@@ -18,21 +18,8 @@ defaultproperties
     HullFireChance=0.31
     EngineFireChance=0.61
 
-<<<<<<< Updated upstream
-    //Penetration
-    DHPenetrationTable(0)=24.6
-    DHPenetrationTable(1)=24.0
-    DHPenetrationTable(2)=23.3
-    DHPenetrationTable(3)=22.6 
-    DHPenetrationTable(4)=21.9 
-    DHPenetrationTable(5)=21.3
-    DHPenetrationTable(6)=20.7
-    DHPenetrationTable(7)=20.0
-    DHPenetrationTable(8)=19.3
-    DHPenetrationTable(9)=18.5 
-    DHPenetrationTable(10)=17.9 
-=======
-     //Penetration
+
+  //Penetration
     DHPenetrationTable(0)=24.0
     DHPenetrationTable(1)=22.9
     DHPenetrationTable(2)=21.3
@@ -44,5 +31,4 @@ defaultproperties
     DHPenetrationTable(8)=12.4
     DHPenetrationTable(9)=10.1
     DHPenetrationTable(10)=7.6
->>>>>>> Stashed changes
 }

--- a/DH_Vehicles/Classes/DH_WolverineCannonShellHVAP.uc
+++ b/DH_Vehicles/Classes/DH_WolverineCannonShellHVAP.uc
@@ -19,15 +19,15 @@ defaultproperties
     EngineFireChance=0.61
 
     //Penetration
-    DHPenetrationTable(0)=19.2
-    DHPenetrationTable(1)=17.7
-    DHPenetrationTable(2)=16.5
-    DHPenetrationTable(3)=14.6
-    DHPenetrationTable(4)=13.7
-    DHPenetrationTable(5)=12.5
-    DHPenetrationTable(6)=11.3
-    DHPenetrationTable(7)=10.6
-    DHPenetrationTable(8)=9.4
-    DHPenetrationTable(9)=8.0
-    DHPenetrationTable(10)=6.7
+    DHPenetrationTable(0)=24.6
+    DHPenetrationTable(1)=24.0 
+    DHPenetrationTable(2)=23.3
+    DHPenetrationTable(3)=22.6 
+    DHPenetrationTable(4)=21.9
+    DHPenetrationTable(5)=21.3
+    DHPenetrationTable(6)=20.7 
+    DHPenetrationTable(7)=20.0
+    DHPenetrationTable(8)=19.3
+    DHPenetrationTable(9)=18.5
+    DHPenetrationTable(10)=17.9 
 }

--- a/DH_Vehicles/Classes/DH_WolverineCannonShellHVAP.uc
+++ b/DH_Vehicles/Classes/DH_WolverineCannonShellHVAP.uc
@@ -18,6 +18,7 @@ defaultproperties
     HullFireChance=0.31
     EngineFireChance=0.61
 
+<<<<<<< Updated upstream
     //Penetration
     DHPenetrationTable(0)=24.6
     DHPenetrationTable(1)=24.0 
@@ -30,4 +31,18 @@ defaultproperties
     DHPenetrationTable(8)=19.3
     DHPenetrationTable(9)=18.5
     DHPenetrationTable(10)=17.9 
+=======
+      //Penetration
+    DHPenetrationTable(0)=24.0
+    DHPenetrationTable(1)=22.9
+    DHPenetrationTable(2)=21.3
+    DHPenetrationTable(3)=19.6
+    DHPenetrationTable(4)=17.9
+    DHPenetrationTable(5)=16.3
+    DHPenetrationTable(6)=14.9
+    DHPenetrationTable(7)=13.8
+    DHPenetrationTable(8)=12.4
+    DHPenetrationTable(9)=10.1
+    DHPenetrationTable(10)=7.6
+>>>>>>> Stashed changes
 }

--- a/DH_Vehicles/Classes/DH_WolverineCannonShellHVAP.uc
+++ b/DH_Vehicles/Classes/DH_WolverineCannonShellHVAP.uc
@@ -18,21 +18,8 @@ defaultproperties
     HullFireChance=0.31
     EngineFireChance=0.61
 
-<<<<<<< Updated upstream
-    //Penetration
-    DHPenetrationTable(0)=24.6
-    DHPenetrationTable(1)=24.0 
-    DHPenetrationTable(2)=23.3
-    DHPenetrationTable(3)=22.6 
-    DHPenetrationTable(4)=21.9
-    DHPenetrationTable(5)=21.3
-    DHPenetrationTable(6)=20.7 
-    DHPenetrationTable(7)=20.0
-    DHPenetrationTable(8)=19.3
-    DHPenetrationTable(9)=18.5
-    DHPenetrationTable(10)=17.9 
-=======
-      //Penetration
+
+  //Penetration
     DHPenetrationTable(0)=24.0
     DHPenetrationTable(1)=22.9
     DHPenetrationTable(2)=21.3
@@ -44,5 +31,4 @@ defaultproperties
     DHPenetrationTable(8)=12.4
     DHPenetrationTable(9)=10.1
     DHPenetrationTable(10)=7.6
->>>>>>> Stashed changes
 }


### PR DESCRIPTION
I have changed the penetration of the M93 HVAP round for the 76mm Sherman, M18 Hellcat, and M10 Wolverine. 

The values were taken from a graph from, Terminal Ballistic Data Volume 3, on page 161, (https://i.imgur.com/lAEdkbp.jpg)

This study here: https://apps.dtic.mil/sti/pdfs/AD1045347.pdf 
also supports the upping of the penetration as a table on page 32 states the HVAP round was able to penetrate the front of the panthers turret, but unable to penetrate the front hull, which would be expected from an uncapped slug. 

This handbook: https://archive.org/details/HandbookOfBallisticAndEngineeringDataForAmmunitionVol2/page/n63/mode/2up?q=m93
also supports the penetration numbers, as a shell identical in size (presumably M93, but only described as 1.5 inch tungsten core) penetrates much higher than was previously modelled in DH. (Graph is on page 8) 