### PR TITLE
Reverted Squad Leader Role Restrictions for VS Rifleman and Assault.

### DIFF
--- a/DH_GerPlayers/Classes/DH_VSAssault.uc
+++ b/DH_GerPlayers/Classes/DH_VSAssault.uc
@@ -16,6 +16,4 @@ defaultproperties
     PrimaryWeapons(0)=(Item=class'DH_Weapons.DH_VG15weapon',AssociatedAttachment=class'ROInventory.ROSTG44AmmoPouch')
     PrimaryWeapons(1)=(Item=class'DH_Weapons.DH_GeratPweapon',AssociatedAttachment=class'ROInventory.ROMP40AmmoPouch')
     PrimaryWeapons(2)=(Item=class'DH_Weapons.DH_MP3008weapon',AssociatedAttachment=class'ROInventory.ROMP40AmmoPouch')
-    
-    bCanBeSquadLeader=false
 }

--- a/DH_GerPlayers/Classes/DH_VSRifleman.uc
+++ b/DH_GerPlayers/Classes/DH_VSRifleman.uc
@@ -15,6 +15,4 @@ defaultproperties
 
     PrimaryWeapons(0)=(Item=class'DH_Weapons.DH_G98Weapon',AssociatedAttachment=class'ROInventory.ROKar98AmmoPouch')
     PrimaryWeapons(1)=(Item=class'DH_Weapons.DH_VK98Weapon',AssociatedAttachment=class'ROInventory.ROKar98AmmoPouch')
-    
-    bCanBeSquadLeader=false
 }


### PR DESCRIPTION
This change caused issues with Berlin maps as VS roles were often the only unlimited ones available, a situation could exist where a player created a squad and could not choose any role. Other solutions such as giving infinite Corporal roles to compensate do not make sense. Additionally, the Volkssturm historically had the same standard squad structure as the Heer and SS and operated independently, a Volkssturm squad would be lead by Volkssturm, not other Heer or SS NCOs. 