### PR TITLE
Level Updates

### DIFF
--- a/DH_Engine/Classes/DHMapDatabase.uc
+++ b/DH_Engine/Classes/DHMapDatabase.uc
@@ -321,4 +321,5 @@ defaultproperties
     MapInfos(159)=(Name="DH-Kharkov_Advance",AlliedNation=NATION_USSR,GameType=GAMETYPE_Advance,Size=SIZE_Large)
     MapInfos(160)=(Name="DH-Endsieg_Advance",AlliedNation=NATION_USSR,GameType=GAMETYPE_Advance,Size=SIZE_Large)
     MapInfos(161)=(Name="DH-Armored_La_Feuillie_Advance",AlliedNation=NATION_USA,GameType=GAMETYPE_Advance,Size=SIZE_Any)
+    MapInfos(162)=(Name="DH-Maupertus_Advance",AlliedNation=NATION_USA,GameType=GAMETYPE_Advance,Size=SIZE_Medium)
 }

--- a/DarkestHourDev/Maps/DH-Les_Champs_de_Losque_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Les_Champs_de_Losque_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c796d3a144ec1e870bb2e7b6193e4ea771ac3072f4a826279ec15fc659aee3d7
-size 73914539
+oid sha256:90faccecec5cba3de1fefc7e9ad4c3752fb5e163a0680423511aaa5be967d89c
+size 73915152

--- a/DarkestHourDev/Maps/DH-Maupertus_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Maupertus_Advance.rom
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6dfda226c8c5b14f11fedc061136baa7f634d0128714cba028b4da278d78c3d
+size 42918252

--- a/DarkestHourDev/Maps/DH-Pointe_Du_Hoc_Push.rom
+++ b/DarkestHourDev/Maps/DH-Pointe_Du_Hoc_Push.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3546769539ff4e2385ef226fe98a6523b1f348a324984a82c4d411b135b0e8ea
-size 50003377
+oid sha256:fd0847b2d21fed20ad9b9b5a64e0bc8d504b67c329f9a353a698ac4cdfe09464
+size 50003367


### PR DESCRIPTION
Pointe du Hoc:

- Changed Allies to have +2% team ratio.
- Increased Axis respawn interval to 20 seconds from 15.
- Increased Allied Combat Engineer roles from 3 to 4.

Les Champs:

- Reworked Danger Zone influences of most objectives.

Maupertus Advance:

- Converted Maupertus Push to Advance game mode.
- Changed Allied faction to more historically accurate US 4th ID.
- Changed Axis faction to standard WH Heer (709th ID).
- Added 2 spawns of M4A1 75mm tanks to Allies.
- Limited M5A1 Stuart tanks to 6 spawns max. 
- Added Stug 3G with 2 spawns max to Axis.
- Added several new interiors on the map.
- Opened some additional flanking routes in the hedgerows.
- Fixed a variety of misc. bugs.