### PR TITLE
Feature/logi crew roles

### DIFF
--- a/DH_BritishPlayers/Classes/DHCWLogisticCrewRoles.uc
+++ b/DH_BritishPlayers/Classes/DHCWLogisticCrewRoles.uc
@@ -1,0 +1,23 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHCWLogisticCrewRoles extends DHAlliedLogisticCrewRoles
+    abstract;
+
+defaultproperties
+{
+    PrimaryWeapons(0)=(Item=class'DH_Weapons.DH_EnfieldNo4Weapon')
+    Grenades(0)=(Item=class'DH_Weapons.DH_MillsBombWeapon')
+    GivenItems(0)="DH_Equipment.DHShovelItem_US"
+    Headgear(0)=class'DH_BritishPlayers.DH_BritishTurtleHelmet'
+    Headgear(1)=class'DH_BritishPlayers.DH_BritishTurtleHelmetNet'
+    Headgear(2)=class'DH_BritishPlayers.DH_BritishTommyHelmet'
+    HeadgearProbabilities(0)=0.1
+    HeadgearProbabilities(1)=0.1
+    HeadgearProbabilities(2)=0.8
+    VoiceType="DH_BritishPlayers.DHBritishVoice"
+    AltVoiceType="DH_BritishPlayers.DHBritishVoice"
+    SleeveTexture=Texture'DHBritishCharactersTex.Sleeves.brit_sleeves'
+}

--- a/DH_Construction/Classes/DHConstruction_Foxhole.uc
+++ b/DH_Construction/Classes/DHConstruction_Foxhole.uc
@@ -91,7 +91,7 @@ static function float GetTerrainScale(TerrainInfo TI)
 
 static function bool IsPlaceableByPlayer(DHPlayerReplicationInfo PRI)
 {
-    return PRI.IsSLorASL() || PRI.IsPatron();
+    return PRI.IsAbleToConstruct() || PRI.IsPatron();
 }
 
 static function bool IsTerrainScaleLarge(TerrainInfo TI)

--- a/DH_Engine/Classes/DHAlliedLogisticCrewRoles.uc
+++ b/DH_Engine/Classes/DHAlliedLogisticCrewRoles.uc
@@ -1,0 +1,19 @@
+//==============================================================================
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHAlliedLogisticCrewRoles extends DHAlliedRoles
+    abstract;
+
+defaultproperties
+{
+    MyName="Logistic Crew"
+    AltName="Logistic Crew"
+    Article="a "
+    PluralName="Logistic Crew"
+    Limit=3
+    bIsLogiCrew=true
+    bSpawnWithExtraAmmo=false
+}

--- a/DH_Engine/Classes/DHAlliedLogisticCrewRoles.uc
+++ b/DH_Engine/Classes/DHAlliedLogisticCrewRoles.uc
@@ -15,5 +15,7 @@ defaultproperties
     PluralName="Logistic Crew"
     Limit=3
     bIsLogiCrew=true
-    bSpawnWithExtraAmmo=false
+    bCanBeSquadLeader=false
+    bExemptSquadRequirement=true
+    bSpawnWithExtraAmmo=true
 }

--- a/DH_Engine/Classes/DHAxisLogisticCrewRoles.uc
+++ b/DH_Engine/Classes/DHAxisLogisticCrewRoles.uc
@@ -9,10 +9,12 @@ class DHAxisLogisticCrewRoles extends DHAxisRoles
 defaultproperties
 {
     MyName="Logistic Crew"
-    AltName="Pioneer"
+    AltName="Pioneer Besatzung"
     Article="a "
     PluralName="Logistic Crew"
     Limit=3
     bIsLogiCrew=true
-    bSpawnWithExtraAmmo=false
+    bCanBeSquadLeader=false
+    bExemptSquadRequirement=true
+    bSpawnWithExtraAmmo=true
 }

--- a/DH_Engine/Classes/DHAxisLogisticCrewRoles.uc
+++ b/DH_Engine/Classes/DHAxisLogisticCrewRoles.uc
@@ -1,0 +1,18 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHAxisLogisticCrewRoles extends DHAxisRoles
+    abstract;
+
+defaultproperties
+{
+    MyName="Logistic Crew"
+    AltName="Pioneer"
+    Article="a "
+    PluralName="Logistic Crew"
+    Limit=3
+    bIsLogiCrew=true
+    bSpawnWithExtraAmmo=false
+}

--- a/DH_Engine/Classes/DHCommandMenu_SquadLogisticCrew.uc
+++ b/DH_Engine/Classes/DHCommandMenu_SquadLogisticCrew.uc
@@ -1,0 +1,61 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHCommandMenu_SquadLogisticCrew extends DHCommandMenu;
+
+function OnSelect(int OptionIndex, vector Location, optional vector HitNormal)
+{
+    local DHPlayer PC;
+    local DHPlayerReplicationInfo PRI;
+
+    PC = GetPlayerController();
+
+    if (PC == none || OptionIndex < 0 || OptionIndex >= Options.Length)
+    {
+        return;
+    }
+
+    PRI = DHPlayerReplicationInfo(PC.PlayerReplicationInfo);
+
+    switch (OptionIndex)
+    {
+        case 0: // Construction
+            Interaction.PushMenu("DH_Construction.DHCommandMenu_ConstructionGroups");
+            return;
+        default:
+            break;
+    }
+
+    Interaction.Hide();
+}
+
+function bool IsOptionDisabled(int OptionIndex)
+{
+    local DHPlayer PC;
+    local DHGameReplicationInfo GRI;
+
+    PC = GetPlayerController();
+
+    if (PC == none)
+    {
+        return true;
+    }
+
+    GRI = DHGameReplicationInfo(PC.GameReplicationInfo);
+
+    switch (OptionIndex)
+    {
+        case 0: // Construction
+            return DHPawn(PC.Pawn) == none || GRI == none || !GRI.bAreConstructionsEnabled;
+        default:
+            return false;
+    }
+}
+
+defaultproperties
+{
+//    NoPlayerInLineOfSight="No player in sights"
+    Options(0)=(ActionText="Construction",Material=Texture'DH_InterfaceArt2_tex.Icons.construction')
+}

--- a/DH_Engine/Classes/DHConstruction.uc
+++ b/DH_Engine/Classes/DHConstruction.uc
@@ -945,7 +945,7 @@ function static bool ShouldShowOnMenu(DHActorProxy.Context Context)
 
 static function bool IsPlaceableByPlayer(DHPlayerReplicationInfo PRI)
 {
-    return PRI.IsSLorASL();
+    return PRI.IsAbleToConstruct();
 }
 
 // This function is used for determining if a player is able to build this type

--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -1480,7 +1480,7 @@ simulated function EVehicleReservationError GetVehicleReservationError(DHPlayer 
         return ERROR_NoReservations;
     }
 
-    if (VC.default.bRequiresDriverLicense && !DHPlayerReplicationInfo(PC.PlayerReplicationInfo).IsPlayerLicensedToDrive(PC))
+    if (VC.default.bRequiresDriverLicense && !DHPlayerReplicationInfo(PC.PlayerReplicationInfo).IsPlayerLicensedToSpawnDriveVehicle(PC, RI))
     {
         return ERROR_NoLicense;
     }

--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -3992,8 +3992,8 @@ function DrawPlayerIconsOnMap(Canvas C, AbsoluteCoordsInfo SubCoords, float MyMa
         SRI = PC.SquadReplicationInfo;
     }
 
-    // Draw other squad leaders on map
-    if (PRI.IsSLorASL() || PRI.IsRadioman())
+    // Draw other important roles on the map
+    if (PRI.IsRadioman() || PRI.IsAbleToConstruct() || PRI.IsSLorASL() )
     {
         for (i = 0; i < SRI.GetTeamSquadLimit(PC.GetTeamNum()); ++i)
         {

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -2214,6 +2214,15 @@ simulated function bool IsRadioman()
     return RI != none && RI.bCarriesRadio;
 }
 
+simulated function bool IsLogisticCrew()
+{
+    local DHRoleInfo RI;
+
+    RI = DHRoleInfo(GetRoleInfo());
+
+    return RI != none && RI.bIsLogiCrew;
+}
+
 function ServerNotifyRoles(DHPlayerReplicationInfo.ERoleSelector RoleSelector, class<ROCriticalMessage> Message, int MessageIndex, optional Object OptionalObject)
 {
     local int                     TeamIndex, SquadIndex;
@@ -6340,6 +6349,11 @@ function bool GetCommandInteractionMenu(out string MenuClassName, out Object Men
     else if (PRI.bIsSquadAssistant)
     {
         MenuClassName = "DH_Engine.DHCommandMenu_SquadAssistant";
+        return true;
+    }
+    else if (PRI.IsLogisticCrew())
+    {
+        MenuClassName = "DH_Engine.DHCommandMenu_SquadLogisticCrew";
         return true;
     }
     else if (!PRI.IsInSquad())

--- a/DH_Engine/Classes/DHPlayerReplicationInfo.uc
+++ b/DH_Engine/Classes/DHPlayerReplicationInfo.uc
@@ -216,6 +216,11 @@ simulated static function bool IsPlayerLicensedToDrive(DHPlayer C)
     return C != none && DHPlayerReplicationInfo(C.PlayerReplicationInfo) != none && DHPlayerReplicationInfo(C.PlayerReplicationInfo).IsAbleToConstruct();
 }
 
+simulated static function bool IsPlayerLicensedToSpawnDriveVehicle(DHPlayer C, DHRoleInfo RI)
+{
+    return RI.bIsLogiCrew || C != none && DHPlayerReplicationInfo(C.PlayerReplicationInfo) != none && DHPlayerReplicationInfo(C.PlayerReplicationInfo).IsSLorASL();
+}
+
 // Modified to fix bug where the last line was being drawn at top of screen, instead of in vertical sequence, so overwriting info in the 1st screen line
 simulated function DisplayDebug(Canvas Canvas, out float YL, out float YPos)
 {

--- a/DH_Engine/Classes/DHPlayerReplicationInfo.uc
+++ b/DH_Engine/Classes/DHPlayerReplicationInfo.uc
@@ -46,6 +46,7 @@ var     int                     CategoryScores[2];
 
 var     localized string        SquadLeaderAbbreviation;
 var     localized string        AssistantAbbreviation;
+var     localized string        LogisticCrewAbbreviation;
 
 var     int                     CountryIndex;
 var     int                     PlayerIQ;
@@ -56,7 +57,7 @@ replication
 {
     // Variables the server will replicate to all clients
     reliable if (bNetDirty && Role == ROLE_Authority)
-        SquadIndex, SquadMemberIndex, PatronTier, bIsDeveloper, DHKills, bIsSquadAssistant,
+        SquadIndex, SquadMemberIndex, PatronTier, bIsDeveloper, DHKills, bIsSquadAssistant, bIsLogisticCrew,
         TotalScore, CategoryScores, CountryIndex, PlayerIQ, NoRallyPointsTime;
 }
 
@@ -69,6 +70,10 @@ simulated function string GetNamePrefix()
     else if (bIsSquadAssistant)
     {
         return default.AssistantAbbreviation;
+    }
+    else if (IsLogisticCrew()) 
+    {
+        return default.LogisticCrewAbbreviation;
     }
     else if (IsInSquad())
     {
@@ -97,6 +102,11 @@ simulated function bool IsSL()
 simulated function bool IsAssistantLeader()
 {
     return IsInSquad() && bIsSquadAssistant;
+}
+
+simulated function bool IsLogisticCrew()
+{
+    return bIsLogisticCrew;
 }
 
 simulated function bool IsASL()
@@ -264,5 +274,6 @@ defaultproperties
     SquadMemberIndex=-1
     SquadLeaderAbbreviation="SL"
     AssistantAbbreviation="A"
+    LogisticCrewAbbreviation="L"
     CountryIndex=-1
 }

--- a/DH_Engine/Classes/DHPlayerReplicationInfo.uc
+++ b/DH_Engine/Classes/DHPlayerReplicationInfo.uc
@@ -25,7 +25,9 @@ enum ERoleSelector
     ERS_ARTILLERY_SPOTTER,
     ERS_RADIOMAN,
     ERS_ADMIN,
-    ERS_PATRON
+    ERS_PATRON,
+    ERS_LOGISTICCREW,
+
 };
 
 var     EPatronTier             PatronTier;
@@ -57,7 +59,7 @@ replication
 {
     // Variables the server will replicate to all clients
     reliable if (bNetDirty && Role == ROLE_Authority)
-        SquadIndex, SquadMemberIndex, PatronTier, bIsDeveloper, DHKills, bIsSquadAssistant, bIsLogisticCrew,
+        SquadIndex, SquadMemberIndex, PatronTier, bIsDeveloper, DHKills, bIsSquadAssistant,
         TotalScore, CategoryScores, CountryIndex, PlayerIQ, NoRallyPointsTime;
 }
 
@@ -106,7 +108,11 @@ simulated function bool IsAssistantLeader()
 
 simulated function bool IsLogisticCrew()
 {
-    return bIsLogisticCrew;
+    local DHPlayer PC;
+
+    PC = DHPlayer(Owner);
+
+    return PC != none && PC.IsLogisticCrew();
 }
 
 simulated function bool IsASL()
@@ -117,6 +123,11 @@ simulated function bool IsASL()
 simulated function bool IsSLorASL()
 {
     return IsSL() || IsASL();
+}
+
+simulated function bool IsAbleToConstruct() 
+{
+    return IsLogisticCrew() || IsSLorASL();
 }
 
 simulated function bool IsInSquad()
@@ -202,7 +213,7 @@ simulated static function bool IsPlayerTankCrew(Pawn P)
 
 simulated static function bool IsPlayerLicensedToDrive(DHPlayer C)
 {
-    return C != none && DHPlayerReplicationInfo(C.PlayerReplicationInfo) != none && DHPlayerReplicationInfo(C.PlayerReplicationInfo).IsSLorASL();
+    return C != none && DHPlayerReplicationInfo(C.PlayerReplicationInfo) != none && DHPlayerReplicationInfo(C.PlayerReplicationInfo).IsAbleToConstruct();
 }
 
 // Modified to fix bug where the last line was being drawn at top of screen, instead of in vertical sequence, so overwriting info in the 1st screen line
@@ -235,6 +246,8 @@ simulated function bool CheckRole(ERoleSelector RoleSelector)
             return IsSL();
         case ERS_ASL:
             return IsASL();
+        case ERS_LOGISTICCREW:
+            return IsLogisticCrew();
         case ERS_ARTILLERY_SPOTTER:
             return IsArtillerySpotter();
         case ERS_ARTILLERY_OPERATOR:

--- a/DH_Engine/Classes/DHRoleInfo.uc
+++ b/DH_Engine/Classes/DHRoleInfo.uc
@@ -20,6 +20,7 @@ var     bool                bCanUseMortars;         // role has functionality of
 var     bool                bCanCarryExtraAmmo;     // role can carry extra ammo
 var     bool                bSpawnWithExtraAmmo;    // role spawns with extra ammo
 var     bool                bCarriesRadio;          // role can carry radios
+var     bool                bIsLogiCrew;            // role can construct but can't spot
 var     bool                bCanPickupWeapons;
 
 var     bool                bExemptSquadRequirement;// this role will be exempt from the requirement of being in a squad to select

--- a/DH_Engine/Classes/DHSquadReplicationInfo.uc
+++ b/DH_Engine/Classes/DHSquadReplicationInfo.uc
@@ -236,7 +236,7 @@ function Timer()
         }
 
         // SLs, ASLs and radio operators should know where all squad leaders are.
-        if (PRI.IsSLorASL() || PRI.IsRadioman())
+        if (PRI.IsAbleToConstruct() || PRI.IsRadioman() || PRI.IsSLorASL())
         {
             UpdateSquadLeaderLocations(PC);
         }

--- a/DH_GerPlayers/Classes/DHGELogisticCrewRoles.uc
+++ b/DH_GerPlayers/Classes/DHGELogisticCrewRoles.uc
@@ -1,0 +1,18 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHGELogisticCrewRoles extends DHAxisLogisticCrewRoles
+    abstract;
+
+defaultproperties
+{
+    PrimaryWeapons(0)=(Item=class'DH_Weapons.DH_Kar98Weapon',AssociatedAttachment=class'ROInventory.ROKar98AmmoPouch')
+    PrimaryWeapons(1)=(Item=class'DH_Weapons.DH_Kar98NoCoverWeapon',AssociatedAttachment=class'ROInventory.ROKar98AmmoPouch')
+    Grenades(0)=(Item=class'DH_Weapons.DH_StielGranateWeapon')
+    GivenItems(0)="DH_Equipment.DHWireCuttersItem"
+    HeadgearProbabilities(0)=0.2
+    HeadgearProbabilities(1)=0.8
+    GlovedHandTexture=Texture'Weapons1st_tex.Arms.hands_gergloves'
+}

--- a/DH_SovietPlayers/Classes/DHCSLogisticCrewRoles.uc
+++ b/DH_SovietPlayers/Classes/DHCSLogisticCrewRoles.uc
@@ -1,0 +1,19 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHCSLogisticCrewRoles extends DHAlliedLogisticCrewRoles
+    abstract;
+
+defaultproperties
+{
+    AltName="Zenista"
+    PrimaryWeapons(0)=(Item=class'DH_Weapons.DH_SVT40Weapon',AssociatedAttachment=class'ROInventory.SVT40AmmoPouch') 
+    Grenades(0)=(Item=class'DH_Weapons.DH_F1GrenadeWeapon')
+    GivenItems(1)="DH_Equipment.DHWireCuttersItem"
+    VoiceType="DH_SovietPlayers.DHCzechVoice"
+    AltVoiceType="DH_SovietPlayers.DHCzechVoice"
+    SleeveTexture=Texture'DHSovietCharactersTex.RussianSleeves.DH_rus_sleeves'
+    GlovedHandTexture=Texture'DHBritishCharactersTex.Winter.hands_BRITgloves'
+}

--- a/DH_SovietPlayers/Classes/DHPOLLogisticCrewRoles.uc
+++ b/DH_SovietPlayers/Classes/DHPOLLogisticCrewRoles.uc
@@ -1,0 +1,20 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHPOLLogisticCrewRoles extends DHAlliedLogisticCrewRoles
+    abstract;
+
+defaultproperties
+{
+    AltName="Saper"
+    PrimaryWeapons(0)=(Item=class'DH_Weapons.DH_M38Weapon',AssociatedAttachment=class'ROInventory.ROMN9130AmmoPouch')
+    Grenades(0)=(Item=class'DH_Weapons.DH_F1GrenadeWeapon')
+    GivenItems(0)="DH_Equipment.DHShovelItem_Russian"
+    VoiceType="DH_SovietPlayers.DHPolishVoice"
+    AltVoiceType="DH_SovietPlayers.DHPolishVoice"
+    SleeveTexture=Texture'DHSovietCharactersTex.RussianSleeves.DH_rus_sleeves'
+    GlovedHandTexture=Texture'DHSovietCharactersTex.soviet_gear.hands_sovgloves'
+
+}

--- a/DH_SovietPlayers/Classes/DHSOVLogisticCrewRoles.uc
+++ b/DH_SovietPlayers/Classes/DHSOVLogisticCrewRoles.uc
@@ -1,0 +1,19 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHSOVLogisticCrewRoles extends DHAlliedLogisticCrewRoles
+    abstract;
+
+defaultproperties
+{
+    PrimaryWeapons(0)=(Item=class'DH_Weapons.DH_M38Weapon',AssociatedAttachment=class'ROInventory.ROMN9130AmmoPouch')
+    Grenades(0)=(Item=class'DH_Weapons.DH_F1GrenadeWeapon')
+    GivenItems(0)="DH_Equipment.DHShovelItem_Russian"
+    VoiceType="DH_SovietPlayers.DHSovietVoice"
+    AltVoiceType="DH_SovietPlayers.DHSovietVoice"
+    SleeveTexture=Texture'DHSovietCharactersTex.RussianSleeves.DH_rus_sleeves'
+    GlovedHandTexture=Texture'DHSovietCharactersTex.soviet_gear.hands_sovgloves'
+
+}

--- a/DH_USPlayers/Classes/DHUSLogisticCrewRoles.uc
+++ b/DH_USPlayers/Classes/DHUSLogisticCrewRoles.uc
@@ -1,0 +1,20 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHUSLogisticCrewRoles extends DHAlliedLogisticCrewRoles
+    abstract;
+
+defaultproperties
+{
+    PrimaryWeapons(0)=(Item=class'DH_Weapons.DH_M1CarbineWeapon',AssociatedAttachment=class'DH_Weapons.DH_M1CarbineAmmoPouch')
+    Grenades(0)=(Item=class'DH_Weapons.DH_M1GrenadeWeapon')
+    GivenItems(0)="DH_Equipment.DHShovelItem_US"
+    HeadgearProbabilities(0)=0.2
+    HeadgearProbabilities(1)=0.8
+    SleeveTexture=Texture'DHUSCharactersTex.Sleeves.US_sleeves'
+    GlovedHandTexture=Texture'DHUSCharactersTex.Gear.hands_USgloves'
+    VoiceType="DH_USPlayers.DHUSVoice"
+    AltVoiceType="DH_USPlayers.DHUSVoice"
+}

--- a/DH_USPlayers/Classes/DH_USLogisticCrewAutumn.uc
+++ b/DH_USPlayers/Classes/DH_USLogisticCrewAutumn.uc
@@ -1,0 +1,14 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_USLogisticCrewAutumn extends DHUSLogisticCrewRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_USPlayers.DH_AmericanPawn',Weight=4.0)
+    RolePawns(1)=(PawnClass=class'DH_USPlayers.DH_USVestPawn',Weight=1.0)
+    Headgear(0)=class'DH_USPlayers.DH_AmericanHelmet'
+    Headgear(1)=class'DH_USPlayers.DH_AmericanHelmetNet'
+}

--- a/DH_USPlayers/Classes/DH_USLogisticCrewAutumn.uc
+++ b/DH_USPlayers/Classes/DH_USLogisticCrewAutumn.uc
@@ -9,6 +9,6 @@ defaultproperties
 {
     RolePawns(0)=(PawnClass=class'DH_USPlayers.DH_AmericanPawn',Weight=4.0)
     RolePawns(1)=(PawnClass=class'DH_USPlayers.DH_USVestPawn',Weight=1.0)
-    Headgear(0)=class'DH_USPlayers.DH_AmericanHelmet'
-    Headgear(1)=class'DH_USPlayers.DH_AmericanHelmetNet'
+    Headgear(0)=class'DH_USPlayers.DH_USTankerHat'
+    Headgear(1)=class'DH_USPlayers.DH_USTankerHat'
 }

--- a/DH_USPlayers/Classes/DH_USLogisticCrewSummer.uc
+++ b/DH_USPlayers/Classes/DH_USLogisticCrewSummer.uc
@@ -8,6 +8,6 @@ class DH_USLogisticCrewSummer extends DHUSLogisticCrewRoles;
 defaultproperties
 {
     RolePawns(0)=(PawnClass=class'DH_USPlayers.DH_AmericanPawn',Weight=3.0)
-    Headgear(0)=class'DH_USPlayers.DH_AmericanHelmet'
-    Headgear(1)=class'DH_USPlayers.DH_AmericanHelmetNet'
+    Headgear(0)=class'DH_USPlayers.DH_USTankerHat'
+    Headgear(1)=class'DH_USPlayers.DH_USTankerHat'
 }

--- a/DH_USPlayers/Classes/DH_USLogisticCrewSummer.uc
+++ b/DH_USPlayers/Classes/DH_USLogisticCrewSummer.uc
@@ -1,0 +1,13 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_USLogisticCrewSummer extends DHUSLogisticCrewRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_USPlayers.DH_AmericanPawn',Weight=3.0)
+    Headgear(0)=class'DH_USPlayers.DH_AmericanHelmet'
+    Headgear(1)=class'DH_USPlayers.DH_AmericanHelmetNet'
+}

--- a/DH_USPlayers/Classes/DH_USLogisticCrewWinter.uc
+++ b/DH_USPlayers/Classes/DH_USLogisticCrewWinter.uc
@@ -11,7 +11,7 @@ defaultproperties
     RolePawns(1)=(PawnClass=class'DH_USPlayers.DH_USWinterScarfPawn',Weight=1.0)
     RolePawns(2)=(PawnClass=class'DH_USPlayers.DH_USTrenchcoatPawn',Weight=0.6)
     RolePawns(3)=(PawnClass=class'DH_USPlayers.DH_USWinterPawn',Weight=0.3)
-    Headgear(0)=class'DH_USPlayers.DH_AmericanHelmetWinter'
-    Headgear(1)=class'DH_USPlayers.DH_AmericanHelmet1stEMa'
+    Headgear(0)=class'DH_USPlayers.DH_USTankerHat'
+    Headgear(1)=class'DH_USPlayers.DH_USTankerHat'
     HandType=Hand_Gloved
 }

--- a/DH_USPlayers/Classes/DH_USLogisticCrewWinter.uc
+++ b/DH_USPlayers/Classes/DH_USLogisticCrewWinter.uc
@@ -1,0 +1,17 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_USLogisticCrewWinter extends DHUSLogisticCrewRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_USPlayers.DH_USTrenchcoatScarfPawn',Weight=2.0)
+    RolePawns(1)=(PawnClass=class'DH_USPlayers.DH_USWinterScarfPawn',Weight=1.0)
+    RolePawns(2)=(PawnClass=class'DH_USPlayers.DH_USTrenchcoatPawn',Weight=0.6)
+    RolePawns(3)=(PawnClass=class'DH_USPlayers.DH_USWinterPawn',Weight=0.3)
+    Headgear(0)=class'DH_USPlayers.DH_AmericanHelmetWinter'
+    Headgear(1)=class'DH_USPlayers.DH_AmericanHelmet1stEMa'
+    HandType=Hand_Gloved
+}

--- a/DarkestHourDev/Maps/DH-_Debug-Logistic.rom
+++ b/DarkestHourDev/Maps/DH-_Debug-Logistic.rom
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48f6170361f52e05d3e90e5d86d1caf4a2d7276d3e929f73e51da699a0e96a9a
+size 10930678


### PR DESCRIPTION
Added a **logistic crew** role that players can select in the class list.
They can only construct buildings and are armed with a carbine instead of regular weaponary.

This way the squad leader and the assistant can focus on leading a squad together, instead of having the assistant driving across the map building stuff. Maybe we could give the assistant the ability to call in artillery strikes, to take off the workload of the squad leader.

But the biggest reason for this feature, is that that logi players no longer have to ask squad leaders for the assistant role.
The squad leader may not know how to accept a request, or they're busy in the game menu where the request isn't visible or they just don't understand english.

Currently there's a test map with the logi role added for the US nation, but more could be added later for the other nations.