### PR TITLE
Faster Reload & Resupply of LeIG18

### DIFF
--- a/DH_Guns/Classes/DH_LeIG18Cannon.uc
+++ b/DH_Guns/Classes/DH_LeIG18Cannon.uc
@@ -49,11 +49,11 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'Vehicle_Weapons.Panzeriii.50mm_fire01'
     CannonFireSound(1)=SoundGroup'Vehicle_Weapons.Panzeriii.50mm_fire02'
     CannonFireSound(2)=SoundGroup'Vehicle_Weapons.Panzeriii.50mm_fire03'
-    ReloadStages(0)=(Sound=Sound'Vehicle_reloads.Reloads.SU_76_Reload_01',Duration=4.0)
-    ReloadStages(1)=(Sound=Sound'Vehicle_reloads.Reloads.SU_76_Reload_02',Duration=4.0)
-    ReloadStages(2)=(Sound=Sound'Vehicle_reloads.Reloads.SU_76_Reload_03',Duration=2.0)
+    ReloadStages(0)=(Sound=Sound'Vehicle_reloads.Reloads.SU_76_Reload_01',Duration=2.0)
+    ReloadStages(1)=(Sound=Sound'Vehicle_reloads.Reloads.SU_76_Reload_02',Duration=2.0)
+    ReloadStages(2)=(Sound=Sound'Vehicle_reloads.Reloads.SU_76_Reload_03',Duration=1.0)
     ReloadStages(3)=(Sound=Sound'Vehicle_reloads.Reloads.SU_76_Reload_04',Duration=1.0)
 
     bIsArtillery=true
-    ResupplyInterval=25.0
+    ResupplyInterval=15.0
 }


### PR DESCRIPTION
changing reload speed to 6 seconds reflecting the 8-12 rpm which it should have. Additionally reduced the 25 second resupply interval to 15, as with 25 + the new reload time, it'd be faster to rebuild the gun rather than wait for it to resupply.