### PR TITLE
Indicate squads without rally points

### DIFF
--- a/DH_Engine/Classes/DHPlayerReplicationInfo.uc
+++ b/DH_Engine/Classes/DHPlayerReplicationInfo.uc
@@ -50,12 +50,14 @@ var     localized string        AssistantAbbreviation;
 var     int                     CountryIndex;
 var     int                     PlayerIQ;
 
+var     int                     NoRallyPointsTime; // Time when SL lost all rally points
+
 replication
 {
     // Variables the server will replicate to all clients
     reliable if (bNetDirty && Role == ROLE_Authority)
         SquadIndex, SquadMemberIndex, PatronTier, bIsDeveloper, DHKills, bIsSquadAssistant,
-        TotalScore, CategoryScores, CountryIndex, PlayerIQ;
+        TotalScore, CategoryScores, CountryIndex, PlayerIQ, NoRallyPointsTime;
 }
 
 simulated function string GetNamePrefix()

--- a/DH_Engine/Classes/DHSpawnPoint_SquadRallyPoint.uc
+++ b/DH_Engine/Classes/DHSpawnPoint_SquadRallyPoint.uc
@@ -508,11 +508,6 @@ function AwardScoreOnEstablishment()
 
 function Destroyed()
 {
-    if (SRI != none)
-    {
-        SRI.OnSquadRallyPointDestroyed(self);
-    }
-
     super.Destroyed();
 
     if (MetricsObject != none)
@@ -523,6 +518,11 @@ function Destroyed()
     if (ResupplyAttachment != none)
     {
         ResupplyAttachment.Destroy();
+    }
+
+    if (SRI != none)
+    {
+        SRI.OnSquadRallyPointDestroyed(self);
     }
 }
 

--- a/DH_Engine/Classes/DHSquadReplicationInfo.uc
+++ b/DH_Engine/Classes/DHSquadReplicationInfo.uc
@@ -3152,6 +3152,11 @@ function UpdateSquadLeaderNoRallyPointsTime(int TeamIndex, int SquadIndex)
 {
     local DHPlayerReplicationInfo SL;
 
+    if (!bAreRallyPointsEnabled)
+    {
+	return;
+    }
+
     SL = GetSquadLeader(TeamIndex, SquadIndex);
 
     if (SL != none && GRI != none && GetSquadRallyPointCount(TeamIndex, SquadIndex) == 0)
@@ -3167,6 +3172,11 @@ simulated function bool SquadHadNoRallyPointsInAwhile(int TeamIndex, int SquadIn
 {
     local DHGameReplicationInfo MyGRI;
     local DHPlayerReplicationInfo SL;
+
+    if (!bAreRallyPointsEnabled)
+    {
+	return false;
+    }
 
     MyGRI = GetGameReplicationInfo();
     SL = GetSquadLeader(TeamIndex, SquadIndex);

--- a/DH_Engine/Classes/DHSquadReplicationInfo.uc
+++ b/DH_Engine/Classes/DHSquadReplicationInfo.uc
@@ -1948,6 +1948,11 @@ function SetSquadNextRallyPointTime(int TeamIndex, int SquadIndex, int ElapsedTi
     }
 }
 
+simulated function bool SquadHasRallyPoint(int TeamIndex, int SquadIndex)
+{
+    return GetSquadRallyPointCount(TeamIndex, SquadIndex) > 0;
+}
+
 simulated function int GetSquadRallyPointCount(int TeamIndex, int SquadIndex)
 {
     local int i, Count;
@@ -1956,7 +1961,8 @@ simulated function int GetSquadRallyPointCount(int TeamIndex, int SquadIndex)
     {
         if (RallyPoints[i] != none &&
             RallyPoints[i].GetTeamIndex() == TeamIndex &&
-            RallyPoints[i].SquadIndex == SquadIndex)
+            RallyPoints[i].SquadIndex == SquadIndex &&
+            !RallyPoints[i].bPendingDelete)
         {
             ++Count;
         }
@@ -3159,7 +3165,7 @@ function UpdateSquadLeaderNoRallyPointsTime(int TeamIndex, int SquadIndex)
 
     SL = GetSquadLeader(TeamIndex, SquadIndex);
 
-    if (SL != none && GRI != none && GetSquadRallyPointCount(TeamIndex, SquadIndex) == 0)
+    if (SL != none && GRI != none && !SquadHasRallyPoint(TeamIndex, SquadIndex))
     {
         SL.NoRallyPointsTime = GRI.ElapsedTime;
     }
@@ -3184,7 +3190,7 @@ simulated function bool SquadHadNoRallyPointsInAwhile(int TeamIndex, int SquadIn
     return SL != none &&
            MyGRI != none &&
            MyGRI.ElapsedTime >= SL.NoRallyPointsTime + SquadLeaderRallyPointInactivityThreshold &&
-           GetSquadRallyPointCount(TeamIndex, SquadIndex) == 0;
+           !SquadHasRallyPoint(TeamIndex, SquadIndex);
 }
 
 defaultproperties

--- a/DH_Engine/Classes/DHSquadReplicationInfo.uc
+++ b/DH_Engine/Classes/DHSquadReplicationInfo.uc
@@ -3154,7 +3154,7 @@ function UpdateSquadLeaderNoRallyPointsTime(int TeamIndex, int SquadIndex)
 
     if (!bAreRallyPointsEnabled)
     {
-	return;
+        return;
     }
 
     SL = GetSquadLeader(TeamIndex, SquadIndex);
@@ -3175,7 +3175,7 @@ simulated function bool SquadHadNoRallyPointsInAwhile(int TeamIndex, int SquadIn
 
     if (!bAreRallyPointsEnabled)
     {
-	return false;
+        return false;
     }
 
     MyGRI = GetGameReplicationInfo();

--- a/DH_Interface/Classes/DHDeployMenu.uc
+++ b/DH_Interface/Classes/DHDeployMenu.uc
@@ -1639,6 +1639,7 @@ function UpdateSquads()
             SetVisible(C.b_LeaveSquad, false);
             SetVisible(C.b_LockSquad, false);
             SetVisible(C.i_LockSquad, false);
+            SetVisible(C.i_NoRallyPoints, false);
         }
 
         return;
@@ -1697,6 +1698,7 @@ function UpdateSquads()
         SetVisible(C.b_LeaveSquad, bIsInSquad);
         SetVisible(C.b_LockSquad, bIsSquadLeader);
         SetVisible(C.i_LockSquad, bIsSquadLocked || bIsSquadLeader);
+        SetVisible(C.i_NoRallyPoints, SRI.SquadHadNoRallyPointsInAwhile(TeamIndex, i));
 
         if (bIsSquadLeader)
         {
@@ -1788,6 +1790,7 @@ function UpdateSquads()
         SetVisible(C.b_LockSquad, false);
         SetVisible(C.i_LockSquad, false);
         SetVisible(C.eb_SquadName, false);
+        SetVisible(C.i_NoRallyPoints, false);
     }
 
     while (j < p_Squads.SquadComponents.Length - 1)
@@ -1820,6 +1823,7 @@ function UpdateSquads()
         SetVisible(C.b_LeaveSquad, false);
         SetVisible(C.b_LockSquad, false);
         SetVisible(C.i_LockSquad, false);
+        SetVisible(C.i_NoRallyPoints, false);
 
         SavedPRI = DHPlayerReplicationInfo(C.li_Members.GetObject());
 

--- a/DH_Interface/Classes/DHGUISquadComponent.uc
+++ b/DH_Interface/Classes/DHGUISquadComponent.uc
@@ -209,7 +209,7 @@ defaultproperties
         RenderWeight=10.0
         bAcceptsInput=true
         ToolTip=NoRallyPointsImageTooltip
-        Hint="This squad had no rally points in a while. Respawn options will be limited!"
+        Hint="This squad has had no rally points in a while. Deployment options may be limited!"
     End Object
     i_NoRallyPoints=NoRallyPointsImage
 

--- a/DH_Interface/Classes/DHGUISquadComponent.uc
+++ b/DH_Interface/Classes/DHGUISquadComponent.uc
@@ -190,20 +190,26 @@ defaultproperties
     End Object
     i_LockSquad=LockSquadImage
 
+    Begin Object Class=GUIToolTip Name=NoRallyPointsImageTooltip
+    End Object
+
     Begin Object class=GUIImage Name=NoRallyPointsImage
         WinWidth=0.15
         WinHeight=0.075
-        WinLeft=0.8
+        WinLeft=0.76
         WinTop=0.05
-        Image=Texture'DH_InterfaceArt2_tex.Icons.rally_point'
-        ImageColor=(R=255,G=0,B=0,A=255)
+        Image=Texture'DH_InterfaceArt2_tex.Icons.no_rally_point'
+        ImageColor=(R=255,G=0,B=0,A=200)
         ImageRenderStyle=MSTY_Alpha
         ImageStyle=ISTY_Justified
         ImageAlign=ISTY_Center
         bBoundToParent=true
         bScaleToParent=true
-	bVisible=false
+        bVisible=false
         RenderWeight=10.0
+        bAcceptsInput=true
+        ToolTip=NoRallyPointsImageTooltip
+        Hint="This squad had no rally points in a while. Respawn options will be limited!"
     End Object
     i_NoRallyPoints=NoRallyPointsImage
 

--- a/DH_Interface/Classes/DHGUISquadComponent.uc
+++ b/DH_Interface/Classes/DHGUISquadComponent.uc
@@ -19,6 +19,7 @@ var automated   DHGUIButton         b_LeaveSquad;   // Leaves the squad. Only sh
 var automated   DHGUIButton         b_LockSquad;    // Locks and unlocks the squad. Only show to squad leader.
 var automated   GUIImage            i_LockSquad;
 var automated   GUIImage            i_Locked;       // Show this when the squad is locked an the user is not a member of this squad.
+var automated   GUIImage            i_NoRallyPoints;
 var automated   DHGUIEditBox        eb_SquadName;
 var automated   GUIImage            i_Background;
 
@@ -188,6 +189,23 @@ defaultproperties
         RenderWeight=10.0
     End Object
     i_LockSquad=LockSquadImage
+
+    Begin Object class=GUIImage Name=NoRallyPointsImage
+        WinWidth=0.15
+        WinHeight=0.075
+        WinLeft=0.8
+        WinTop=0.05
+        Image=Texture'DH_InterfaceArt2_tex.Icons.rally_point'
+        ImageColor=(R=255,G=0,B=0,A=255)
+        ImageRenderStyle=MSTY_Alpha
+        ImageStyle=ISTY_Justified
+        ImageAlign=ISTY_Center
+        bBoundToParent=true
+        bScaleToParent=true
+	bVisible=false
+        RenderWeight=10.0
+    End Object
+    i_NoRallyPoints=NoRallyPointsImage
 
     Begin Object class=GUIImage Name=BackgroundImage
         WinWidth=1.0

--- a/DarkestHourDev/Textures/DH_InterfaceArt2_tex.utx
+++ b/DarkestHourDev/Textures/DH_InterfaceArt2_tex.utx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b3fefbab52c596181f277bd628e69ad6003a3ff7870a604ff916750baf22552
-size 1132819
+oid sha256:f6563fb85b416f81e0704aba5161464944d0bc223f66af6b5b7229ddf7575e69
+size 1137033


### PR DESCRIPTION
Added indicators to the squad menu to let players know which squads have bad rally point habits.

The indicator will show up if no rallies are placed in 1 minute after:
1. all squad rally points are lost;
2. new squad leader is assigned.

![20230414071840_1](https://user-images.githubusercontent.com/36604408/231947587-3685fed4-6438-4bcf-beb0-131aeed348c1.jpg)
