### PR TITLE
Reload changes

### DIFF
--- a/DH_Vehicles/Classes/DH_BT7Cannon.uc
+++ b/DH_Vehicles/Classes/DH_BT7Cannon.uc
@@ -79,7 +79,7 @@ defaultproperties
     CannonFireSound(0)=SoundGroup'DH_CC_Vehicle_Weapons.45mm.45mmAT_fire01'
     CannonFireSound(1)=SoundGroup'DH_CC_Vehicle_Weapons.45mm.45mmAT_fire02'
     CannonFireSound(2)=SoundGroup'DH_CC_Vehicle_Weapons.45mm.45mmAT_fire03'
-    ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_01')
+    ReloadStages(0)=(Sound=none)
     ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_02')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_03')
     ReloadStages(3)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_04')

--- a/DH_Vehicles/Classes/DH_PanzerIIILCannon.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIIILCannon.uc
@@ -76,8 +76,8 @@ defaultproperties
     CannonFireSound(2)=SoundGroup'Vehicle_Weapons.Panzeriii.50mm_fire03'
     AltFireSoundClass=sound'Inf_Weapons.mg34_p_fire_loop'
     AltFireEndSound=SoundGroup'DH_WeaponSounds.mg34.mg34_fire_end'
-    ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_01')
-    ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_02')
+    ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_1')
+    ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_short_2')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_03')
     ReloadStages(3)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_04')
 

--- a/DH_Vehicles/Classes/DH_StuartCannon.uc
+++ b/DH_Vehicles/Classes/DH_StuartCannon.uc
@@ -73,7 +73,7 @@ defaultproperties
     CannonFireSound(2)=SoundGroup'DH_CC_Vehicle_Weapons.37mm.37mmAT_fire_02'
     AltFireSoundClass=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireLoop01'
     AltFireEndSound=SoundGroup'DH_WeaponSounds.30Cal.30cal_FireEnd01'
-    ReloadStages(0)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_01')
+    ReloadStages(0)=(Sound=none)
     ReloadStages(1)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_02')
     ReloadStages(2)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_03')
     ReloadStages(3)=(Sound=Sound'DH_Vehicle_Reloads.Reloads.reload_01s_04')


### PR DESCRIPTION
-Reduced reload time of "small" caliber tank cannons

_"stuart and bt7 should be cut from ~5 seconds to about 3.8
while panzer 3 L should be about 4.25
which should be about half a second longer than panzer 3 J"_

(all credit goes to AAZ, he created the changes but did not have the drive space in order to change branches at the moment)