### PR TITLE
Endsieg:

### DIFF
--- a/DarkestHourDev/Maps/DH-Endsieg_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Endsieg_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1888ceb48576e567e279bffb42eedf48d01e34bd75093dd7a84cdfe886a8a128
-size 124444974
+oid sha256:31d7edc86bc24e26ace0c19c82e19495907342c02d5c7a76fdf2c581e7095c23
+size 123528698


### PR DESCRIPTION
From Mad Death Hound:
- Made Panzer 4 spawnd unlimited
- Made stuG3 spawns unlimited
- Floater fixes
- New defensive areas added, including the Axis last stand area from Praiserplatz
- Pantherturms added
- New barriers added to restrict soviet movement and give the Axis some areas to defend
- Additional detailing to previously neglected areas of the map
- More rubble and smoke emmitters added to give the sense of a bombed city
- Added a Hetzer
- Removed semi-solid BSP.