### PR TITLE
Additon of "marksman" role for axis

### DIFF
--- a/DH_Engine/Classes/DHAxisMarksmanRoles.uc
+++ b/DH_Engine/Classes/DHAxisMarksmanRoles.uc
@@ -10,11 +10,11 @@ defaultproperties
 {
     //historically, there was no "marksman" type role within the wehrmacht or Waffen-SS, however the ZF41 was given out to fullfill this role and there was no distinction between snipers with or without 
     MyName="Marksman"   //https://www.youtube.com/watch?v=sBstpqUAniw <--- reference to marksman being a thing in the wehr and SS
-    AltName="Scharfsch�tze" //the native role name reflects this, but the translated name is there so that people can understand that this isnt a true "sniper"
+    AltName="Scharfsch?tze" //the native role name reflects this, but the translated name is there so that people can understand that this isnt a true "sniper"
     Article="a "        
     PluralName="Snipers"    
     Limit=2
-    AddedRoleRespawnTime=8  //"snipers" or marksman with the zf41 get a penaulty for respawn, but it is not as high as regular higher level snipers
-    bExemptSquadRequirement=true
+    AddedRoleRespawnTime=8  //"snipers" or marksman with the zf41 get a penalty for respawn, but it is not as high as regular higher level snipers
+    bExemptSquadRequirement=false
     bCanBeSquadLeader=false
 }

--- a/DH_Engine/Classes/DHAxisMarksmanRoles.uc
+++ b/DH_Engine/Classes/DHAxisMarksmanRoles.uc
@@ -8,13 +8,13 @@ class DHAxisMarksmanRoles extends DHAxisRoles
 
 defaultproperties
 {
-    //historically, there was no "marksman" type role within the wehrmacht or Waffen-SS, however the ZF41 was given out to fullfill this role and there was no distinction between snipers with or without 
-    MyName="Marksman"   //https://www.youtube.com/watch?v=sBstpqUAniw <--- reference to marksman being a thing in the wehr and SS
-    AltName="Scharfsch?tze" //the native role name reflects this, but the translated name is there so that people can understand that this isnt a true "sniper"
+    //historically, there was no "marksman" type role within the wehrmacht or Waffen-SS, however the ZF41 was given out to fullfill this role and there was no distinction between snipers with or without. 
+    MyName="Marksman"   //https://www.youtube.com/watch?v=sBstpqUAniw <--- reference to marksman being a thing in the wehr and SS.
+    AltName="Scharfschütze" //the native role name reflects this, but the translated name is there so that people can understand that this isnt a true "sniper"
     Article="a "        
     PluralName="Snipers"    
     Limit=2
-    AddedRoleRespawnTime=8  //"snipers" or marksman with the zf41 get a penalty for respawn, but it is not as high as regular higher level snipers
+    AddedRoleRespawnTime=8  //"snipers" or marksman with the zf41 get a penalty for respawn, but it is not as high as regular higher level snipers.
     bExemptSquadRequirement=false
     bCanBeSquadLeader=false
 }

--- a/DH_Engine/Classes/DHAxisMarksmanRoles.uc
+++ b/DH_Engine/Classes/DHAxisMarksmanRoles.uc
@@ -1,0 +1,19 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHAxisMarksmanRoles extends DHAxisRoles
+    abstract;
+
+defaultproperties
+{
+    MyName="Marksman"   //historically, there was no "marksman" type role within the wehrmacht or Waffen-SS, however the ZF41 was given out to fullfill this role and there was no distinction between snipers with or without
+    AltName="Scharfsch�tze" //the native role name reflects this, but the translated name is there so that people can understand that this isnt a true "sniper"
+    Article="a "        
+    PluralName="Snipers"    
+    Limit=2
+    AddedRoleRespawnTime=8  //"snipers" or marksman with the zf41 get a penaulty for respawn, but it is not as high as regular higher level snipers
+    bExemptSquadRequirement=true
+    bCanBeSquadLeader=false
+}

--- a/DH_Engine/Classes/DHAxisMarksmanRoles.uc
+++ b/DH_Engine/Classes/DHAxisMarksmanRoles.uc
@@ -8,7 +8,8 @@ class DHAxisMarksmanRoles extends DHAxisRoles
 
 defaultproperties
 {
-    MyName="Marksman"   //historically, there was no "marksman" type role within the wehrmacht or Waffen-SS, however the ZF41 was given out to fullfill this role and there was no distinction between snipers with or without
+    //historically, there was no "marksman" type role within the wehrmacht or Waffen-SS, however the ZF41 was given out to fullfill this role and there was no distinction between snipers with or without 
+    MyName="Marksman"   //https://www.youtube.com/watch?v=sBstpqUAniw <--- reference to marksman being a thing in the wehr and SS
     AltName="Scharfsch�tze" //the native role name reflects this, but the translated name is there so that people can understand that this isnt a true "sniper"
     Article="a "        
     PluralName="Snipers"    

--- a/DH_Engine/Classes/DHAxisSniperRoles.uc
+++ b/DH_Engine/Classes/DHAxisSniperRoles.uc
@@ -9,10 +9,10 @@ class DHAxisSniperRoles extends DHAxisRoles
 defaultproperties
 {
     MyName="Sniper"
-    AltName="Scharfschütze"
+    AltName="Scharfschï¿½tze"
     Article="a "
     PluralName="Snipers"
-    Limit=2
+    Limit=1
     AddedRoleRespawnTime=15
     bExemptSquadRequirement=true
     bCanBeSquadLeader=false

--- a/DH_Engine/Classes/DHAxisSniperRoles.uc
+++ b/DH_Engine/Classes/DHAxisSniperRoles.uc
@@ -9,7 +9,7 @@ class DHAxisSniperRoles extends DHAxisRoles
 defaultproperties
 {
     MyName="Sniper"
-    AltName="Scharfsch�tze"
+    AltName="Scharfschütze"
     Article="a "
     PluralName="Snipers"
     Limit=1

--- a/DH_Engine/Classes/DHAxisSniperRoles.uc
+++ b/DH_Engine/Classes/DHAxisSniperRoles.uc
@@ -9,7 +9,7 @@ class DHAxisSniperRoles extends DHAxisRoles
 defaultproperties
 {
     MyName="Sniper"
-    AltName="ScharfschÃ¼tze"
+    AltName="Scharfschütze"
     Article="a "
     PluralName="Snipers"
     Limit=1

--- a/DH_GerPlayers/Classes/DHGEMarksmanRoles.uc
+++ b/DH_GerPlayers/Classes/DHGEMarksmanRoles.uc
@@ -1,0 +1,19 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DHGEMarksmanRoles extends DHAxisMarksmanRoles
+    abstract;
+
+defaultproperties
+{
+    //ZF41 was used in place of regular snipers as a way to extend the gruppe's range and allow them to take out harder targets like machineguns and pillboxes
+    //There was distinction between snipers and marksmen
+    PrimaryWeapons(0)=(Item=class'DH_Weapons.DH_Kar98ScopedZF41Weapon')
+    SecondaryWeapons(0)=(Item=class'DH_Weapons.DH_P38Weapon')
+    SecondaryWeapons(1)=(Item=class'DH_Weapons.DH_P08LugerWeapon')
+    HeadgearProbabilities(0)=0.5
+    HeadgearProbabilities(1)=0.5
+    GlovedHandTexture=Texture'Weapons1st_tex.Arms.hands_gergloves'
+}

--- a/DH_GerPlayers/Classes/DHGEMarksmanRoles.uc
+++ b/DH_GerPlayers/Classes/DHGEMarksmanRoles.uc
@@ -11,8 +11,7 @@ defaultproperties
     //ZF41 was used in place of regular snipers as a way to extend the gruppe's range and allow them to take out harder targets like machineguns and pillboxes
     //There was distinction between snipers and marksmen
     PrimaryWeapons(0)=(Item=class'DH_Weapons.DH_Kar98ScopedZF41Weapon')
-    SecondaryWeapons(0)=(Item=class'DH_Weapons.DH_P38Weapon')
-    SecondaryWeapons(1)=(Item=class'DH_Weapons.DH_P08LugerWeapon')
+    Grenades(0)=(Item=class'DH_Weapons.DH_StielGranateWeapon')
     HeadgearProbabilities(0)=0.5
     HeadgearProbabilities(1)=0.5
     GlovedHandTexture=Texture'Weapons1st_tex.Arms.hands_gergloves'

--- a/DH_GerPlayers/Classes/DH_12thSSMarksman.uc
+++ b/DH_GerPlayers/Classes/DH_12thSSMarksman.uc
@@ -1,0 +1,18 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_12thSSMarksman extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_German12thSSPawnB',Weight=1.0)
+    SleeveTexture=Texture'DHGermanCharactersTex.GerSleeves.Dot44Sleeve'
+    Headgear(0)=class'DH_GerPlayers.DH_SSHelmetOne'
+    Headgear(1)=class'DH_GerPlayers.DH_SSHelmetTwo'
+
+    SecondaryWeapons(0)=(Item=class'DH_Weapons.DH_BHPWeapon')
+    SecondaryWeapons(1)=(Item=class'DH_Weapons.DH_P08LugerWeapon')
+    SecondaryWeapons(2)=(Item=class'DH_Weapons.DH_ColtM1914Weapon')
+}

--- a/DH_GerPlayers/Classes/DH_FJ45Marksman.uc
+++ b/DH_GerPlayers/Classes/DH_FJ45Marksman.uc
@@ -1,0 +1,18 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_FJ45Marksman extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanArdennesFJPawn',Weight=1.0)
+    SleeveTexture=Texture'DHGermanCharactersTex.GerSleeves.FJ_Sleeve'
+    Headgear(0)=class'DH_GerPlayers.DH_FJHelmetTwo'
+    Headgear(1)=class'DH_GerPlayers.DH_FJHelmetNetTwo'
+    Headgear(2)=class'DH_GerPlayers.DH_FJHelmetNetOne'
+    HeadgearProbabilities(0)=0.33
+    HeadgearProbabilities(1)=0.33
+    HeadgearProbabilities(2)=0.33
+}

--- a/DH_GerPlayers/Classes/DH_FJMarksman.uc
+++ b/DH_GerPlayers/Classes/DH_FJMarksman.uc
@@ -1,0 +1,18 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_FJMarksman extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanFJPawn',Weight=1.0)
+    SleeveTexture=Texture'DHGermanCharactersTex.GerSleeves.FJ_Sleeve'
+    Headgear(0)=class'DH_GerPlayers.DH_FJHelmetCamoOne'
+    Headgear(1)=class'DH_GerPlayers.DH_FJHelmetCamoTwo'
+    Headgear(2)=class'DH_GerPlayers.DH_FJHelmetNetOne'
+    HeadgearProbabilities(0)=0.33
+    HeadgearProbabilities(1)=0.33
+    HeadgearProbabilities(2)=0.33
+}

--- a/DH_GerPlayers/Classes/DH_WHMarksman.uc
+++ b/DH_GerPlayers/Classes/DH_WHMarksman.uc
@@ -1,0 +1,15 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_WHMarksman extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanSniperHeerPawn')
+    RolePawns(1)=(PawnClass=class'DH_GerPlayers.DH_GermanCamoHeerPawn')
+    SleeveTexture=Texture'Weapons1st_tex.Arms.german_sleeves'
+    Headgear(0)=class'DH_GerPlayers.DH_HeerHelmetOne'
+    Headgear(1)=class'ROInventory.ROGermanHat'
+}

--- a/DH_GerPlayers/Classes/DH_WHMarksmanC.uc
+++ b/DH_GerPlayers/Classes/DH_WHMarksmanC.uc
@@ -3,12 +3,13 @@
 // Darklight Games (c) 2008-2023
 //==============================================================================
 
-class DH_WHMarksman extends DHGEMarksmanRoles;
+class DH_WHMarksmanC extends DHGEMarksmanRoles;
 
 defaultproperties
 {
-    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanHeerPawn',Weight=1.0)
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanSniperHeerPawn')
+    RolePawns(1)=(PawnClass=class'DH_GerPlayers.DH_GermanCamoHeerPawn')
     SleeveTexture=Texture'Weapons1st_tex.Arms.german_sleeves'
-    Headgear(0)=class'DH_GerPlayers.DH_HeerHelmetThree'
+    Headgear(0)=class'DH_GerPlayers.DH_HeerHelmetOne'
     Headgear(1)=class'ROInventory.ROGermanHat'
 }

--- a/DH_GerPlayers/Classes/DH_WHMarksman_Greatcoat.uc
+++ b/DH_GerPlayers/Classes/DH_WHMarksman_Greatcoat.uc
@@ -1,0 +1,16 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_WHMarksman_Greatcoat extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanGreatCoatPawn',Weight=1.0)
+    SleeveTexture=Texture'Weapons1st_tex.Arms.GermanCoatSleeves'
+    DetachedArmClass=class'ROEffects.SeveredArmGerGreat'
+    DetachedLegClass=class'ROEffects.SeveredLegGerGreat'
+    Headgear(0)=class'ROInventory.ROGermanHat'
+    Headgear(1)=class'DH_GerPlayers.DH_HeerCamoCap'
+}

--- a/DH_GerPlayers/Classes/DH_WHMarksman_Greatcoat_Winter.uc
+++ b/DH_GerPlayers/Classes/DH_WHMarksman_Greatcoat_Winter.uc
@@ -1,0 +1,17 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_WHMarksman_Greatcoat_Winter extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanGreatCoatPawn_Winter',Weight=1.0)
+    SleeveTexture=Texture'Weapons1st_tex.Arms.GermanCoatSleeves'
+    DetachedArmClass=class'ROEffects.SeveredArmGerGreat'
+    DetachedLegClass=class'ROEffects.SeveredLegGerGreat'
+    Headgear(0)=class'ROInventory.ROGermanHat'
+    Headgear(1)=class'DH_GerPlayers.DH_HeerCamoCap'
+    HandType=Hand_Gloved
+}

--- a/DH_GerPlayers/Classes/DH_WHMarksman_Snow.uc
+++ b/DH_GerPlayers/Classes/DH_WHMarksman_Snow.uc
@@ -1,0 +1,16 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_WHSniper_Snow extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanParkaSnowHeerPawn',Weight=2.0)
+    RolePawns(1)=(PawnClass=class'DH_GerPlayers.DH_GermanSmockToqueHeerPawn',Weight=1.0)
+    SleeveTexture=Texture'Weapons1st_tex.Arms.RussianSnow_Sleeves'
+    Headgear(0)=class'DH_GerPlayers.DH_HeerHelmetSnow'
+    HeadgearProbabilities(0)=1.0
+    HandType=Hand_Gloved
+}

--- a/DH_GerPlayers/Classes/DH_WHMarksman_Snow.uc
+++ b/DH_GerPlayers/Classes/DH_WHMarksman_Snow.uc
@@ -3,7 +3,7 @@
 // Darklight Games (c) 2008-2023
 //==============================================================================
 
-class DH_WHSniper_Snow extends DHGEMarksmanRoles;
+class DH_WHMarksman_Snow extends DHGEMarksmanRoles;
 
 defaultproperties
 {

--- a/DH_GerPlayers/Classes/DH_WHMarksman_SnowTwo.uc
+++ b/DH_GerPlayers/Classes/DH_WHMarksman_SnowTwo.uc
@@ -1,0 +1,22 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_WHMarksman_SnowTwo extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanSnowGreatCoatPawn',Weight=2.0)
+    RolePawns(1)=(PawnClass=class'DH_GerPlayers.DH_GermanSnowHeerPawn',Weight=1.0)
+    SleeveTexture=Texture'DHGermanCharactersTex.GerSleeves.snow_sleeves'
+    Headgear(0)=class'DH_GerPlayers.DH_HeerHelmetSnowTwo'
+    Headgear(1)=class'DH_GerPlayers.DH_HeerHelmetSnowThree'
+    Headgear(2)=class'DH_GerPlayers.DH_HeerHelmetSnow'
+    Headgear(3)=class'DH_GerPlayers.DH_HeerHelmetCover'
+    HeadgearProbabilities(0)=0.4
+    HeadgearProbabilities(1)=0.25
+    HeadgearProbabilities(2)=0.3
+    HeadgearProbabilities(3)=0.05
+    HandType=Hand_Gloved
+}

--- a/DH_GerPlayers/Classes/DH_WHSMarksman_Autumn.uc
+++ b/DH_GerPlayers/Classes/DH_WHSMarksman_Autumn.uc
@@ -1,0 +1,15 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_WHSMarksman_Autumn extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanParkaHeerPawn',Weight=2.0)
+    RolePawns(1)=(PawnClass=class'DH_GerPlayers.DH_GermanSmockHeerPawn',Weight=1.0)
+    SleeveTexture=Texture'DHGermanCharactersTex.GerSleeves.SplinterASleeve'
+    Headgear(0)=class'DH_GerPlayers.DH_HeerHelmetCover'
+    Headgear(1)=class'DH_GerPlayers.DH_HeerCamoCap'
+}

--- a/DH_GerPlayers/Classes/DH_WKMarksman.uc
+++ b/DH_GerPlayers/Classes/DH_WKMarksman.uc
@@ -3,12 +3,12 @@
 // Darklight Games (c) 2008-2023
 //==============================================================================
 
-class DH_WHMarksman extends DHGEMarksmanRoles;
+class DH_WKMarksman extends DHGEMarksmanRoles;
 
 defaultproperties
 {
-    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanHeerPawn',Weight=1.0)
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanKriegsmarinePawn',Weight=1.0)
     SleeveTexture=Texture'Weapons1st_tex.Arms.german_sleeves'
-    Headgear(0)=class'DH_GerPlayers.DH_HeerHelmetThree'
-    Headgear(1)=class'ROInventory.ROGermanHat'
+    Headgear(0)=class'DH_GerPlayers.DH_KriegsmarineHelmet'
+    HeadgearProbabilities(0)=1.0
 }

--- a/DH_GerPlayers/Classes/DH_WSSGreatcoatMarksman.uc
+++ b/DH_GerPlayers/Classes/DH_WSSGreatcoatMarksman.uc
@@ -1,0 +1,16 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_WSSGreatcoatMarksman extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanGreatCoatSSPawn',Weight=1.0)
+    SleeveTexture=Texture'DHGermanCharactersTex.GerSleeves.Dot44Sleeve'
+    DetachedArmClass=class'ROEffects.SeveredArmGerGreat'
+    DetachedLegClass=class'ROEffects.SeveredLegGerGreat'
+    Headgear(0)=class'DH_GerPlayers.DH_SSHelmetOne'
+    Headgear(1)=class'DH_GerPlayers.DH_SSHelmetTwo'
+}

--- a/DH_GerPlayers/Classes/DH_WSSGreatcoatMarksman_Winter.uc
+++ b/DH_GerPlayers/Classes/DH_WSSGreatcoatMarksman_Winter.uc
@@ -1,0 +1,17 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_WSSGreatcoatMarksman_Winter extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanGreatCoatSSPawn_Winter',Weight=1.0)
+    SleeveTexture=Texture'DHGermanCharactersTex.GerSleeves.Dot44Sleeve'
+    DetachedArmClass=class'ROEffects.SeveredArmGerGreat'
+    DetachedLegClass=class'ROEffects.SeveredLegGerGreat'
+    Headgear(0)=class'DH_GerPlayers.DH_SSHelmetOne'
+    Headgear(1)=class'DH_GerPlayers.DH_SSHelmetTwo'
+    HandType=Hand_Gloved
+}

--- a/DH_GerPlayers/Classes/DH_WSSMarksman.uc
+++ b/DH_GerPlayers/Classes/DH_WSSMarksman.uc
@@ -1,0 +1,19 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_WSSMarksman extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanSSPawn',Weight=1.0)
+    RolePawns(1)=(PawnClass=class'DH_GerPlayers.DH_GermanSpringSmockSSPawn',Weight=2.0)
+    SleeveTexture=Texture'DHGermanCharactersTex.GerSleeves.DotGreenSleeve'
+    Headgear(0)=class'DH_GerPlayers.DH_SSHelmetOne'
+    Headgear(1)=class'DH_GerPlayers.DH_SSHelmetTwo'
+
+    SecondaryWeapons(0)=(Item=class'DH_Weapons.DH_BHPWeapon')
+    SecondaryWeapons(1)=(Item=class'DH_Weapons.DH_P08LugerWeapon')
+    SecondaryWeapons(2)=(Item=class'DH_Weapons.DH_TT33Weapon')
+}

--- a/DH_GerPlayers/Classes/DH_WSSMarksman_Autumn.uc
+++ b/DH_GerPlayers/Classes/DH_WSSMarksman_Autumn.uc
@@ -1,0 +1,20 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_WSSMarksman_Autumn extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanParkaSSPawn',Weight=1.5)
+    RolePawns(1)=(PawnClass=class'DH_GerPlayers.DH_GermanAutumnSmockSSPawn',Weight=1.0)
+    RolePawns(2)=(PawnClass=class'DH_GerPlayers.DH_GermanAutumnSSPawn',Weight=1.0)
+    SleeveTexture=Texture'DHGermanCharactersTex.GerSleeves.Dot44Sleeve'
+    Headgear(0)=class'DH_GerPlayers.DH_SSHelmetCover'
+    HeadgearProbabilities(0)=1.0
+
+    SecondaryWeapons(0)=(Item=class'DH_Weapons.DH_BHPWeapon')
+    SecondaryWeapons(1)=(Item=class'DH_Weapons.DH_P08LugerWeapon')
+    SecondaryWeapons(2)=(Item=class'DH_Weapons.DH_TT33Weapon')
+}

--- a/DH_GerPlayers/Classes/DH_WSSMarksman_Snow.uc
+++ b/DH_GerPlayers/Classes/DH_WSSMarksman_Snow.uc
@@ -1,0 +1,19 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_WSSMarksman_Snow extends DHGEMarksmanRoles;
+
+defaultproperties
+{
+    RolePawns(0)=(PawnClass=class'DH_GerPlayers.DH_GermanParkaSnowSSPawn',Weight=2.0)
+    RolePawns(1)=(PawnClass=class'DH_GerPlayers.DH_GermanSmockToqueSSPawn',Weight=1.0)
+    SleeveTexture=Texture'Weapons1st_tex.Arms.RussianSnow_Sleeves'
+    Headgear(0)=class'DH_GerPlayers.DH_SSHelmetSnow'
+    HeadgearProbabilities(0)=1.0
+    SecondaryWeapons(0)=(Item=class'DH_Weapons.DH_BHPWeapon')
+    SecondaryWeapons(1)=(Item=class'DH_Weapons.DH_P08LugerWeapon')
+    SecondaryWeapons(2)=(Item=class'DH_Weapons.DH_ColtM1914Weapon')
+    HandType=Hand_Gloved
+}


### PR DESCRIPTION
Historically, there was no distinction between snipers with the ZF39 (4x power) scope and those with the ZF41 (1.5x power) scope, however the ZF41 was used in a role much similar to designated marksmen today, and the ZF41 was far more numerous than the ZF39

https://www.youtube.com/watch?v=sBstpqUAniw (citation)

Proposed changes would be the reduction of higher tier snipers (those with zf39 and zf4 scopes), addition of a new "marksman" role, and a replacement for those that were reduced, I.E changing a map from 2 snipers to 1, but then adding a marksman.

The marksman role is named as such in code and with standard naming conventions, but within the native names for the faction, it is still named "scharfschütze" as there was no NAMED distinction within the Wehrmacht and SS, only one with how the scope was USED.

As well as this, the name marksman is there so that players can understand that this isnt a proper sniper role, it is one similar to that of a designated marksman.