### PR TITLE
Combined AT resupply and reload assist into a single action

### DIFF
--- a/DH_Engine/Classes/DHPawn.uc
+++ b/DH_Engine/Classes/DHPawn.uc
@@ -6465,7 +6465,15 @@ simulated function NotifySelected(Pawn User)
 
     if (!P.bUsedCarriedMGAmmo && P.bCarriesExtraAmmo && bWeaponNeedsResupply)
     {
-        P.ReceiveLocalizedMessage(TouchMessageClass, 0, self.PlayerReplicationInfo,, User.Controller);
+        if (bWeaponNeedsReload && bIronSights)
+        {
+            P.ReceiveLocalizedMessage(TouchMessageClass, 2, self.PlayerReplicationInfo,, User.Controller);
+        }
+        else
+        {
+            P.ReceiveLocalizedMessage(TouchMessageClass, 0, self.PlayerReplicationInfo,, User.Controller);
+        }
+
         LastNotifyTime = Level.TimeSeconds;
     }
     else if (bWeaponNeedsReload)

--- a/DH_Engine/Classes/DHPawnTouchMessage.uc
+++ b/DH_Engine/Classes/DHPawnTouchMessage.uc
@@ -38,7 +38,6 @@ defaultproperties
     Messages(0)="Press [%THROWMGAMMO%] to resupply {0}"
     Messages(1)="Press [%THROWMGAMMO%] to reload {0}"
     Messages(2)="Press [%THROWMGAMMO%] to resupply and reload {0}"
-    Messages(3)="Press [%USE%] to request artillery" // this message is unused
     FallbackPlayerName="friendly soldier"
 }
 

--- a/DH_Engine/Classes/DHPawnTouchMessage.uc
+++ b/DH_Engine/Classes/DHPawnTouchMessage.uc
@@ -37,7 +37,8 @@ defaultproperties
 {
     Messages(0)="Press [%THROWMGAMMO%] to resupply {0}"
     Messages(1)="Press [%THROWMGAMMO%] to reload {0}"
-    Messages(2)="Press [%USE%] to request artillery"
+    Messages(2)="Press [%THROWMGAMMO%] to resupply and reload {0}"
+    Messages(3)="Press [%USE%] to request artillery" // this message is unused
     FallbackPlayerName="friendly soldier"
 }
 

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -1172,8 +1172,7 @@ exec function ThrowMGAmmo()
             {
                 ServerThrowMGAmmo(OtherPawn);
             }
-
-            if (OtherPawn.bWeaponNeedsReload)
+            else if (OtherPawn.bWeaponNeedsReload)
             {
                 ServerLoadATAmmo(OtherPawn);
             }
@@ -1185,15 +1184,22 @@ exec function ThrowMGAmmo()
     }
 }
 
+// Resupply the gunner and perform an assisted reload if possible
 function ServerThrowMGAmmo(Pawn Gunner)
 {
-    local DHPawn P;
+    local DHPawn P, OtherP;
 
     P = DHPawn(Pawn);
+    OtherP = DHPawn(Gunner);
 
-    if (P != none && Gunner != none)
+    if (P != none && OtherP != none)
     {
-        P.TossAmmo(Gunner);
+        P.TossAmmo(OtherP);
+
+        if (OtherP.bWeaponNeedsReload)
+        {
+            P.LoadWeapon(OtherP);
+        }
     }
 }
 


### PR DESCRIPTION
When applicable, players can now perform resupply and assisted reload on AT weapons in one key stroke.

This should prevent players from forgetting to double-click the resupply button and run away, which is never a desired outcome.