### PR TITLE
[Squads] Squad leader promotions are now opt-in

### DIFF
--- a/DH_Engine/Classes/DHCommandMenu_SquadManageMember.uc
+++ b/DH_Engine/Classes/DHCommandMenu_SquadManageMember.uc
@@ -65,7 +65,7 @@ function OnSelect(int OptionIndex, vector Location, optional vector HitNormal)
                     PC.ServerSquadKick(OtherPRI);
                     break;
                 case 1: // Promote to leader
-                    PC.ServerSquadPromote(OtherPRI);
+                    PC.ServerSendSquadPromotionRequest(OtherPRI);
                     break;
                 case 2: // Ban from squad
                     PC.ServerSquadBan(OtherPRI);

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -205,12 +205,13 @@ replication
         ServerAddMapMarker, ServerRemoveMapMarker,
         ServerSquadCreate, ServerSquadRename,
         ServerSquadJoin, ServerSquadJoinAuto, ServerSquadLeave,
-        ServerSquadInvite, ServerSendSquadPromotionRequest, ServerSquadKick, ServerSquadBan,
+        ServerSquadInvite, ServerSquadKick, ServerSquadBan,
         ServerSquadMakeAssistant, ServerSendVote,
         ServerSquadSay, ServerCommandSay, ServerSquadLock, ServerSignal,
         ServerSquadSpawnRallyPoint, ServerSquadDestroyRallyPoint, ServerSquadSwapRallyPoints,
         ServerSetPatronTier, ServerSquadLeaderVolunteer, ServerForgiveLastFFKiller,
         ServerSendSquadMergeRequest, ServerAcceptSquadMergeRequest, ServerDenySquadMergeRequest,
+        ServerSendSquadPromotionRequest, ServerAcceptSquadPromotionRequest, ServerDenySquadPromotionRequest,
         ServerSquadVolunteerToAssist,
         ServerPunishLastFFKiller, ServerRequestArtillery, ServerCancelArtillery, /*ServerVote,*/
         ServerDoLog, ServerLeaveBody, ServerPossessBody, ServerDebugObstacles, ServerLockWeapons, // these ones in debug mode only
@@ -6965,6 +6966,14 @@ function ServerDenySquadMergeRequest(int SquadMergeRequestID)
     }
 }
 
+function ServerAcceptSquadPromotionRequest(int SquadMergeRequestID)
+{
+    if (SquadReplicationInfo != none)
+    {
+        SquadReplicationInfo.AcceptSquadPromotionRequest(self, SquadMergeRequestID);
+    }
+}
+
 function ServerDenySquadPromotionRequest(int SquadPromotionRequestID)
 {
     if (SquadReplicationInfo != none)
@@ -7302,7 +7311,7 @@ exec function IpFuzz(int Iterations)
     }
 }
 
-simulated function bool GetEyeTraceLocation(out vector HitLocation, out vector HitNormal, optional out Actor HitActor)
+simulated function GetEyeTraceLocation(out vector HitLocation, out vector HitNormal, optional out Actor HitActor)
 {
     local vector TraceStart, TraceEnd;
     local Actor A;

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -227,7 +227,7 @@ replication
         ClientTeamKillPrompt, ClientOpenLogFile, ClientLogToFile, ClientCloseLogFile,
         ClientSquadAssistantVolunteerPrompt,
         ClientReceiveSquadMergeRequest, ClientSendSquadMergeRequestResult,
-        ClientReceiveSquadPromotionRequest,
+        ClientReceiveSquadPromotionRequest, ClientSendSquadPromotionRequestResult,
         ClientTeamSurrenderResponse,
         ClientReceiveVotePrompt, ClientSetMapMarkerClassLock,
         ClientAddPersonalMapMarker;
@@ -5833,12 +5833,15 @@ function ServerSquadLock(bool bIsLocked)
 function ServerSendSquadPromotionRequest(DHPlayerReplicationInfo Recipient)
 {
     local DHPlayerReplicationInfo PRI;
+    local DHSquadReplicationInfo.ESquadPromotionRequestResult Result;
 
     PRI = DHPlayerReplicationInfo(PlayerReplicationInfo);
 
     if (SquadReplicationInfo != none && PRI != none)
     {
-        SquadReplicationInfo.SendSquadPromotionRequest(PRI, Recipient, GetTeamNum(), PRI.SquadIndex);
+        Result = SquadReplicationInfo.SendSquadPromotionRequest(PRI, Recipient, GetTeamNum(), PRI.SquadIndex);
+
+        ClientSendSquadPromotionRequestResult(Result);
     }
 }
 
@@ -6997,6 +7000,8 @@ function ClientReceiveSquadMergeRequest(int SquadMergeRequestID, string SenderPl
     Player.InteractionMaster.AddInteraction("DH_Engine.DHSquadMergeRequestInteraction", Player);
 }
 
+
+// Squad Promotion Requests
 function ClientReceiveSquadPromotionRequest(int SquadPromotionRequestID, string SenderPlayerName, string SenderSquadName)
 {
     if (bIgnoreSquadPromotionRequestPrompts)
@@ -7030,6 +7035,27 @@ function ClientSendSquadMergeRequestResult(DHSquadReplicationInfo.ESquadMergeReq
     if (Page != none)
     {
         Page.OnMessage("SQUAD_MERGE_REQUEST_RESULT", int(Result));
+    }
+}
+
+function ClientSendSquadPromotionRequestResult(DHSquadReplicationInfo.ESquadPromotionRequestResult Result)
+{
+    local UT2K4GUIController GUIController;
+    local GUIPage Page;
+
+    // Find the currently open ROGUIRoleSelection menu and notify it
+    GUIController = UT2K4GUIController(Player.GUIController);
+
+    if (GUIController == none)
+    {
+        return;
+    }
+
+    Page = GUIController.FindMenuByClass(class'GUIPage');
+
+    if (Page != none)
+    {
+        Page.OnMessage("SQUAD_PROMOTION_REQUEST_RESULT", int(Result));
     }
 }
 

--- a/DH_Engine/Classes/DHSquadMessage.uc
+++ b/DH_Engine/Classes/DHSquadMessage.uc
@@ -63,6 +63,7 @@ var localized string SquadTargetSelectionRefused;
 var localized string SquadPromotionRequestDeniedMessage;
 var localized string SquadPromotionRequestAcceptedMessage;
 var localized string SquadPromotionRequestSentMessage;
+var localized string SquadPromotionRequestDuplicateMessage;
 
 static function string GetString(optional int S, optional PlayerReplicationInfo RelatedPRI_1, optional PlayerReplicationInfo RelatedPRI_2, optional Object OptionalObject)
 {
@@ -208,6 +209,8 @@ static function string GetString(optional int S, optional PlayerReplicationInfo 
             return Repl(default.SquadPromotionRequestAcceptedMessage, "{0}", RelatedPRI_1.PlayerName);
         case 84:
             return Repl(default.SquadPromotionRequestSentMessage, "{0}", RelatedPRI_1.PlayerName);
+        case 85:
+            return Repl(default.SquadPromotionRequestDuplicateMessage, "{0}", RelatedPRI_1.PlayerName);
         default:
             break;
     }
@@ -275,6 +278,7 @@ defaultproperties
     SquadPromotionRequestDeniedMessage="Your squad leader promotion request was denied by {0}."
     SquadPromotionRequestAcceptedMessage="Your squad leader promotion request was accepted by {0}."
     SquadPromotionRequestSentMessage="A squad leader promotion request has been sent to {0}."
+    SquadPromotionRequestDuplicateMessage="You have already sent {0} a squad promotion request."
 
     bIsSpecial=false
     bIsConsoleMessage=true

--- a/DH_Engine/Classes/DHSquadMessage.uc
+++ b/DH_Engine/Classes/DHSquadMessage.uc
@@ -60,6 +60,9 @@ var localized string SquadMergeRequestDeniedMessage;
 var localized string SquadMergeRequestDeniedGenericMessage;
 var localized string SquadMergeFailedMessage;
 var localized string SquadTargetSelectionRefused;
+var localized string SquadPromotionRequestDeniedMessage;
+var localized string SquadPromotionRequestAcceptedMessage;
+var localized string SquadPromotionRequestSentMessage;
 
 static function string GetString(optional int S, optional PlayerReplicationInfo RelatedPRI_1, optional PlayerReplicationInfo RelatedPRI_2, optional Object OptionalObject)
 {
@@ -199,6 +202,12 @@ static function string GetString(optional int S, optional PlayerReplicationInfo 
             return default.RallyPointBehindEnemyLines;
         case 81:
             return default.SquadTargetSelectionRefused;
+        case 82:
+            return Repl(default.SquadPromotionRequestDeniedMessage, "{0}", RelatedPRI_1.PlayerName);
+        case 83:
+            return Repl(default.SquadPromotionRequestAcceptedMessage, "{0}", RelatedPRI_1.PlayerName);
+        case 84:
+            return Repl(default.SquadPromotionRequestSentMessage, "{0}", RelatedPRI_1.PlayerName);
         default:
             break;
     }
@@ -263,6 +272,9 @@ defaultproperties
     SquadMergeRequestDeniedGenericMessage="Your squad merge was denied."
     SquadMergeFailedMessage="The squad merge failed,"
     SquadTargetSelectionRefused="You are an artillery spotter. You cannot switch the active artillery target to your own marker."
+    SquadPromotionRequestDeniedMessage="Your squad leader promotion request was denied by {0}."
+    SquadPromotionRequestAcceptedMessage="Your squad leader promotion request was accepted by {0}."
+    SquadPromotionRequestSentMessage="A squad leader promotion request has been sent to {0}."
 
     bIsSpecial=false
     bIsConsoleMessage=true

--- a/DH_Engine/Classes/DHSquadPromotionRequestInteraction.uc
+++ b/DH_Engine/Classes/DHSquadPromotionRequestInteraction.uc
@@ -28,13 +28,13 @@ function OnOptionSelected(int Index)
         switch (Index)
         {
             case 0: // Accept
-                PC.ServerAcceptSquadMergeRequest(default.SquadPromotionRequestID);
+                PC.ServerAcceptSquadPromotionRequest(default.SquadPromotionRequestID);
                 break;
             case 1: // Decline
-                PC.ServerDenySquadMergeRequest(default.SquadPromotionRequestID);
+                PC.ServerDenySquadPromotionRequest(default.SquadPromotionRequestID);
                 break;
             case 2: // Ignore All
-                PC.ServerDenySquadMergeRequest(default.SquadPromotionRequestID);
+                PC.ServerDenySquadPromotionRequest(default.SquadPromotionRequestID);
                 PC.bIgnoreSquadPromotionRequestPrompts = true;
                 break;
         }

--- a/DH_Engine/Classes/DHSquadPromotionRequestInteraction.uc
+++ b/DH_Engine/Classes/DHSquadPromotionRequestInteraction.uc
@@ -45,7 +45,7 @@ function OnOptionSelected(int Index)
 
 defaultproperties
 {
-    PromptText="{0} has offered to promote you to squad leader of {1} squad."
+    PromptText="{0} wants to promote you to leader of {1} squad."
     Options(0)=(Key=IK_F5,Text="Accept")
     Options(1)=(Key=IK_F2,Text="Decline")
     Options(2)=(Key=IK_F3,Text="Ignore All")

--- a/DH_Engine/Classes/DHSquadPromotionRequestInteraction.uc
+++ b/DH_Engine/Classes/DHSquadPromotionRequestInteraction.uc
@@ -1,0 +1,52 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHSquadPromotionRequestInteraction extends DHPromptInteraction;
+
+var int SquadPromotionRequestID;
+var string SenderPlayerName;
+var string SenderSquadName;
+
+function Initialized()
+{
+    super.Initialized();
+
+    PromptText = Repl(PromptText, "{0}", default.SenderPlayerName);
+    PromptText = Repl(PromptText, "{1}", class'GameInfo'.static.MakeColorCode(class'DHColor'.default.SquadColor) $ default.SenderSquadName $ class'GameInfo'.static.MakeColorCode(class'UColor'.default.White));
+}
+
+function OnOptionSelected(int Index)
+{
+    local DHPlayer PC;
+
+    PC = DHPlayer(ViewportOwner.Actor);
+
+    if (PC != none)
+    {
+        switch (Index)
+        {
+            case 0: // Accept
+                PC.ServerAcceptSquadMergeRequest(default.SquadPromotionRequestID);
+                break;
+            case 1: // Decline
+                PC.ServerDenySquadMergeRequest(default.SquadPromotionRequestID);
+                break;
+            case 2: // Ignore All
+                PC.ServerDenySquadMergeRequest(default.SquadPromotionRequestID);
+                PC.bIgnoreSquadPromotionRequestPrompts = true;
+                break;
+        }
+    }
+
+    Master.RemoveInteraction(self);
+}
+
+defaultproperties
+{
+    PromptText="{0} has offered to promote you to squad leader of {1} squad."
+    Options(0)=(Key=IK_F5,Text="Accept")
+    Options(1)=(Key=IK_F2,Text="Decline")
+    Options(2)=(Key=IK_F3,Text="Ignore All")
+}

--- a/DH_Engine/Classes/DHSquadPromotionRequestInteraction.uc
+++ b/DH_Engine/Classes/DHSquadPromotionRequestInteraction.uc
@@ -14,7 +14,9 @@ function Initialized()
     super.Initialized();
 
     PromptText = Repl(PromptText, "{0}", default.SenderPlayerName);
-    PromptText = Repl(PromptText, "{1}", class'GameInfo'.static.MakeColorCode(class'DHColor'.default.SquadColor) $ default.SenderSquadName $ class'GameInfo'.static.MakeColorCode(class'UColor'.default.White));
+    PromptText = Repl(PromptText, "{1}", class'GameInfo'.static.MakeColorCode(class'DHColor'.default.SquadColor) $
+                                         default.SenderSquadName $
+                                         class'GameInfo'.static.MakeColorCode(class'UColor'.default.White));
 }
 
 function OnOptionSelected(int Index)

--- a/DH_Engine/Classes/DHSquadReplicationInfo.uc
+++ b/DH_Engine/Classes/DHSquadReplicationInfo.uc
@@ -75,6 +75,7 @@ struct SquadLeaderDraw
 };
 var array<SquadLeaderDraw>          SquadLeaderDraws;
 
+// Squads Bans
 struct SquadBan
 {
     var int TeamIndex;
@@ -83,6 +84,7 @@ struct SquadBan
 };
 var array<SquadBan>                 SquadBans;
 
+// Squad Merge Requests
 enum ESquadMergeRequestResult
 {
     RESULT_Throttled,
@@ -3031,6 +3033,16 @@ function int GetSquadMergeRequestIndexByID(int ID)
     }
 
     return -1;
+}
+
+function bool DenySquadPromotionRequest(DHPlayer SenderPC, int SquadPromotionRequestID)
+{
+    //
+}
+
+function bool AcceptSquadPromotionRequest(DHPlayer SenderPC, int SquadPromotionRequestID)
+{
+    // 
 }
 
 function bool DenySquadMergeRequest(DHPlayer SenderPC, int SquadMergeRequestID)

--- a/DH_Engine/Classes/DHSquadReplicationInfo.uc
+++ b/DH_Engine/Classes/DHSquadReplicationInfo.uc
@@ -3234,8 +3234,8 @@ function int GetSquadPromotionRequestIndexByID(int SquadPromotionRequestID)
 function bool IsSquadPromotionRequestValid(SquadPromotionRequest SPR)
 {
     return IsSquadActive(SPR.TeamIndex, SPR.SquadIndex) &&
-        IsInSquad(SPR.Recipient, SPR.TeamIndex, SPR.SquadIndex) &&
-        !IsSquadLeader(SPR.Recipient, SPR.TeamIndex, SPR.SquadIndex);
+           IsInSquad(SPR.Recipient, SPR.TeamIndex, SPR.SquadIndex) &&
+           !IsSquadLeader(SPR.Recipient, SPR.TeamIndex, SPR.SquadIndex);
 }
 
 function bool DenySquadPromotionRequest(DHPlayer SenderPC, int SquadPromotionRequestID)

--- a/DH_Interface/Classes/DHContextMenu_SquadMembers.uc
+++ b/DH_Interface/Classes/DHContextMenu_SquadMembers.uc
@@ -197,7 +197,7 @@ protected function ProcessEntry(int EntryIndex, GUIComponent Component)
             return;
 
         case 4:
-            PC.ServerSquadPromote(SelectedPRI);
+            PC.ServerSendSquadPromotionRequest(SelectedPRI);
             return;
 
         case 5:
@@ -263,7 +263,7 @@ protected function ProcessEntry(int EntryIndex, GUIComponent Component)
                 return;
 
             case 14:
-                PC.ServerSquadPromote(SelectedPRI);
+                PC.ServerSendSquadPromotionRequest(SelectedPRI);
                 return;
 
             case 15:

--- a/DH_Interface/Classes/DHDeployMenu.uc
+++ b/DH_Interface/Classes/DHDeployMenu.uc
@@ -1217,6 +1217,11 @@ function InternalOnMessage(coerce string Msg, float MsgLife)
         MessageText = class'DHSquadReplicationInfo'.static.GetSquadMergeRequestResultString(Result);
         Controller.ShowQuestionDialog(MessageText, QBTN_OK, QBTN_OK);
     }
+    else if (Msg ~= "SQUAD_PROMOTION_REQUEST_RESULT")
+    {
+        MessageText = class'DHSquadReplicationInfo'.static.GetSquadPromotionRequestResultString(Result);
+        Controller.ShowQuestionDialog(MessageText, QBTN_OK, QBTN_OK);
+    }
 
     SetButtonsEnabled(true);
 }


### PR DESCRIPTION
When a squad leader promotes a squad member to squad leader, the squad member must now accept it. This is to top malicious or careless squad leaders from just dumping the squad leader role on someone unwilling, potentially invalidating their selected role and putting them in a position of responsibility that they didn't ask for.