### PR TITLE
Fixed "last fire" animations not working in multiplayer

### DIFF
--- a/DH_Engine/Classes/DHAutomaticFire.uc
+++ b/DH_Engine/Classes/DHAutomaticFire.uc
@@ -46,9 +46,6 @@ function PlayFiring()
 {
     // TODO: there is a HUGE amount of redundancy here, we should be able to roll all of this into DHProjectileFire at some point
     local name Anim;
-    local bool bIsLastShot;
-
-    bIsLastShot = Weapon.AmmoAmount(ThisModeNum) < 1;
 
     if (Weapon != none)
     {
@@ -61,7 +58,7 @@ function PlayFiring()
                 {
                     if (IsInstigatorBipodDeployed())
                     {
-                        if (bIsLastShot && Weapon.HasAnim(BipodDeployFireLastAnim))
+                        if (ShouldPlayFireLastAnim() && Weapon.HasAnim(BipodDeployFireLastAnim))
                         {
                             Anim = BipodDeployFireLastAnim;
                         }
@@ -70,7 +67,7 @@ function PlayFiring()
                             Anim = BipodDeployFireLoopAnim;
                         }
                     }
-                    else if (bIsLastShot && Weapon.HasAnim(FireIronLastAnim))
+                    else if (ShouldPlayFireLastAnim() && Weapon.HasAnim(FireIronLastAnim))
                     {
                         Anim = FireIronLastAnim;
                     }
@@ -81,7 +78,7 @@ function PlayFiring()
                 }
                 else
                 {
-                    if (bIsLastShot && Weapon.HasAnim(FireLastAnim))
+                    if (ShouldPlayFireLastAnim() && Weapon.HasAnim(FireLastAnim))
                     {
                         Anim = FireLastAnim;
                     }
@@ -107,7 +104,7 @@ function PlayFiring()
                     {
                         Anim = BipodDeployFireAnim;
                     }
-                    else if (bIsLastShot && Weapon.HasAnim(FireIronLastAnim))
+                    else if (ShouldPlayFireLastAnim() && Weapon.HasAnim(FireIronLastAnim))
                     {
                         Anim = FireIronLastAnim;
                     }
@@ -118,7 +115,7 @@ function PlayFiring()
                 }
                 else
                 {
-                    if (bIsLastShot && Weapon.HasAnim(FireLastAnim))
+                    if (ShouldPlayFireLastAnim() && Weapon.HasAnim(FireLastAnim))
                     {
                         Anim = FireLastAnim;
                     }
@@ -150,14 +147,11 @@ function PlayFiring()
 function PlayFireEnd()
 {
     local name Anim;
-    local bool bIsLastShot;
 
     if (Weapon == none || Weapon.Mesh == none)
     {
         return;
     }
-
-    bIsLastShot = Weapon.AmmoAmount(ThisModeNum) < 1;
 
     if (Weapon.GetFireMode(ThisModeNum).bWaitForRelease)
     {
@@ -169,7 +163,7 @@ function PlayFireEnd()
     {
         if (IsInstigatorBipodDeployed())
         {
-            if (bIsLastShot && Weapon.HasAnim(BipodDeployFireLastAnim))
+            if (ShouldPlayFireLastAnim() && Weapon.HasAnim(BipodDeployFireLastAnim))
             {
                 Anim = BipodDeployFireLastAnim;
             }
@@ -178,7 +172,7 @@ function PlayFireEnd()
                 Anim = BipodDeployFireEndAnim;
             }
         }
-        else if (bIsLastShot && Weapon.HasAnim(FireIronLastAnim))
+        else if (ShouldPlayFireLastAnim() && Weapon.HasAnim(FireIronLastAnim))
         {
             Anim = FireIronLastAnim;
         }
@@ -189,7 +183,7 @@ function PlayFireEnd()
     }
     else
     {
-        if (bIsLastShot && Weapon.HasAnim(FireLastAnim))
+        if (ShouldPlayFireLastAnim() && Weapon.HasAnim(FireLastAnim))
         {
             Anim = FireLastAnim;
         }
@@ -197,7 +191,7 @@ function PlayFireEnd()
 
     if (Anim == '')
     {
-        if (bIsLastShot && Weapon.HasAnim(FireLastAnim))
+        if (ShouldPlayFireLastAnim() && Weapon.HasAnim(FireLastAnim))
         {
             Anim = FireLastAnim;
         }

--- a/DH_Engine/Classes/DHProjectileFire.uc
+++ b/DH_Engine/Classes/DHProjectileFire.uc
@@ -559,7 +559,7 @@ function PlayFiring()
             }
             else if (!IsPlayerHipFiring() && Weapon.HasAnim(FireIronAnim))
             {
-                if (Weapon.AmmoAmount(ThisModeNum) < 2 && Weapon.HasAnim(FireIronLastAnim))
+                if (ShouldPlayFireLastAnim() && Weapon.HasAnim(FireIronLastAnim))
                 {
                     Weapon.PlayAnim(FireIronLastAnim, FireAnimRate, FireTweenTime);
                 }

--- a/DH_Engine/Classes/DHProjectileFire.uc
+++ b/DH_Engine/Classes/DHProjectileFire.uc
@@ -559,7 +559,7 @@ function PlayFiring()
             }
             else if (!IsPlayerHipFiring() && Weapon.HasAnim(FireIronAnim))
             {
-                if (Weapon.AmmoAmount(ThisModeNum) < 1 && Weapon.HasAnim(FireIronLastAnim))
+                if (Weapon.AmmoAmount(ThisModeNum) < 2 && Weapon.HasAnim(FireIronLastAnim))
                 {
                     Weapon.PlayAnim(FireIronLastAnim, FireAnimRate, FireTweenTime);
                 }
@@ -570,7 +570,7 @@ function PlayFiring()
             }
             else if (Weapon.HasAnim(FireAnim))
             {
-                if (Weapon.AmmoAmount(ThisModeNum) < 1 && Weapon.HasAnim(FireLastAnim))
+                if (ShouldPlayFireLastAnim() && Weapon.HasAnim(FireLastAnim))
                 {
                     Weapon.PlayAnim(FireLastAnim, FireAnimRate, FireTweenTime);
                 }
@@ -604,6 +604,27 @@ function PlayFireEnd()
         {
             Weapon.PlayAnim(FireEndAnim, FireEndAnimRate, FireTweenTime);
         }
+    }
+}
+
+simulated function bool ShouldPlayFireLastAnim()
+{
+    local DHProjectileWeapon PW;
+
+    PW = DHProjectileWeapon(Weapon);
+
+    if (PW == none)
+    {
+        return false;
+    }
+
+    if (PW.bAmmoAmountNotReplicated)
+    {
+        return Weapon.AmmoAmount(ThisModeNum) == AmmoPerFire;
+    }
+    else
+    {
+        return Weapon.AmmoAmount(ThisModeNum) < AmmoPerFire;
     }
 }
 

--- a/DH_Engine/Classes/DHProjectileWeapon.uc
+++ b/DH_Engine/Classes/DHProjectileWeapon.uc
@@ -3529,9 +3529,15 @@ simulated function UpdateWeaponComponentAnimations()
 // Handles making ammo belt bullets disappear
 simulated function UpdateAmmoBelt()
 {
-    local int i;
+    local int i, AmmoAmountOffset;
 
-    for (i = Max(0, AmmoAmount(0)); i < MGBeltArray.Length; ++i)
+    if (bAmmoAmountNotReplicated)
+    {
+        // Offset ammo count to account for replication delay.
+        AmmoAmountOffset = FireMode[0].AmmoPerFire;
+    }
+
+    for (i = Max(0, AmmoAmount(0) - AmmoAmountOffset); i < MGBeltArray.Length; ++i)
     {
         if (MGBeltArray[i] != none)
         {

--- a/DH_Engine/Classes/DHProjectileWeapon.uc
+++ b/DH_Engine/Classes/DHProjectileWeapon.uc
@@ -184,6 +184,8 @@ var     class<ROFPAmmoRound>    BeltBulletClass;   // class to spawn for each bu
 var     array<ROFPAmmoRound>    MGBeltArray;       // array of first person ammo rounds
 var     array<name>             MGBeltBones;       // array of bone names to attach the belt to
 
+var     bool                    bAmmoAmountNotReplicated; // set on clients in multiplayer
+
 replication
 {
     // Variables the server will replicate to the client that owns this actor
@@ -3683,6 +3685,16 @@ exec simulated function DebugAddedYaw(int AddedYaw)
         {
             DHProjectileFire(FireMode[0]).AddedYaw = AddedYaw;
         }
+    }
+}
+
+simulated function PostNetReceive()
+{
+    super.PostNetReceive();
+
+    if (bAmmoAmountNotReplicated)
+    {
+        bAmmoAmountNotReplicated = false;
     }
 }
 

--- a/DH_Engine/Classes/DHWeaponFire.uc
+++ b/DH_Engine/Classes/DHWeaponFire.uc
@@ -202,51 +202,51 @@ simulated function bool IsPlayerHipFiring()
 simulated function EjectShell()
 {
     local int i;
-	local Coords EjectCoords;
-	local Vector EjectOffset, X, Y, Z;
-	local Rotator EjectRot;
-	local ROShellEject Shell;
+    local Coords EjectCoords;
+    local Vector EjectOffset, X, Y, Z;
+    local Rotator EjectRot;
+    local ROShellEject Shell;
 
     for (i = 0; i < ShellEjectors.Length; ++i)
     {
-	    if (ShellEjectors[i].EjectClass == none)
+        if (ShellEjectors[i].EjectClass == none)
         {
             continue;
         }
 
         if (IsPlayerHipFiring())
         {
-			// Find the shell eject location then scale it down 5x (since the weapons are scaled up 5x)
-        	EjectCoords = Weapon.GetBoneCoords(ShellEjectors[i].EjectBone);
-			EjectOffset = (EjectCoords.Origin - Weapon.Location) / 5.0;
-        	EjectOffset += Weapon.Location;
-        	EjectOffset += (EjectCoords.XAxis * ShellEjectors[i].HipOffset.X) 
+            // Find the shell eject location then scale it down 5x (since the weapons are scaled up 5x)
+            EjectCoords = Weapon.GetBoneCoords(ShellEjectors[i].EjectBone);
+            EjectOffset = (EjectCoords.Origin - Weapon.Location) / 5.0;
+            EjectOffset += Weapon.Location;
+            EjectOffset += (EjectCoords.XAxis * ShellEjectors[i].HipOffset.X)
                          + (EjectCoords.YAxis * ShellEjectors[i].HipOffset.Y)
                          + (EjectCoords.ZAxis * ShellEjectors[i].HipOffset.Z);
 
-			if (bReverseShellSpawnDirection)
-			{
-            	EjectRot = Rotator(EjectCoords.YAxis);
+            if (bReverseShellSpawnDirection)
+            {
+                EjectRot = Rotator(EjectCoords.YAxis);
             }
             else
             {
-            	EjectRot = Rotator(-EjectCoords.YAxis);
+                EjectRot = Rotator(-EjectCoords.YAxis);
             }
 
-	    	Shell = Weapon.Spawn(ShellEjectors[i].EjectClass, none,, EjectOffset, EjectRot);
-	    	EjectRot = Rotator(EjectCoords.XAxis) + ShellEjectors[i].RotOffsetHip;
+            Shell = Weapon.Spawn(ShellEjectors[i].EjectClass, none,, EjectOffset, EjectRot);
+            EjectRot = Rotator(EjectCoords.XAxis) + ShellEjectors[i].RotOffsetHip;
         }
         else
         {
-			Weapon.GetViewAxes(X, Y, Z);
-			EjectOffset = Instigator.Location + Instigator.EyePosition();
-			EjectOffset += (X * ShellEjectors[i].IronSightOffset.X)
+            Weapon.GetViewAxes(X, Y, Z);
+            EjectOffset = Instigator.Location + Instigator.EyePosition();
+            EjectOffset += (X * ShellEjectors[i].IronSightOffset.X)
                          + (Y * ShellEjectors[i].IronSightOffset.Y)
                          + (Z * ShellEjectors[i].IronSightOffset.Z);
-    		EjectRot = Rotator(Y);
-			EjectRot.Yaw += 16384;
-			Shell = Weapon.Spawn(ShellEjectors[i].EjectClass, none,, EjectOffset, EjectRot);
-			EjectRot = Rotator(Y) + ShellEjectors[i].RotOffsetIron;
+            EjectRot = Rotator(Y);
+            EjectRot.Yaw += 16384;
+            Shell = Weapon.Spawn(ShellEjectors[i].EjectClass, none,, EjectOffset, EjectRot);
+            EjectRot = Rotator(Y) + ShellEjectors[i].RotOffsetIron;
         }
 
         EjectRot.Yaw = EjectRot.Yaw + Shell.RandomYawRange - Rand(Shell.RandomYawRange * 2);


### PR DESCRIPTION
This fixes a visual bug where some guns (G43, G41, MP40, and others) have heir bolt slowly slide into position when the magazine is emptied.

### Additional changes:
- [Optimization] Disabled component animation update calls on the server in `ModeDoFire()`.
- Fixed MG belt bullets being out of sync with ammo count in multiplayer.