### PR TITLE
Level updates wolfkraut

### DIFF
--- a/DarkestHourDev/Maps/DH-Berezina_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Berezina_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92b4f2be0817e842ce305c86cf9817ed27679f2595c338d12c7206ac160e25de
-size 31633038
+oid sha256:a6cb63a0c3c7b411ef3c8a8cec81039d69269d69b169a6aaef6612dcbd858663
+size 31637865

--- a/DarkestHourDev/Maps/DH-Cholm_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Cholm_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13911b2d48e955f1f7a8c21ac8f1ff372c56d9e62fe6feedd0c15175149549e5
-size 33936681
+oid sha256:f02681e0e0a574450846dea503730cfff4b0e7c07a2fc456aca6f1fcfde5806b
+size 33985354

--- a/DarkestHourDev/Maps/DH-St_Marie_du_Mont_Advance.rom
+++ b/DarkestHourDev/Maps/DH-St_Marie_du_Mont_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9b3175caa5a3d8739b9b752f92a78465e0f997f9b2a5be23e8a6200062c9e55
-size 77163794
+oid sha256:d056ad11f4fc710b8aff4365f23d3de8a40c7c3afa2cc11e5cd0998acb18badc
+size 77205861


### PR DESCRIPTION
Berezina Advance:

- Added 2 Combat Engineer roles for Soviets.
- Reduced max tanks for both teams, Soviets now have 2 tanks active at once, Germans have 3.
- Made BT7, Panzer III and Panzer IV Ausf. F1 spawns unlimited.
- Reduced max active logi trucks for both teams from 3 to 2.
- Implemented gun limit of 6 for Soviet light AT guns.

Cholm Advance:

- Fixed issue where Axis would bleed tickets while still controlling objectives.
- Improved spawn protection minefield around Axis main spawn.
- Added additional cover to Axis main spawn.
- Disabled Karma collision on all wooden fences.

St Marie du Mont Advance:

- Added new Northwestern and Eastern Road objectives, replacing the old Stable objective.
- Added new spawn protection minefields to both teams.
- Added some additional light cover around the Church objective.
- Added artillery triggers to static radios on the map.
- Added additional logi truck spawn for Axis.
- Reduced Axis main spawn cache limit from 8000 to 6000.
- Reworked Axis main spawn protection minefield.
- Reworked Danger Zone influences of all objectives.
- Reduced artillery strikes available to both teams significantly.
- Removed US Autorifleman roles and instead increased LMGs to 2.
- Fixed an off-grid BSP building that caused an invisible wall near the stables.