### PR TITLE
Give both Squad Leader and Assistants the ability to call in Arty/mortar support

### DIFF
--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -1134,6 +1134,11 @@ simulated function bool IsASL()
     return DHPlayerReplicationInfo(PlayerReplicationInfo) != none && DHPlayerReplicationInfo(PlayerReplicationInfo).IsASL();
 }
 
+simulated function bool IsAbleToUseFireSupport()
+{
+    return DHPlayerReplicationInfo(PlayerReplicationInfo) != none && DHPlayerReplicationInfo(PlayerReplicationInfo).IsSLorASL();
+}
+
 simulated function bool HasLimitedRole()
 {
     local DHRoleInfo RI;
@@ -2202,7 +2207,7 @@ simulated function bool IsArtilleryOperator()
 
 simulated function bool IsArtillerySpotter()
 {
-    return IsSquadLeader();
+    return IsSLorASL();
 }
 
 simulated function bool IsRadioman()
@@ -7396,7 +7401,7 @@ simulated function bool CanUseFireSupportMenu()
         P = DHPawn(Pawn);
     }
 
-    return P != none && IsSquadLeader();
+    return P != none && IsAbleToUseFireSupport();
 }
 
 function AddMarker(class<DHMapMarker> MarkerClass, float MapLocationX, float MapLocationY, optional vector L)

--- a/DH_Engine/Classes/DHRadio.uc
+++ b/DH_Engine/Classes/DHRadio.uc
@@ -145,7 +145,7 @@ simulated function ERadioUsageError GetRadioUsageError(Pawn User)
 
 simulated function bool IsPlayerQualified(DHPlayer PC)
 {
-    return PC != none && PC.IsSquadLeader();
+    return PC != none && PC.IsAbleToUseFireSupport();
 }
 
 function RequestArtillery(Pawn Sender, int ArtilleryTypeIndex)


### PR DESCRIPTION
Instead of adding back the Artillery Observer class, we give the assistant the ability to call in arty and make HE/Smoke requests.

This will ease the burden on the squad leader and make mortar operators happier as they will have more marked targets.