### PR TITLE
Feature/heavy weapons ironsights

### DIFF
--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -985,7 +985,7 @@ function UpdateRotation(float DeltaTime, float MaxPitch)
 
         if (DHPW != none && DHPW.bHasScope && DHPW.bUsingSights)
         {
-            TurnSpeedFactor *= DHScopeTurnSpeedFactor; // reduce if player is using a sniper scope or binocs or is bipod deployed
+            TurnSpeedFactor *= DHScopeTurnSpeedFactor; // reduce if player is using a sniper scope or binocs
         }
         else if (DHPwn != none)
         {

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -64,6 +64,7 @@ var     float                   DHSwayDampingFactor;
 var     float                   DHStandardTurnSpeedFactor;
 var     float                   DHHalfTurnSpeedFactor;
 var     globalconfig float      DHISTurnSpeedFactor;        // 0.0 to 1.0
+var     globalconfig float      DHISBipodTurnSpeedFactor;     // 0.0 to 1.0
 var     globalconfig float      DHScopeTurnSpeedFactor;     // 0.0 to 1.0
 
 // Player flinch
@@ -984,13 +985,18 @@ function UpdateRotation(float DeltaTime, float MaxPitch)
 
         if (DHPW != none && DHPW.bHasScope && DHPW.bUsingSights)
         {
-            TurnSpeedFactor *= DHScopeTurnSpeedFactor; // reduce if player is using a sniper scope or binocs
+            TurnSpeedFactor *= DHScopeTurnSpeedFactor; // reduce if player is using a sniper scope or binocs or is bipod deployed
         }
         else if (DHPwn != none)
         {
             if (DHPwn.bIronSights || DHPwn.bBipodDeployed)
             {
-                TurnSpeedFactor *= DHISTurnSpeedFactor; // reduce if player is using ironsights or is bipod deployed
+                if (DHPwn.bBipodDeployed) {
+                    TurnSpeedFactor *= DHISBipodTurnSpeedFactor; // reduce if player is bipod deployed
+                }
+                else {
+                    TurnSpeedFactor *= DHISTurnSpeedFactor; // reduce if player is using ironsights
+                }
             }
         }
         else if (ROVeh != none && ROVeh.DriverPositions[ROVeh.DriverPositionIndex].bDrawOverlays && ROVeh.HUDOverlay == none

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -64,7 +64,7 @@ var     float                   DHSwayDampingFactor;
 var     float                   DHStandardTurnSpeedFactor;
 var     float                   DHHalfTurnSpeedFactor;
 var     globalconfig float      DHISTurnSpeedFactor;        // 0.0 to 1.0
-var     globalconfig float      DHISBipodTurnSpeedFactor;     // 0.0 to 1.0
+var     globalconfig float      DHBipodTurnSpeedFactor;     // 0.0 to 1.0
 var     globalconfig float      DHScopeTurnSpeedFactor;     // 0.0 to 1.0
 
 // Player flinch
@@ -989,14 +989,13 @@ function UpdateRotation(float DeltaTime, float MaxPitch)
         }
         else if (DHPwn != none)
         {
-            if (DHPwn.bIronSights || DHPwn.bBipodDeployed)
+            if (DHPwn.bBipodDeployed)
             {
-                if (DHPwn.bBipodDeployed) {
-                    TurnSpeedFactor *= DHISBipodTurnSpeedFactor; // reduce if player is bipod deployed
-                }
-                else {
-                    TurnSpeedFactor *= DHISTurnSpeedFactor; // reduce if player is using ironsights
-                }
+                TurnSpeedFactor *= DHBipodTurnSpeedFactor; // reduce if player is bipod deployed
+            }
+            else if (DHPwn.bIronSights)
+            {
+                TurnSpeedFactor *= DHISTurnSpeedFactor; // reduce if player is using ironsights
             }
         }
         else if (ROVeh != none && ROVeh.DriverPositions[ROVeh.DriverPositionIndex].bDrawOverlays && ROVeh.HUDOverlay == none

--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -7698,6 +7698,7 @@ defaultproperties
     DHHalfTurnSpeedFactor=16.0
     DHISTurnSpeedFactor=0.5
     DHScopeTurnSpeedFactor=0.2
+    DHBipodTurnSpeedFactor=1.0
 
     // Max flinch offset for close snaps
     FlinchMaxOffset=450.0

--- a/DH_Interface/Classes/DHTab_Input.uc
+++ b/DH_Interface/Classes/DHTab_Input.uc
@@ -7,7 +7,7 @@ class DHTab_Input extends ROTab_Input;
 
 var automated DHmoNumericEdit           nu_MousePollRate;
 var automated moFloatEdit               fl_IronSightFactor;
-var automated moFloatEdit               fl_IronSightBipodFactor;
+var automated moFloatEdit               fl_BipodFactor;
 var automated moFloatEdit               fl_ScopedFactor;
 
 event InitComponent(GUIController MyController, GUIComponent MyOwner)
@@ -16,7 +16,7 @@ event InitComponent(GUIController MyController, GUIComponent MyOwner)
 
     i_BG3.ManageComponent(nu_MousePollRate);
     i_BG3.ManageComponent(fl_IronSightFactor);
-    i_BG3.ManageComponent(fl_IronSightBipodFactor);
+    i_BG3.ManageComponent(fl_BipodFactor);
     i_BG3.ManageComponent(fl_ScopedFactor);
 }
 
@@ -38,8 +38,8 @@ function InternalOnLoadINI(GUIComponent Sender, string s)
         case fl_IronSightFactor:
             fl_IronSightFactor.SetComponentValue(float(PC.ConsoleCommand("get DH_Engine.DHPlayer DHISTurnSpeedFactor")),true);
             break;
-        case fl_IronSightBipodFactor:
-            fl_IronSightBipodFactor.SetComponentValue(float(PC.ConsoleCommand("get DH_Engine.DHPlayer DHISBipodTurnSpeedFactor")),true);
+        case fl_BipodFactor:
+            fl_BipodFactor.SetComponentValue(float(PC.ConsoleCommand("get DH_Engine.DHPlayer DHBipodTurnSpeedFactor")),true);
             break;
         case fl_ScopedFactor:
             fl_ScopedFactor.SetComponentValue(float(PC.ConsoleCommand("get DH_Engine.DHPlayer DHScopeTurnSpeedFactor")),true);
@@ -54,7 +54,7 @@ function ResetClicked()
 {
     class'PlayerInput'.static.ResetConfig("MouseSamplingTime");
     class'DHPlayer'.static.ResetConfig("DHISTurnSpeedFactor");
-    class'DHPlayer'.static.ResetConfig("DHISBipodTurnSpeedFactor");
+    class'DHPlayer'.static.ResetConfig("DHBipodTurnSpeedFactor");
     class'DHPlayer'.static.ResetConfig("DHScopeTurnSpeedFactor");
 
     super.ResetClicked();
@@ -84,13 +84,13 @@ function OnInputChange(GUIComponent Sender)
             DHPlayer(PC).SaveConfig();
         }
     }
-    else if (Sender == fl_IronSightBipodFactor)
+    else if (Sender == fl_BipodFactor)
     {
-        PC.ConsoleCommand("set DH_Engine.DHPlayer DHISBipodTurnSpeedFactor" @ fl_IronSightBipodFactor.GetValue());
+        PC.ConsoleCommand("set DH_Engine.DHPlayer DHBipodTurnSpeedFactor" @ fl_BipodFactor.GetValue());
 
         if (DHPlayer(PC) != none)
         {
-            DHPlayer(PC).DHISBipodTurnSpeedFactor = fl_IronSightBipodFactor.GetValue();
+            DHPlayer(PC).DHBipodTurnSpeedFactor = fl_BipodFactor.GetValue();
             DHPlayer(PC).SaveConfig();
         }
     }
@@ -463,7 +463,7 @@ defaultproperties
         OnChange=OnInputChange
         OnLoadIni=InternalOnLoadINI
     End Object
-    fl_IronSightBipodFactor=InputIronSightBipodFactor
+    fl_BipodFactor=InputIronSightBipodFactor
 
     Begin Object class=DHmoFloatEdit Name=InputScopedFactor
         MinValue=0.01

--- a/DH_Interface/Classes/DHTab_Input.uc
+++ b/DH_Interface/Classes/DHTab_Input.uc
@@ -7,6 +7,7 @@ class DHTab_Input extends ROTab_Input;
 
 var automated DHmoNumericEdit           nu_MousePollRate;
 var automated moFloatEdit               fl_IronSightFactor;
+var automated moFloatEdit               fl_IronSightBipodFactor;
 var automated moFloatEdit               fl_ScopedFactor;
 
 event InitComponent(GUIController MyController, GUIComponent MyOwner)
@@ -15,6 +16,7 @@ event InitComponent(GUIController MyController, GUIComponent MyOwner)
 
     i_BG3.ManageComponent(nu_MousePollRate);
     i_BG3.ManageComponent(fl_IronSightFactor);
+    i_BG3.ManageComponent(fl_IronSightBipodFactor);
     i_BG3.ManageComponent(fl_ScopedFactor);
 }
 
@@ -36,9 +38,13 @@ function InternalOnLoadINI(GUIComponent Sender, string s)
         case fl_IronSightFactor:
             fl_IronSightFactor.SetComponentValue(float(PC.ConsoleCommand("get DH_Engine.DHPlayer DHISTurnSpeedFactor")),true);
             break;
+        case fl_IronSightBipodFactor:
+            fl_IronSightBipodFactor.SetComponentValue(float(PC.ConsoleCommand("get DH_Engine.DHPlayer DHISBipodTurnSpeedFactor")),true);
+            break;
         case fl_ScopedFactor:
             fl_ScopedFactor.SetComponentValue(float(PC.ConsoleCommand("get DH_Engine.DHPlayer DHScopeTurnSpeedFactor")),true);
             break;
+      
         default:
             super.InternalOnLoadINI(Sender, s);
     }
@@ -48,6 +54,7 @@ function ResetClicked()
 {
     class'PlayerInput'.static.ResetConfig("MouseSamplingTime");
     class'DHPlayer'.static.ResetConfig("DHISTurnSpeedFactor");
+    class'DHPlayer'.static.ResetConfig("DHISBipodTurnSpeedFactor");
     class'DHPlayer'.static.ResetConfig("DHScopeTurnSpeedFactor");
 
     super.ResetClicked();
@@ -74,6 +81,16 @@ function OnInputChange(GUIComponent Sender)
         if (DHPlayer(PC) != none)
         {
             DHPlayer(PC).DHISTurnSpeedFactor = fl_IronSightFactor.GetValue();
+            DHPlayer(PC).SaveConfig();
+        }
+    }
+    else if (Sender == fl_IronSightBipodFactor)
+    {
+        PC.ConsoleCommand("set DH_Engine.DHPlayer DHISBipodTurnSpeedFactor" @ fl_IronSightBipodFactor.GetValue());
+
+        if (DHPlayer(PC) != none)
+        {
+            DHPlayer(PC).DHISBipodTurnSpeedFactor = fl_IronSightBipodFactor.GetValue();
             DHPlayer(PC).SaveConfig();
         }
     }
@@ -429,6 +446,25 @@ defaultproperties
     End Object
     fl_IronSightFactor=InputIronSightFactor
 
+    Begin Object class=DHmoFloatEdit Name=InputIronSightBipodFactor
+        MinValue=0.01
+        MaxValue=1.0
+        Step=0.05
+        ComponentJustification=TXTA_Left
+        CaptionWidth=0.725
+        Caption="Bipod Sensitivity Factor"
+        OnCreateComponent=InputIronSightBipodFactor.InternalOnCreateComponent
+        IniOption="@Internal"
+        WinTop=0.324167
+        WinLeft=0.502344
+        WinWidth=0.421875
+        WinHeight=0.045352
+        TabOrder=12
+        OnChange=OnInputChange
+        OnLoadIni=InternalOnLoadINI
+    End Object
+    fl_IronSightBipodFactor=InputIronSightBipodFactor
+
     Begin Object class=DHmoFloatEdit Name=InputScopedFactor
         MinValue=0.01
         MaxValue=1.0
@@ -442,7 +478,7 @@ defaultproperties
         WinLeft=0.502344
         WinWidth=0.421875
         WinHeight=0.045352
-        TabOrder=12
+        TabOrder=13
         OnChange=OnInputChange
         OnLoadIni=InternalOnLoadINI
     End Object


### PR DESCRIPTION
Added DHISBipodTurnSpeedFactor to the settings menu, so players who want to have a slower ironsights with bipod weapons like the mg34 and PTRD can have it.

Decided to use the DHISBipodTurnSpeedFactor instead of DHScopeTurnSpeedFactor so that sniper weapons aren't affected, should the player want to have a slower bipod speed while keeping their current scope speed.