### PR TITLE
Numerous squad system improvements

### DIFF
--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -5348,6 +5348,12 @@ function ServerSquadVolunteerToAssist()
     PRI = DHPlayerReplicationInfo(PlayerReplicationInfo);
     SLPRI = SquadReplicationInfo.GetSquadLeader(TeamIndex, SquadIndex);
 
+    if (SquadReplicationInfo.HasAssistant(TeamIndex, SquadIndex))
+    {
+        // Squad assistant already exists.
+        return;
+    }
+
     if (PRI == none || SLPRI == none)
     {
         return;
@@ -5355,17 +5361,6 @@ function ServerSquadVolunteerToAssist()
 
     SLPC = DHPlayer(SLPRI.Owner);
     SLBot = DHBot(SLPRI.Owner);
-
-    if (SLPC == none && SLBot == none)
-    {
-        return;
-    }
-
-    if (SquadReplicationInfo.HasAssistant(TeamIndex, SquadIndex))
-    {
-        // Squad assistant already exists.
-        return;
-    }
 
     if (SLPC != none)
     {

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -5340,6 +5340,7 @@ function ServerSquadVolunteerToAssist()
     local int TeamIndex, SquadIndex;
     local DHPlayerReplicationInfo PRI, SLPRI;
     local DHPlayer SLPC;
+    local DHBot SLBot;
 
     TeamIndex = GetTeamNum();
     SquadIndex = GetSquadIndex();
@@ -5353,8 +5354,9 @@ function ServerSquadVolunteerToAssist()
     }
 
     SLPC = DHPlayer(SLPRI.Owner);
+    SLBot = DHBot(SLPRI.Owner);
 
-    if (SLPC == none)
+    if (SLPC == none && SLBot == none)
     {
         return;
     }
@@ -5365,7 +5367,16 @@ function ServerSquadVolunteerToAssist()
         return;
     }
 
-    SLPC.ClientSquadAssistantVolunteerPrompt(TeamIndex, SquadIndex, PRI);
+    if (SLPC != none)
+    {
+        // Prompt the squad leader with the player's request to become the assistant.
+        SLPC.ClientSquadAssistantVolunteerPrompt(TeamIndex, SquadIndex, PRI);
+    }
+    else if (SLBot != none)
+    {
+        // Bot auto-approves the new assistant.
+        SquadReplicationInfo.SetAssistantSquadLeader(TeamIndex, SquadIndex, PRI);
+    }
 }
 
 //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/DH_Engine/Classes/DHSquadReplicationInfo.uc
+++ b/DH_Engine/Classes/DHSquadReplicationInfo.uc
@@ -147,13 +147,26 @@ replication
         AxisNextRallyPointTimes, AlliesNextRallyPointTimes;
 }
 
-function PostBeginPlay()
+simulated function PostBeginPlay()
 {
     local DH_LevelInfo LI;
+    local PlayerController PC;
 
     super.PostBeginPlay();
 
-    GRI = DHGameReplicationInfo(Level.Game.GameReplicationInfo);
+    if (Role == ROLE_Authority)
+    {
+        GRI = DHGameReplicationInfo(Level.Game.GameReplicationInfo);
+    }
+    else
+    {
+        PC = Level.GetLocalPlayerController();
+
+        if (PC != none)
+        {
+            GRI = DHGameReplicationInfo(PC.GameReplicationInfo);
+        }
+    }
 
     if (Role == ROLE_Authority)
     {

--- a/DH_Engine/Classes/DHSquadReplicationInfo.uc
+++ b/DH_Engine/Classes/DHSquadReplicationInfo.uc
@@ -420,9 +420,19 @@ private function UpdateSquadLeaderDraws()
                 else
                 {
                     // The squad is big enough to not be disbanded, so someone
-                    // in the squad is going to randomly be assigned the leader.
+                    // in the squad (who isn't the squad assistant) is going to
+                    // randomly be assigned the leader.
                     BroadcastSquadLocalizedMessage(TeamIndex, SquadIndex, SquadMessageClass, 66);
                     GetMembers(TeamIndex, SquadIndex, Volunteers);
+
+                    for (i = 0; i < Volunteers.Length; ++i)
+                    {
+                        if (IsSquadAssistant(Volunteers[i], TeamIndex, SquadIndex))
+                        {
+                            Volunteers.Remove(i, 1);
+                            break;
+                        }
+                    }
                 }
             }
 
@@ -434,6 +444,12 @@ private function UpdateSquadLeaderDraws()
 
             // New squad leader has been selected, remove draw from the list.
             SquadLeaderDraws.Remove(i, 1);
+
+            // If somehow there are no volunteers (e.g., ASL is the only one left in the squad and didn't volunteer), just disband the squad.
+            if (Volunteers.Length == 0)
+            {
+                DisbandSquad(TeamIndex, SquadIndex);
+            }
         }
     }
 }
@@ -867,29 +883,18 @@ private function OnSquadLeaderLeftSquad(int TeamIndex, int SquadIndex)
 
     ClearSquadMergeRequests(TeamIndex, SquadIndex);
 
-    Assistant = GetAssistantSquadLeader(TeamIndex, SquadIndex);
+    GetSquadLeaderVolunteers(TeamIndex, SquadIndex, Volunteers);
 
-    if (Assistant != none)
+    if (Volunteers.Length > 0)
     {
-        // The squad has an assistant squad leader, so let's make them the
-        // new assistant squad leader.
-        CommandeerSquad(Assistant, TeamIndex, SquadIndex);
+        // There are volunteers, so let's make one of them the new
+        // squad leader without delay.
+        SelectNewSquadLeader(TeamIndex, SquadIndex, Volunteers);
     }
     else
     {
-        GetSquadLeaderVolunteers(TeamIndex, SquadIndex, Volunteers);
-
-        if (Volunteers.Length > 0)
-        {
-            // There are volunteers, so let's make one of them the new
-            // squad leader without delay.
-            SelectNewSquadLeader(TeamIndex, SquadIndex, Volunteers);
-        }
-        else
-        {
-            // No volunteers, start a new squad leader draw.
-            StartSquadLeaderDraw(TeamIndex, SquadIndex);
-        }
+        // No volunteers, start a new squad leader draw.
+        StartSquadLeaderDraw(TeamIndex, SquadIndex);
     }
 }
 

--- a/DH_Interface/Classes/DHDeployMenu.uc
+++ b/DH_Interface/Classes/DHDeployMenu.uc
@@ -1848,6 +1848,12 @@ function UpdateSquads()
     {
         SetVisible(p_Squads.SquadComponents[j], false);
     }
+
+    // Update the background colors.
+    for (i = 0; i < p_Squads.SquadComponents.Length; ++i)
+    {
+        p_Squads.SquadComponents[i].UpdateBackgroundColor(PRI);
+    }
 }
 
 static function SetEnabled(GUIComponent C, bool bEnabled)

--- a/DH_Interface/Classes/DHDeployMenu.uc
+++ b/DH_Interface/Classes/DHDeployMenu.uc
@@ -1730,7 +1730,7 @@ function UpdateSquads()
             }
         }
 
-        bCanJoinSquad = !bIsInASquad && SRI.IsSquadJoinable(TeamIndex, i);
+        bCanJoinSquad = SRI.IsSquadJoinable(TeamIndex, i);
 
         if (bCanJoinSquad)
         {

--- a/DH_Interface/Classes/DHGUISquadComponent.uc
+++ b/DH_Interface/Classes/DHGUISquadComponent.uc
@@ -22,6 +22,9 @@ var automated   GUIImage            i_Locked;       // Show this when the squad 
 var automated   DHGUIEditBox        eb_SquadName;
 var automated   GUIImage            i_Background;
 
+var Color DarkBackgroundColor;
+var Color LightBackgroundColor;
+
 function InitComponent(GUIController MyController, GUIComponent MyOwner)
 {
     super.InitComponent(MyController, MyOwner);
@@ -146,6 +149,18 @@ function MembersListContextMenuSelect(GUIContextMenu Sender, int ClickIndex)
     }
 }
 
+function UpdateBackgroundColor(DHPlayerReplicationInfo PRI)
+{
+    if (SquadIndex == PRI.SquadIndex)
+    {
+        i_Background.ImageColor = default.LightBackgroundColor;
+    }
+    else
+    {
+        i_Background.ImageColor = default.DarkBackgroundColor;
+    }
+}
+
 defaultproperties
 {
     Begin Object Class=DHGUIButton Name=LockSquadButton
@@ -180,7 +195,7 @@ defaultproperties
         WinLeft=0.0
         WinTop=0.0
         Image=Texture'DH_GUI_tex.DeployMenu.squad_panel'
-        ImageColor=(R=255,G=255,B=255,A=255);
+        ImageColor=(R=192,G=192,B=192,A=255)
         ImageRenderStyle=MSTY_Alpha
         ImageStyle=ISTY_Stretched
         bBoundToParent=true
@@ -276,4 +291,7 @@ defaultproperties
     b_JoinSquad=JoinSquadButton
 
     OnShow=InternalOnShow
+    
+    DarkBackgroundColor=(R=128,G=128,B=128,A=255)
+    LightBackgroundColor=(R=255,G=255,B=255,A=255)
 }


### PR DESCRIPTION
This makes the following changes:

* The squad panels in the UI will have a different background depending on whether or not the user is in the squad or not.
* Players can now join other squads without losing their non-leader role (i.e., machine-gunner, anti-tank etc.)
* Squad assistants are no longer immediately assigned to be the new squad leader after the squad leader leaves.
* Squad assistants will also not be eligible to be auto-assigned to squad leader if they did not explicitly volunteer to.

The rationale for the ASL changes is that in the current meta, ASLs are usually running logistics, and having an ASL automatically being turned into the SL means that they can no longer build without someone nearby. In the future when we have a dedicated logistics squad, this whole thing can be ripped out as we figure out what the ASLs new job will be.