### PR TITLE
17 pounder damage

### DIFF
--- a/DH_Guns/Classes/DH_17PounderCannonShell.uc
+++ b/DH_Guns/Classes/DH_17PounderCannonShell.uc
@@ -13,7 +13,7 @@ defaultproperties
     BallisticCoefficient=2.45 //TODO: pls check
 
     // Damage
-    ImpactDamage=580  //solid shell
+    ImpactDamage=725 //solid shell
     ShellImpactDamage=class'DH_Engine.DHShellAPGunImpactDamageType'
     HullFireChance=0.35
     EngineFireChance=0.75

--- a/DH_Vehicles/Classes/DH_AchillesCannonShell.uc
+++ b/DH_Vehicles/Classes/DH_AchillesCannonShell.uc
@@ -13,7 +13,7 @@ defaultproperties
     BallisticCoefficient=2.45
 
     // Damage
-    ImpactDamage=580  //solid shell
+    ImpactDamage=725  //solid shell
     ShellImpactDamage=class'DH_Engine.DHShellAPGunImpactDamageType'
     HullFireChance=0.35
     EngineFireChance=0.75

--- a/DH_Vehicles/Classes/DH_ShermanFireFlyCannonShell.uc
+++ b/DH_Vehicles/Classes/DH_ShermanFireFlyCannonShell.uc
@@ -13,7 +13,7 @@ defaultproperties
     BallisticCoefficient=2.45 //TODO: pls check
 
     // Damage
-    ImpactDamage=580  //solid shell
+    ImpactDamage=725  //solid shell
     ShellImpactDamage=class'DH_Engine.DHShellAPGunImpactDamageType'
     HullFireChance=0.35
     EngineFireChance=0.75


### PR DESCRIPTION
 Changing this up from its very low 580, this is based upon a few energy calculations I did comparing the panthers pzgr39/42 and the APCBC shell of the 17 pounder, APCBC in the end showed higher energy transfer thus displacing more mass/creating more shrapnel. I chose 725 as it is still a solid shell and doesnt disperese shrapnel around the crew compartment like pzgr39/42

17 pounder calculations (ignore APDS)
https://imgur.com/a/QD0dwU3

Pzgr39/42 calculations
https://imgur.com/a/mNUkfVs