### PR TITLE
Damage Change

### DIFF
--- a/DH_Vehicles/Classes/DH_JagdpantherCannonShell.uc
+++ b/DH_Vehicles/Classes/DH_JagdpantherCannonShell.uc
@@ -13,7 +13,7 @@ defaultproperties
     BallisticCoefficient=3.8 //TODO: find correct BC
 
     //Damage
-    ImpactDamage=975  //109 gramms TNT filler
+    ImpactDamage=1150  //109 gramms TNT filler same as king tiger now
     ShellImpactDamage=class'DH_Engine.DHShellAPGunImpactDamageType'
     HullFireChance=0.5
     EngineFireChance=0.98


### PR DESCRIPTION
The JPV was utilizing the damage of the tiger 1 while being the exact same gun as the tiger 2, this change only switches the damage to be identical to the tiger 2's.