### PR TITLE
Sd.Kfz. 234/1 Changes

### DIFF
--- a/DH_Vehicles/Classes/DH_Sdkfz2341Cannon.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz2341Cannon.uc
@@ -39,22 +39,22 @@ defaultproperties
     CustomPitchDownLimit=64443
 
     // Cannon ammo
-    PrimaryProjectileClass=class'DH_Engine.DHCannonShell_MixedMag'
-    SecondaryProjectileClass=class'DH_Vehicles.DH_Sdkfz2341CannonShell'
-    TertiaryProjectileClass=class'DH_Vehicles.DH_Sdkfz2341CannonShellHE'
+    PrimaryProjectileClass=class'DH_Vehicles.DH_Sdkfz2341CannonShell'
+    SecondaryProjectileClass=class'DH_Vehicles.DH_Sdkfz2341CannonShellHE'
+    TertiaryProjectileClass=class'DH_Vehicles.DH_Sdkfz2341CannonShellAPCR'
 
-    ProjectileDescriptions(0)="Mixed"
-    ProjectileDescriptions(1)="AP"
-    ProjectileDescriptions(2)="HE-T"
+    ProjectileDescriptions(0)="AP-T"
+    ProjectileDescriptions(1)="HE-T"
+    ProjectileDescriptions(2)="APCR-T"
 
-    nProjectileDescriptions(0)="PzGr.+Sprgr.39"
-    nProjectileDescriptions(1)="PzGr."
-    nProjectileDescriptions(2)="Sprgr.39"
+    nProjectileDescriptions(0)="Pzgr. L'spur"
+    nProjectileDescriptions(1)="Sprgr. L'spur"
+    nProjectileDescriptions(2)="Pzgr. 40 L'spur"
 
 
-    NumPrimaryMags=15
-    NumSecondaryMags=15
-    NumTertiaryMags=15
+    NumPrimaryMags=11
+    NumSecondaryMags=11
+    NumTertiaryMags=2
     InitialPrimaryAmmo=10
     InitialSecondaryAmmo=10
     InitialTertiaryAmmo=10

--- a/DH_Vehicles/Classes/DH_Sdkfz2341CannonShellAPCR.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz2341CannonShellAPCR.uc
@@ -1,0 +1,81 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_Sdkfz2341CannonShellAPCR extends DHGermanCannonShell;
+
+defaultproperties
+{
+    bNetTemporary=true // so its torn off straight after actor replication, like a bullet instead of a shell, due to volume of fire adding to net load (each shell is a net channel)
+
+    RoundType=RT_APDS
+    Speed=63369.6
+    MaxSpeed=63369.6
+    ShellDiameter=1.2 // sub-caliber round, 12mm tungsten core
+    BallisticCoefficient=0.75 //Guesstimate based on lower weight and higher velocity of shell
+
+    //Damage
+    bShatterProne=true
+    ImpactDamage=120
+    ShellImpactDamage=class'DH_Vehicles.DH_Sdkfz2341CannonShellDamageAP'
+    HullFireChance=0.20 // Slightly increased fire chances due to incendiary characteristics of projectile
+    EngineFireChance=0.35
+
+    Damage=50 //no explosive filler in 20mm PzGr -- this damage is just to simulate some splinters flying
+    DamageRadius=120
+
+    //Effects
+    DrawScale=0.75
+    CoronaClass=class'DH_Effects.DHShellTracer_Orange'
+    ShellTrailClass=class'DH_Effects.DH20mmShellTrail_Red'
+
+    ShellShatterEffectClass=class'DH_Effects.DHShellShatterEffect_Small'
+    ShellDeflectEffectClass=class'ROEffects.TankAPHitDeflect'
+    ShellHitVehicleEffectClass=class'DH_Effects.DH20mmAPHitPenetrate'
+    ShellHitDirtEffectClass=class'DH_Effects.DH20mmAPHitDirtEffect'
+    ShellHitSnowEffectClass=class'DH_Effects.DH20mmAPHitSnowEffect'
+    ShellHitWoodEffectClass=class'DH_Effects.DH20mmAPHitWoodEffect'
+    ShellHitRockEffectClass=class'DH_Effects.DH20mmAPHitConcreteEffect'
+    ShellHitWaterEffectClass=class'DH_Effects.DHShellSplashEffect'
+
+    ExplosionDecal=class'ROEffects.BulletHoleConcrete'
+    ExplosionDecalSnow=class'ROEffects.BulletHoleSnow'
+
+    //Sounds
+    VehicleDeflectSound=SoundGroup'ProjectileSounds.Bullets.Impact_Metal'
+    VehicleHitSound=SoundGroup'ProjectileSounds.Bullets.PTRD_penetrate'
+    DirtHitSound=SoundGroup'ProjectileSounds.Bullets.Impact_Gravel'
+    RockHitSound=SoundGroup'ProjectileSounds.Bullets.Impact_Gravel'
+    WaterHitSound=SoundGroup'ProjectileSounds.Bullets.Impact_Water'
+    WoodHitSound=SoundGroup'ProjectileSounds.Bullets.Impact_Wood'
+
+    //Penetration
+    DHPenetrationTable(0)=5.8 //100m
+    DHPenetrationTable(1)=4.2 //250
+    DHPenetrationTable(2)=2.4 //500
+    DHPenetrationTable(3)=1.3 //750
+    DHPenetrationTable(4)=0.9 //1000
+    DHPenetrationTable(5)=0.4 //1250
+    DHPenetrationTable(6)=0.2 //1500
+    DHPenetrationTable(7)=0.1 //1750
+    DHPenetrationTable(8)=0.1 //2000
+    DHPenetrationTable(9)=0.1 //2500
+    DHPenetrationTable(10)=0.1 //3000
+
+    //Gunsight adjustments
+    MechanicalRanges(0)=(Range=0,RangeValue=-5.0)
+    MechanicalRanges(1)=(Range=100,RangeValue=10.0) //TODO: Update these for the new shell stats
+    MechanicalRanges(2)=(Range=200,RangeValue=14.0)
+    MechanicalRanges(3)=(Range=300,RangeValue=19.0)
+    MechanicalRanges(4)=(Range=400,RangeValue=26.0)
+    MechanicalRanges(5)=(Range=500,RangeValue=31.0)
+    MechanicalRanges(6)=(Range=600,RangeValue=39.0)
+    MechanicalRanges(7)=(Range=700,RangeValue=46.0)
+    MechanicalRanges(8)=(Range=800,RangeValue=54.0)
+    MechanicalRanges(9)=(Range=900,RangeValue=62.0)
+    MechanicalRanges(10)=(Range=1000,RangeValue=71.0)
+    MechanicalRanges(11)=(Range=1100,RangeValue=79.0)
+    MechanicalRanges(12)=(Range=1200,RangeValue=90.0)
+    bMechanicalAiming=true
+}

--- a/DH_Vehicles/Classes/DH_Sdkfz2341CannonShellAPCR.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz2341CannonShellAPCR.uc
@@ -65,7 +65,7 @@ defaultproperties
 
     //Gunsight adjustments
     MechanicalRanges(0)=(Range=0,RangeValue=-5.0)
-    MechanicalRanges(1)=(Range=100,RangeValue=10.0) //TODO: Update these for the new shell stats
+    MechanicalRanges(1)=(Range=100,RangeValue=10.0)
     MechanicalRanges(2)=(Range=200,RangeValue=14.0)
     MechanicalRanges(3)=(Range=300,RangeValue=19.0)
     MechanicalRanges(4)=(Range=400,RangeValue=26.0)

--- a/DH_Vehicles/Classes/DH_Sdkfz2341CannonShellHE.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz2341CannonShellHE.uc
@@ -17,8 +17,8 @@ defaultproperties
     //Damage
     ImpactDamage=200
     ShellImpactDamage=class'DH_Vehicles.DH_Sdkfz2341CannonShellDamageHE'
-    Damage=80.0 // 6.2g PETN
-    DamageRadius=482.0
+    Damage=110.0 // 6.2g PETN
+    DamageRadius=375.0
     MyDamageType=class'DH_Engine.DHShellHE20mmDamageType'
     HullFireChance=0.25
     EngineFireChance=0.35

--- a/DH_Vehicles/Classes/DH_Sdkfz2341CannonShellHE.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz2341CannonShellHE.uc
@@ -17,7 +17,7 @@ defaultproperties
     //Damage
     ImpactDamage=200
     ShellImpactDamage=class'DH_Vehicles.DH_Sdkfz2341CannonShellDamageHE'
-    Damage=110.0 // 6.2g PETN
+    Damage=80.0 // 6.2g PETN
     DamageRadius=375.0
     MyDamageType=class'DH_Engine.DHShellHE20mmDamageType'
     HullFireChance=0.25
@@ -39,7 +39,7 @@ defaultproperties
     ExplosionDecal=class'ROEffects.GrenadeMark'
     ExplosionDecalSnow=class'ROEffects.GrenadeMarkSnow'
 
-    BlurTime=3.0
+    BlurTime=1.9
     BlurEffectScalar=1.3
     PenetrationMag=110.0
 
@@ -62,7 +62,7 @@ defaultproperties
     MechanicalRanges(0)=(Range=0,RangeValue=-2.0)
     MechanicalRanges(1)=(Range=100,RangeValue=11.0)
     MechanicalRanges(2)=(Range=200,RangeValue=18.0)
-    MechanicalRanges(3)=(Range=300,RangeValue=25.0)
+    MechanicalRanges(3)=(Range=300,RangeValue=26.0)
     MechanicalRanges(4)=(Range=400,RangeValue=35.0)
     MechanicalRanges(5)=(Range=500,RangeValue=42.0)
     MechanicalRanges(6)=(Range=600,RangeValue=52.0)

--- a/DH_Vehicles/Classes/DH_Sdkfz2341CannonShellHE.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz2341CannonShellHE.uc
@@ -9,16 +9,16 @@ defaultproperties
 {
     bNetTemporary=true // so is torn off straight after actor replication, like a bullet instead of a shell, due to volume of fire adding to net load (each shell is a net channel)
 
-    Speed=47075.0
-    MaxSpeed=47075.0
+    Speed=53592.58
+    MaxSpeed=53592.58
     ShellDiameter=2.0
-    BallisticCoefficient=0.68 //G1 figure based on JBM calculation for US M95 20mm AP
+    BallisticCoefficient=0.70 //G1 figure based on JBM calculation for US M95 20mm AP
 
     //Damage
     ImpactDamage=200
     ShellImpactDamage=class'DH_Vehicles.DH_Sdkfz2341CannonShellDamageHE'
-    Damage=75.0 //10.2 gr of TNT
-    DamageRadius=250
+    Damage=80.0 // 6.2g PETN
+    DamageRadius=482.0
     MyDamageType=class'DH_Engine.DHShellHE20mmDamageType'
     HullFireChance=0.25
     EngineFireChance=0.35
@@ -39,8 +39,8 @@ defaultproperties
     ExplosionDecal=class'ROEffects.GrenadeMark'
     ExplosionDecalSnow=class'ROEffects.GrenadeMarkSnow'
 
-    BlurTime=2.0
-    BlurEffectScalar=0.9
+    BlurTime=3.0
+    BlurEffectScalar=1.3
     PenetrationMag=110.0
 
     //Sound
@@ -59,17 +59,18 @@ defaultproperties
     DHPenetrationTable(7)=0.1
 
     //Gunsights adjustment
-    MechanicalRanges(1)=(Range=100,RangeValue=33.0)
-    MechanicalRanges(2)=(Range=200,RangeValue=37.0)
-    MechanicalRanges(3)=(Range=300,RangeValue=41.0)
-    MechanicalRanges(4)=(Range=400,RangeValue=48.0)
-    MechanicalRanges(5)=(Range=500,RangeValue=56.0)
-    MechanicalRanges(6)=(Range=600,RangeValue=64.0)
-    MechanicalRanges(7)=(Range=700,RangeValue=76.0)
-    MechanicalRanges(8)=(Range=800,RangeValue=87.0)
-    MechanicalRanges(9)=(Range=900,RangeValue=97.0)
-    MechanicalRanges(10)=(Range=1000,RangeValue=109.0)
-    MechanicalRanges(11)=(Range=1100,RangeValue=122.0)
-    MechanicalRanges(12)=(Range=1200,RangeValue=131.0)
+    MechanicalRanges(0)=(Range=0,RangeValue=-2.0)
+    MechanicalRanges(1)=(Range=100,RangeValue=11.0)
+    MechanicalRanges(2)=(Range=200,RangeValue=18.0)
+    MechanicalRanges(3)=(Range=300,RangeValue=25.0)
+    MechanicalRanges(4)=(Range=400,RangeValue=35.0)
+    MechanicalRanges(5)=(Range=500,RangeValue=42.0)
+    MechanicalRanges(6)=(Range=600,RangeValue=52.0)
+    MechanicalRanges(7)=(Range=700,RangeValue=61.0)
+    MechanicalRanges(8)=(Range=800,RangeValue=73.0)
+    MechanicalRanges(9)=(Range=900,RangeValue=85.0)
+    MechanicalRanges(10)=(Range=1000,RangeValue=100.0)
+    MechanicalRanges(11)=(Range=1100,RangeValue=116.0)
+    MechanicalRanges(12)=(Range=1200,RangeValue=132.0)
     bMechanicalAiming=true
 }


### PR DESCRIPTION
Sd.Kfz. 234/1 Changes:

- Added new Pzgr. 40 APCR shell as a limited availability ammo option for the 234/1 (replaces the old mixed mag ammo type).
- Renamed cannon shell types appropriately.
- Tweaked 234/1 HE shell to better reflect real life characteristics.