### PR TITLE
G98 Muzzle Flash Fix

### DIFF
--- a/DH_Weapons/Classes/DH_G98Attachment.uc
+++ b/DH_Weapons/Classes/DH_G98Attachment.uc
@@ -10,6 +10,7 @@ defaultproperties
     Mesh=SkeletalMesh'DH_Weapons3rd_2_anm.g98_3rd'  
     MenuImage=Texture'DH_InterfaceArt_tex.weapon_icons.g98_icon' 
     MuzzleBoneName="tipnew"
+    MuzzleFlashOffset=(X=-4.000000)
     mMuzFlashClass=class'ROEffects.MuzzleFlash3rdKar'
     ROShellCaseClass=class'ROAmmo.RO3rdShellEject762x54mm'
     bAnimNotifiedShellEjects=true


### PR DESCRIPTION
- Applied an offset to the G98 muzzle flash to resolve an issue with the flash effect appearing several inches in front of the barrel.