### PR TITLE
Update to APCs/Halftracks

### DIFF
--- a/DH_Engine/Classes/DHArmoredVehicle.uc
+++ b/DH_Engine/Classes/DHArmoredVehicle.uc
@@ -2426,7 +2426,7 @@ defaultproperties
     DamagedEffectHealthMediumSmokeFactor=0.65
     DamagedEffectHealthHeavySmokeFactor=0.35
     DamagedEffectHealthFireFactor=0.0
-    FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' //'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
+    FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
     FireAttachBone="driver_player"
     FireEffectOffset=(X=0.0,Y=0.0,Z=-10.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
 

--- a/DH_Engine/Classes/DHVehicleBurningDamageType.uc
+++ b/DH_Engine/Classes/DHVehicleBurningDamageType.uc
@@ -10,7 +10,7 @@ defaultproperties
 {
     HUDIcon=Texture'DH_InterfaceArt_tex.deathicons.VehicleFireKill'
     TankDamageModifier=1.0
-    APCDamageModifier=1.0
+    APCDamageModifier=0.5
     VehicleDamageModifier=1.0
     DeathString="%o was burned up in a vehicle fire that %k started."
     MaleSuicide="%o burned up in a vehicle fire."

--- a/DH_Guns/Classes/DH_PantherturmGun.uc
+++ b/DH_Guns/Classes/DH_PantherturmGun.uc
@@ -18,7 +18,7 @@ defaultproperties
     VehicleHudTurret=TexRotator'DH_InterfaceArt_tex.Tank_Hud.panther_turret_rot'
     VehicleHudTurretLook=TexRotator'DH_InterfaceArt_tex.Tank_Hud.panther_turret_look'
     ExitPositions(0)=(X=-91.0,Y=20.0,Z=110.0)
-	VehicleMass=14.0
+    VehicleMass=14.0
     MapIconAttachmentClass=class'DH_Engine.DHMapIconAttachment_Vehicle_Armored'
 
     Begin Object Class=KarmaParamsRBFull Name=KParams0

--- a/DH_Guns/Classes/DH_PantherturmGun.uc
+++ b/DH_Guns/Classes/DH_PantherturmGun.uc
@@ -102,7 +102,7 @@ defaultproperties
     HealthMax=1600.0
     Health=1600
     EngineHealth=0
-	VehHitpoints(0)=(PointRadius=30.0,PointBone="Turret",DamageMultiplier=50.0,HitPointType=HP_AmmoStore)
+   VehHitpoints(0)=(PointRadius=30.0,PointBone="Turret",DamageMultiplier=50.0,HitPointType=HP_AmmoStore)
     DamagedEffectClass=none
     DestructionEffectClass=class'DH_Effects.DHVehicleDestroyedEmitter'
     DisintegrationEffectClass=class'DH_Effects.DHVehicleObliteratedEmitter'

--- a/DH_Vehicles/Classes/DH_BrenCarrierMG.uc
+++ b/DH_Vehicles/Classes/DH_BrenCarrierMG.uc
@@ -51,5 +51,5 @@ defaultproperties
 	
 	// Hatch fire
     FireEffectOffset=(X=-84.0,Y=55.0,Z=8.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
-	FireEffectScale=0.5
+    FireEffectScale=0.5
 }

--- a/DH_Vehicles/Classes/DH_BrenCarrierMG.uc
+++ b/DH_Vehicles/Classes/DH_BrenCarrierMG.uc
@@ -48,4 +48,8 @@ defaultproperties
     ReloadStages(1)=(Sound=none,Duration=0.8,HUDProportion=0.67)
     ReloadStages(2)=(Sound=none,Duration=0.7)
     ReloadStages(3)=(Sound=none,Duration=0.7,HUDProportion=0.35)
+	
+	// Hatch fire
+    FireEffectOffset=(X=-84.0,Y=55.0,Z=8.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
+	FireEffectScale=0.5
 }

--- a/DH_Vehicles/Classes/DH_BrenCarrierTransport.uc
+++ b/DH_Vehicles/Classes/DH_BrenCarrierTransport.uc
@@ -3,7 +3,7 @@
 // Darklight Games (c) 2008-2023
 //==============================================================================
 
-class DH_BrenCarrierTransport extends DHVehicle;
+class DH_BrenCarrierTransport extends DHArmoredVehicle;
 
 simulated event DestroyAppearance()
 {
@@ -30,8 +30,12 @@ defaultproperties
     VehicleMass=5.0
     ReinforcementCost=3
     MaxDesireability=1.2
+    MinRunOverSpeed=350 //Lighter vehicle so slightly higher min speed than other APCs
+    PointValue=500
     MapIconAttachmentClass=class'DH_Engine.DHMapIconAttachment_Vehicle'
     PrioritizeWeaponPawnEntryFromIndex=1
+    bMustBeTankCommander=false
+    UnbuttonedPositionIndex=0
 
     // Hull mesh
     Mesh=SkeletalMesh'DH_BrenCarrier_anm.BrenCarrier_body_ext'
@@ -78,22 +82,34 @@ defaultproperties
     WheelLatFrictionScale=3.0
 
     // Damage
-    Health=1500
-    HealthMax=1500.0
-    DamagedEffectHealthFireFactor=0.9
-    EngineHealth=50
-    VehHitpoints(0)=(PointRadius=20.0,PointOffset=(X=-15.0,Y=0.0,Z=0.0)) // engine
-    VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="Engine",PointOffset=(X=22.0,Y=0.0,Z=0.0),DamageMultiplier=1.0,HitPointType=HP_Engine)
-    VehHitpoints(2)=(PointRadius=15.0,PointScale=1.0,PointBone="Engine",PointOffset=(X=0.0,Y=0.0,Z=30.0),DamageMultiplier=1.0,HitPointType=HP_Engine)
-    VehHitpoints(3)=(PointRadius=15.0,PointScale=1.0,PointBone="Engine",PointOffset=(X=27.0,Y=0.0,Z=30.0),DamageMultiplier=1.0,HitPointType=HP_Engine)
-    VehHitpoints(4)=(PointRadius=15.0,PointHeight=15.0,PointScale=1.0,PointBone="body",PointOffset=(X=-83.0,Y=0.0,Z=30.0),DamageMultiplier=2.0,HitPointType=HP_AmmoStore)
-    DirectHEImpactDamageMult=8.0
+    Health=500.0
+    HealthMax=500.0
+    DamagedEffectHealthFireFactor=0.1
+    EngineHealth=150.0
+    EngineDamageFromGrenadeModifier=0.05
+    DirectHEImpactDamageMult=4.0
+    ImpactWorldDamageMult=2.0
+    VehHitpoints(0)=(PointRadius=20.0,PointOffset=(X=0.0,Y=-2.0,Z=3.0),DamageMultiplier=2.0,HitPointType=HP_Engine) // engine
+    VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="Engine",PointOffset=(X=10.0,Y=1.0,Z=1.0),DamageMultiplier=2.0,HitPointType=HP_Engine)
+    VehHitpoints(2)=(PointRadius=15.0,PointScale=1.0,PointBone="Engine",PointOffset=(X=0.0,Y=1.0,Z=25.0),DamageMultiplier=2.0,HitPointType=HP_Engine)
+    VehHitpoints(3)=(PointRadius=15.0,PointScale=1.0,PointBone="Engine",PointOffset=(X=30.0,Y=1.0,Z=25.0),DamageMultiplier=2.0,HitPointType=HP_Engine)
+    VehHitpoints(4)=(PointRadius=15.0,PointScale=1.0,PointBone="Engine",PointOffset=(X=55.0,Y=1.0,Z=25.0),DamageMultiplier=2.0,HitPointType=HP_Engine)
+    VehHitpoints(5)=(PointRadius=12.0,PointScale=1.0,PointBone="body",PointOffset=(X=-50.0,Y=-28.0,Z=0.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // Fuel tank
     TreadHitMaxHeight=7.0
     DamagedEffectScale=0.75
-    DamagedEffectOffset=(X=-40.0,Y=10.0,Z=10.0)
+    DamagedEffectOffset=(X=-20,Y=-3.5,Z=15.0)
     DestroyedVehicleMesh=StaticMesh'DH_allies_vehicles_stc.Carrier.Carrier_destroyed'
     DestructionEffectClass=class'ROEffects.ROVehicleDestroyedEmitter'
     DestructionEffectLowClass=class'ROEffects.ROVehicleDestroyedEmitter_simple'
+    bEnableHatchFires=true
+    FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' //'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
+    FireAttachBone="passenger_l_2"
+    FireEffectOffset=(X=0.0,Y=0.0,Z=5.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
+    EngineToHullFireChance=0.55 //engine of the Uni Carrier is in middle of the hull/passenger compartment
+    AmmoIgnitionProbability=0.35
+    HullFireDamagePer2Secs=2
+    FireDetonationChance=0.05
+
 
     // Vehicle destruction
     ExplosionDamage=85.0

--- a/DH_Vehicles/Classes/DH_BrenCarrierTransport.uc
+++ b/DH_Vehicles/Classes/DH_BrenCarrierTransport.uc
@@ -99,7 +99,7 @@ defaultproperties
     DestructionEffectClass=class'ROEffects.ROVehicleDestroyedEmitter'
     DestructionEffectLowClass=class'ROEffects.ROVehicleDestroyedEmitter_simple'
     bEnableHatchFires=true
-    FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' //'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
+    FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
     FireAttachBone="passenger_l_2"
     FireEffectOffset=(X=5.0,Y=4.0,Z=10.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
     EngineToHullFireChance=0.55 //engine of the Uni Carrier is in the middle of the hull/passenger compartment

--- a/DH_Vehicles/Classes/DH_BrenCarrierTransport.uc
+++ b/DH_Vehicles/Classes/DH_BrenCarrierTransport.uc
@@ -89,26 +89,23 @@ defaultproperties
     EngineDamageFromGrenadeModifier=0.05
     DirectHEImpactDamageMult=4.0
     ImpactWorldDamageMult=2.0
-    VehHitpoints(0)=(PointRadius=20.0,PointOffset=(X=0.0,Y=-2.0,Z=3.0),DamageMultiplier=2.0,HitPointType=HP_Engine) // engine
-    VehHitpoints(1)=(PointRadius=20.0,PointScale=1.0,PointBone="Engine",PointOffset=(X=10.0,Y=1.0,Z=1.0),DamageMultiplier=2.0,HitPointType=HP_Engine)
-    VehHitpoints(2)=(PointRadius=15.0,PointScale=1.0,PointBone="Engine",PointOffset=(X=0.0,Y=1.0,Z=25.0),DamageMultiplier=2.0,HitPointType=HP_Engine)
-    VehHitpoints(3)=(PointRadius=15.0,PointScale=1.0,PointBone="Engine",PointOffset=(X=30.0,Y=1.0,Z=25.0),DamageMultiplier=2.0,HitPointType=HP_Engine)
-    VehHitpoints(4)=(PointRadius=15.0,PointScale=1.0,PointBone="Engine",PointOffset=(X=55.0,Y=1.0,Z=25.0),DamageMultiplier=2.0,HitPointType=HP_Engine)
-    VehHitpoints(5)=(PointRadius=12.0,PointScale=1.0,PointBone="body",PointOffset=(X=-50.0,Y=-28.0,Z=0.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // Fuel tank
+    VehHitpoints(0)=(PointRadius=25.0,PointBone="body",PointOffset=(X=-5.0,Y=-3.0,Z=20.0),DamageMultiplier=2.0,HitPointType=HP_Engine) // engine
+    VehHitpoints(1)=(PointRadius=22.0,PointScale=1.0,PointBone="body",PointOffset=(X=-45.0,Y=-3.0,Z=20.0),DamageMultiplier=2.0,HitPointType=HP_Engine)
+    VehHitpoints(2)=(PointRadius=12.0,PointScale=1.0,PointBone="body",PointOffset=(X=-50.0,Y=-28.0,Z=0.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // Fuel tank
     TreadHitMaxHeight=7.0
-    DamagedEffectScale=0.75
-    DamagedEffectOffset=(X=-20,Y=-3.5,Z=15.0)
+    DamagedEffectScale=0.70
+    DamagedEffectOffset=(X=-20,Y=-3.5,Z=18.0)
     DestroyedVehicleMesh=StaticMesh'DH_allies_vehicles_stc.Carrier.Carrier_destroyed'
     DestructionEffectClass=class'ROEffects.ROVehicleDestroyedEmitter'
     DestructionEffectLowClass=class'ROEffects.ROVehicleDestroyedEmitter_simple'
     bEnableHatchFires=true
     FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' //'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
     FireAttachBone="passenger_l_2"
-    FireEffectOffset=(X=0.0,Y=0.0,Z=5.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
-    EngineToHullFireChance=0.55 //engine of the Uni Carrier is in middle of the hull/passenger compartment
-    AmmoIgnitionProbability=0.35
-    HullFireDamagePer2Secs=2
+    FireEffectOffset=(X=5.0,Y=4.0,Z=10.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
+    EngineToHullFireChance=0.55 //engine of the Uni Carrier is in the middle of the hull/passenger compartment
+    AmmoIgnitionProbability=0.0 // 0 as ammo hitpoints are meant to represent fuel, not explosive ammo
     FireDetonationChance=0.05
+    PlayerFireDamagePer2Secs=10.0 //kills a little more slowly than tanks since halftracks are open vehicles, also gives infantry a little more time to reach safety before bailing
 
 
     // Vehicle destruction

--- a/DH_Vehicles/Classes/DH_M16Halftrack.uc
+++ b/DH_Vehicles/Classes/DH_M16Halftrack.uc
@@ -19,6 +19,10 @@ defaultproperties
     PassengerPawns(3)=(AttachBone="body",DrivePos=(X=-10.0,Y=30.0,Z=85.0),DriveRot=(Yaw=-16384),DriveAnim="VHalftrack_Rider4_idle")
     PassengerPawns(4)=(AttachBone="body",DrivePos=(X=-45.0,Y=30.0,Z=85.0),DriveRot=(Yaw=-16384),DriveAnim="VHalftrack_Rider5_idle")
 
+    //Damage
+    VehHitpoints(5)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-160.0,Y=52.0,Z=80.0),DamageMultiplier=1.5,HitPointType=HP_AmmoStore) // Spare .50 tombstones, won't really explode but incendiaries and propellent might start a fire
+    VehHitpoints(6)=(PointRadius=20.0,PointScale=1.0,PointBone="body",PointOffset=(X=-160.0,Y=-52.0,Z=80.0),DamageMultiplier=1.5,HitPointType=HP_AmmoStore)
+
     // HUD
     VehicleHudImage=Texture'DH_M3Halftrack_tex.hud.m16_body'
     VehicleHudTurret=TexRotator'DH_M3Halftrack_tex.hud.m16_turret_rot'

--- a/DH_Vehicles/Classes/DH_M3Halftrack.uc
+++ b/DH_Vehicles/Classes/DH_M3Halftrack.uc
@@ -72,7 +72,7 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=125.0,Z=65.0)) // engine
     VehHitpoints(1)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_R_1",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel
     VehHitpoints(2)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_L_1",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel
-	VehHitpoints(3)=(PointRadius=30.0,PointScale=1.0,PointBone="body",PointOffset=(X=-31.0,Y=52.0,Z=95.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // right fuel tank
+   VehHitpoints(3)=(PointRadius=30.0,PointScale=1.0,PointBone="body",PointOffset=(X=-31.0,Y=52.0,Z=95.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // right fuel tank
     VehHitpoints(4)=(PointRadius=30.0,PointScale=1.0,PointBone="body",PointOffset=(X=-31.0,Y=-52.0,Z=95.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // left fuel tank
     DamagedWheelSpeedFactor=0.4
     EngineDamageFromGrenadeModifier=0.05

--- a/DH_Vehicles/Classes/DH_M3Halftrack.uc
+++ b/DH_Vehicles/Classes/DH_M3Halftrack.uc
@@ -84,7 +84,7 @@ defaultproperties
     DestructionEffectClass=class'ROEffects.ROVehicleDestroyedEmitter'
     DestructionEffectLowClass=class'ROEffects.ROVehicleDestroyedEmitter_simple'
     bEnableHatchFires=true
-    FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' //'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
+    FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
     FireAttachBone="body"
     FireEffectOffset=(X=-35.0,Y=30.0,Z=85.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
     EngineToHullFireChance=0.05 //Unlikely for a fire to spread

--- a/DH_Vehicles/Classes/DH_M3Halftrack.uc
+++ b/DH_Vehicles/Classes/DH_M3Halftrack.uc
@@ -67,21 +67,30 @@ defaultproperties
     // Damage
     Health=500.0
     HealthMax=500.0
-    DamagedEffectHealthFireFactor=0.2
+    DamagedEffectHealthFireFactor=0.1
     EngineHealth=150.0
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=125.0,Z=65.0)) // engine
     VehHitpoints(1)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_R_1",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel
     VehHitpoints(2)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_L_1",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel
+	VehHitpoints(3)=(PointRadius=23.0,PointScale=1.0,PointBone="body",PointOffset=(X=-35.0,Y=60.0,Z=85.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // right fuel tank
+    VehHitpoints(4)=(PointRadius=23.0,PointScale=1.0,PointBone="body",PointOffset=(X=-35.0,Y=-60.0,Z=85.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // left fuel tank
     DamagedWheelSpeedFactor=0.4
     EngineDamageFromGrenadeModifier=0.05
-    DirectHEImpactDamageMult=8.0
+    DirectHEImpactDamageMult=4.0
     ImpactWorldDamageMult=2.0
     TreadHitMaxHeight=64.0
     DamagedEffectScale=0.75
     DamagedEffectOffset=(X=120.0,Y=0.0,Z=60.0)
     DestructionEffectClass=class'ROEffects.ROVehicleDestroyedEmitter'
     DestructionEffectLowClass=class'ROEffects.ROVehicleDestroyedEmitter_simple'
-    bEnableHatchFires=false
+    bEnableHatchFires=true
+    FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' //'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
+    FireAttachBone="body"
+    FireEffectOffset=(X=-35.0,Y=30.0,Z=85.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
+    EngineToHullFireChance=0.05 //Unlikely for a fire to spread
+    AmmoIgnitionProbability=0.35
+    HullFireDamagePer2Secs=2
+    FireDetonationChance=0.02
 
     // Vehicle destruction
     ExplosionDamage=85.0

--- a/DH_Vehicles/Classes/DH_M3Halftrack.uc
+++ b/DH_Vehicles/Classes/DH_M3Halftrack.uc
@@ -72,15 +72,15 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=40.0,PointOffset=(X=125.0,Z=65.0)) // engine
     VehHitpoints(1)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_R_1",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel
     VehHitpoints(2)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_L_1",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel
-	VehHitpoints(3)=(PointRadius=23.0,PointScale=1.0,PointBone="body",PointOffset=(X=-35.0,Y=60.0,Z=85.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // right fuel tank
-    VehHitpoints(4)=(PointRadius=23.0,PointScale=1.0,PointBone="body",PointOffset=(X=-35.0,Y=-60.0,Z=85.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // left fuel tank
+	VehHitpoints(3)=(PointRadius=30.0,PointScale=1.0,PointBone="body",PointOffset=(X=-31.0,Y=52.0,Z=95.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // right fuel tank
+    VehHitpoints(4)=(PointRadius=30.0,PointScale=1.0,PointBone="body",PointOffset=(X=-31.0,Y=-52.0,Z=95.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // left fuel tank
     DamagedWheelSpeedFactor=0.4
     EngineDamageFromGrenadeModifier=0.05
     DirectHEImpactDamageMult=4.0
     ImpactWorldDamageMult=2.0
     TreadHitMaxHeight=64.0
     DamagedEffectScale=0.75
-    DamagedEffectOffset=(X=120.0,Y=0.0,Z=60.0)
+    DamagedEffectOffset=(X=120.0,Y=0.0,Z=68.0)
     DestructionEffectClass=class'ROEffects.ROVehicleDestroyedEmitter'
     DestructionEffectLowClass=class'ROEffects.ROVehicleDestroyedEmitter_simple'
     bEnableHatchFires=true
@@ -88,9 +88,9 @@ defaultproperties
     FireAttachBone="body"
     FireEffectOffset=(X=-35.0,Y=30.0,Z=85.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
     EngineToHullFireChance=0.05 //Unlikely for a fire to spread
-    AmmoIgnitionProbability=0.35
-    HullFireDamagePer2Secs=2
+    AmmoIgnitionProbability=0.0 // 0 as ammo hitpoints are meant to represent fuel, not explosive ammo
     FireDetonationChance=0.02
+    PlayerFireDamagePer2Secs=10.0 //kills a little more slowly than tanks since halftracks are open vehicles, also gives infantry a little more time to reach safety before bailing
 
     // Vehicle destruction
     ExplosionDamage=85.0

--- a/DH_Vehicles/Classes/DH_M45QuadmountMG.uc
+++ b/DH_Vehicles/Classes/DH_M45QuadmountMG.uc
@@ -140,8 +140,8 @@ defaultproperties
     bForceSkelUpdate=true // necessary for new player hit detection system, as makes server update the MG mesh skeleton, which it wouldn't otherwise as server doesn't draw mesh
     BeginningIdleAnim="idle_sights_in"
     GunnerAttachmentBone="Gun"
-	FireEffectOffset=(X=-25.0,Y=0.0,Z=-10.0)
-	FireEffectScale=0.60
+    FireEffectOffset=(X=-25.0,Y=0.0,Z=-10.0)
+    FireEffectScale=0.60
 
     // Collision
     bCollideActors=true

--- a/DH_Vehicles/Classes/DH_M45QuadmountMG.uc
+++ b/DH_Vehicles/Classes/DH_M45QuadmountMG.uc
@@ -140,7 +140,8 @@ defaultproperties
     bForceSkelUpdate=true // necessary for new player hit detection system, as makes server update the MG mesh skeleton, which it wouldn't otherwise as server doesn't draw mesh
     BeginningIdleAnim="idle_sights_in"
     GunnerAttachmentBone="Gun"
-    FireEffectClass=none // no hatch fire effect
+	FireEffectOffset=(X=-25.0,Y=0.0,Z=-10.0)
+	FireEffectScale=0.60
 
     // Collision
     bCollideActors=true

--- a/DH_Vehicles/Classes/DH_PanzerIVJTank.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIVJTank.uc
@@ -33,7 +33,7 @@ defaultproperties
 	// this modification was produced late in the war (1944-45), most (if not all) tanks of this modification had very low quality armor due to absence of proper alloys, which was less effective and caused a lot of spalling
     Health=535
     HealthMax=535.0
-	VehHitpoints(0)=(PointOffset=(X=-100.0,Y=0.0,Z=12.0)) // engine
+   VehHitpoints(0)=(PointOffset=(X=-100.0,Y=0.0,Z=12.0)) // engine
     VehHitpoints(1)=(PointRadius=20.0,PointOffset=(X=30.0,Y=-27.0,Z=0.0)) // ammo stores x 3
     VehHitpoints(2)=(PointRadius=20.0,PointOffset=(X=-20.0,Y=-27.0,Z=0.0))
     VehHitpoints(3)=(PointRadius=20.0,PointOffset=(X=-30.0,Y=27.0,Z=0.0))

--- a/DH_Vehicles/Classes/DH_SdKfz2519DTransport.uc
+++ b/DH_Vehicles/Classes/DH_SdKfz2519DTransport.uc
@@ -34,6 +34,9 @@ defaultproperties
     DisintegrationHealth=-200.0 // increased because other burning properties dont seem to exist on this vehicle type, hence "compensation"
     EngineHealth=300
 
+    FireDetonationChance=0.07 //increased fire detonation and ammo ignition probability over normal halftrack as ammo is explosive
+    AmmoIgnitionProbability=0.75
+
     VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=-45.0,Y=0.0,Z=15.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
 
     DriverPositions(1)=(ViewPitchUpLimit=5000,ViewPitchDownLimit=60000,ViewPositiveYawLimit=11700,ViewNegativeYawLimit=-15000) // reduced limits so driver can't look behind & see wrong interior without Pak40
@@ -58,7 +61,4 @@ defaultproperties
     VehicleHudOccupantsY(0)=0.4
     VehicleHudOccupantsX(1)=0.45
     VehicleHudOccupantsY(1)=0.53
-
-    //AmmoIgnitionProbability=0.75  // 0.75 default
-    //EngineToHullFireChance=0.1  //increased from 0.05 for all petrol engines
 }

--- a/DH_Vehicles/Classes/DH_SdKfz251_22Transport.uc
+++ b/DH_Vehicles/Classes/DH_SdKfz251_22Transport.uc
@@ -50,6 +50,6 @@ defaultproperties
 
     //Add AMMO HIT BOX for 7.5 cm shell storage
     VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="Body",PointOffset=(X=-45.0,Y=0.0,Z=15.0),DamageMultiplier=5.0,HitPointType=HP_AmmoStore)
-    //AmmoIgnitionProbability=0.75  // 0.75 default
-    //^ "unknown property"
+    FireDetonationChance=0.07 //increased fire detonation and ammo ignition probability over normal halftrack as ammo is explosive
+    AmmoIgnitionProbability=0.75
 }

--- a/DH_Vehicles/Classes/DH_Sdkfz251MG.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz251MG.uc
@@ -56,4 +56,7 @@ defaultproperties
     ReloadStages(1)=(Sound=none,Duration=1.56)
     ReloadStages(2)=(Sound=none,Duration=1.92)
     ReloadStages(3)=(Sound=none,Duration=1.63)
+	
+	FireEffectOffset=(X=-20.0,Y=0.0,Z=-30.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
+	FireEffectScale=0.70
 }

--- a/DH_Vehicles/Classes/DH_Sdkfz251MG.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz251MG.uc
@@ -57,6 +57,6 @@ defaultproperties
     ReloadStages(2)=(Sound=none,Duration=1.92)
     ReloadStages(3)=(Sound=none,Duration=1.63)
 	
-	FireEffectOffset=(X=-20.0,Y=0.0,Z=-30.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
+	FireEffectOffset=(X=-25.0,Y=0.0,Z=-40.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
 	FireEffectScale=0.70
 }

--- a/DH_Vehicles/Classes/DH_Sdkfz251MG.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz251MG.uc
@@ -57,6 +57,6 @@ defaultproperties
     ReloadStages(2)=(Sound=none,Duration=1.92)
     ReloadStages(3)=(Sound=none,Duration=1.63)
 	
-	FireEffectOffset=(X=-25.0,Y=0.0,Z=-40.0) // position of driver's hatch fire - hull mg and turret fire positions are set in those pawn classes
+	FireEffectOffset=(X=-25.0,Y=0.0,Z=-40.0)
 	FireEffectScale=0.70
 }

--- a/DH_Vehicles/Classes/DH_Sdkfz251MG.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz251MG.uc
@@ -57,6 +57,6 @@ defaultproperties
     ReloadStages(2)=(Sound=none,Duration=1.92)
     ReloadStages(3)=(Sound=none,Duration=1.63)
 	
-	FireEffectOffset=(X=-25.0,Y=0.0,Z=-40.0)
-	FireEffectScale=0.70
+    FireEffectOffset=(X=-25.0,Y=0.0,Z=-40.0)
+    FireEffectScale=0.70
 }

--- a/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
@@ -96,7 +96,7 @@ defaultproperties
     DestructionEffectClass=class'ROEffects.ROVehicleDestroyedEmitter'
     DestructionEffectLowClass=class'ROEffects.ROVehicleDestroyedEmitter_simple'
     bEnableHatchFires=true
-    FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' //'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
+    FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
     FireAttachBone="body"
     FireEffectOffset=(X=-70.000000,Y=0.0,Z=-15.0)
     EngineToHullFireChance=0.05 //Unlikely for a fire to spread

--- a/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
@@ -67,7 +67,7 @@ defaultproperties
     ChangeUpPoint=2000.0
     ChangeDownPoint=1000.0
     ChassisTorqueScale=0.4
-    bSpecialTankTurning=false
+    bSpecialTankTurning=true // Sd. Kfz. 251 had tank steering with the tracks braking if the steering wheel was fully turned
     TurnDamping=35.0
 
     // Physics wheels properties
@@ -84,18 +84,26 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=50.0,PointOffset=(X=120.0)) // engine
     VehHitpoints(1)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_F_R",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel
     VehHitpoints(2)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_F_L",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel
+	VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=-70.000000,Y=0.0,Z=-35.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // fuel tank
     EngineDamageFromGrenadeModifier=0.05
     DamagedWheelSpeedFactor=0.4
-    DirectHEImpactDamageMult=8.0
-    ImpactWorldDamageMult=2.0
+    DirectHEImpactDamageMult=4.0
+    ImpactWorldDamageMult=2.0 // 2 before
     TreadHitMaxHeight=-5.0
     DamagedEffectScale=0.75
     DamagedEffectOffset=(X=120.0,Y=00.0,Z=20.0)
     DestroyedVehicleMesh=StaticMesh'DH_German_vehicles_stc.Halftrack.Halftrack0_Destroyed'
     DestructionEffectClass=class'ROEffects.ROVehicleDestroyedEmitter'
     DestructionEffectLowClass=class'ROEffects.ROVehicleDestroyedEmitter_simple'
-    bEnableHatchFires=false
-
+	bEnableHatchFires=true
+    FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' //'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
+    FireAttachBone="body"
+    FireEffectOffset=(X=-70.000000,Y=0.0,Z=-15.0)
+    EngineToHullFireChance=0.05 //Unlikely for a fire to spread
+    AmmoIgnitionProbability=35.00
+    HullFireDamagePer2Secs=2
+    FireDetonationChance=0.02
+	
     // Vehicle destruction
     ExplosionDamage=85.0
     ExplosionRadius=150.0

--- a/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
@@ -100,9 +100,9 @@ defaultproperties
     FireAttachBone="body"
     FireEffectOffset=(X=-70.000000,Y=0.0,Z=-15.0)
     EngineToHullFireChance=0.05 //Unlikely for a fire to spread
-    AmmoIgnitionProbability=35.00
-    HullFireDamagePer2Secs=2
+    AmmoIgnitionProbability=0.0 // 0 as ammo hitpoints are meant to represent fuel, not explosive ammo
     FireDetonationChance=0.02
+    PlayerFireDamagePer2Secs=10.0 //kills a little more slowly than tanks since halftracks are open vehicles, also gives infantry a little more time to reach safety before bailing
 	
     // Vehicle destruction
     ExplosionDamage=85.0

--- a/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
@@ -88,14 +88,14 @@ defaultproperties
     EngineDamageFromGrenadeModifier=0.05
     DamagedWheelSpeedFactor=0.4
     DirectHEImpactDamageMult=4.0
-    ImpactWorldDamageMult=2.0 // 2 before
+    ImpactWorldDamageMult=2.0
     TreadHitMaxHeight=-5.0
     DamagedEffectScale=0.75
     DamagedEffectOffset=(X=120.0,Y=00.0,Z=20.0)
     DestroyedVehicleMesh=StaticMesh'DH_German_vehicles_stc.Halftrack.Halftrack0_Destroyed'
     DestructionEffectClass=class'ROEffects.ROVehicleDestroyedEmitter'
     DestructionEffectLowClass=class'ROEffects.ROVehicleDestroyedEmitter_simple'
-	bEnableHatchFires=true
+    bEnableHatchFires=true
     FireEffectClass=class'DH_Effects.DHVehicleDamagedEffect' //'DH_Effects.DHVehicleDamagedEffect' // driver's hatch fire
     FireAttachBone="body"
     FireEffectOffset=(X=-70.000000,Y=0.0,Z=-15.0)

--- a/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz251Transport.uc
@@ -84,7 +84,7 @@ defaultproperties
     VehHitpoints(0)=(PointRadius=50.0,PointOffset=(X=120.0)) // engine
     VehHitpoints(1)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_F_R",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel
     VehHitpoints(2)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_F_L",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel
-	VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=-70.000000,Y=0.0,Z=-35.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // fuel tank
+   VehHitpoints(3)=(PointRadius=25.0,PointScale=1.0,PointBone="body",PointOffset=(X=-70.000000,Y=0.0,Z=-35.0),DamageMultiplier=1.0,HitPointType=HP_AmmoStore) // fuel tank
     EngineDamageFromGrenadeModifier=0.05
     DamagedWheelSpeedFactor=0.4
     DirectHEImpactDamageMult=4.0


### PR DESCRIPTION
Universal Carrier:

- Reworked to be an armored vehicle, for consistency with halftracks.
- Reduced health significantly (from 1500 to 500, now equivalent to halftracks) and added additional hitpoints, the vehicle will still be survivable but can now only take 2-3 AP shells on average, and may catch fire or explode altogether if weakpoints are hit.
- Fixed incorrect Damage Effect offset. 
- Simplified engine hitpoints.
- Increased time it takes for hull-fire to kill passengers and crew, to give a little extra time to bail out.

Sd.Kfz. 251:

- Added fuel hitpoint and fire chance.
- Enabled tank steering as the Sd.Kfz. 251 was capable of this in reality.
- Increased time it takes for hull-fire to kill passengers and crew, to give a little extra time to bail out.

M3A1 Halftrack:

- Added fuel hitpoints and fire chance.
- Increased time it takes for hull-fire to kill passengers and crew, to give a little extra time to bail out.
- Improved engine fire effect location (no longer clips through the bottom of the engine).

M16 Halftrack:

- Added hitpoint for ammo.
- Added hull fire point for the turret.

Sd.Kfz 251/22 and 251/9 (Pakwagen and Stummel):

- Changed ammo ignition probability in these vehicles to default (0.75) as they have actual high explosive ammo that can detonate.

DHVehicleBurningDamageType:

- Reduced damage modifier to APCs to 0.50, so halftracks that catch fire will take a little while to burn down (20-30 seconds depending on the damage inflicted by the shell that hit them).