### PR TITLE
Panther D and G side armor change

### DIFF
--- a/DH_Vehicles/Classes/DH_PantherDTank.uc
+++ b/DH_Vehicles/Classes/DH_PantherDTank.uc
@@ -52,9 +52,9 @@ defaultproperties
     // Hull armor
     FrontArmor(0)=(Thickness=6.5,Slope=-55.0,MaxRelativeHeight=-8.0,LocationName="lower")
     FrontArmor(1)=(Thickness=8.5,Slope=55.0,LocationName="upper")
-    RightArmor(0)=(Thickness=4.5,MaxRelativeHeight=23.0,LocationName="lower")
+    RightArmor(0)=(Thickness=4.0,MaxRelativeHeight=23.0,LocationName="lower")
     RightArmor(1)=(Thickness=4.0,Slope=30.0,LocationName="upper")
-    LeftArmor(0)=(Thickness=4.5,MaxRelativeHeight=23.0,LocationName="lower")
+    LeftArmor(0)=(Thickness=4.0,MaxRelativeHeight=23.0,LocationName="lower")
     LeftArmor(1)=(Thickness=4.0,Slope=30.0,LocationName="upper")
     RearArmor(0)=(Thickness=4.0,Slope=-30.0)
 

--- a/DH_Vehicles/Classes/DH_PantherGTank.uc
+++ b/DH_Vehicles/Classes/DH_PantherGTank.uc
@@ -12,9 +12,9 @@ defaultproperties
     PassengerWeapons(0)=(WeaponPawnClass=class'DH_Vehicles.DH_PantherGCannonPawn')
     FrontArmor(0)=(Thickness=6.2)
     FrontArmor(1)=(Thickness=8.2)
-    RightArmor(0)=(Thickness=5.0)
+    RightArmor(0)=(Thickness=4.0)
     RightArmor(1)=(Thickness=5.0,Slope=30.0)
-    LeftArmor(0)=(Thickness=5.0)
+    LeftArmor(0)=(Thickness=4.0)
     LeftArmor(1)=(Thickness=5.0,Slope=30.0)
 
     // Damage


### PR DESCRIPTION
Changed the values of panther D and G variants side armor to reflect real world thickness of 40mm.

This change will mostly effect the interactions between the PTRD AT rifle and the panthers. In real life, panthers were vulnerable to these rounds, which is the main reason schurzen was fitten to them. 

Note: currently schurzen on the panther G is random, and it doesn't follow the normal schurzen system (blocking bullet actors) so this should only be approved after a change like that is implemented. 