### PR TITLE
Fixed a bug where constructions are sometimes immune to explosions

### DIFF
--- a/DH_Construction/Classes/DHConstruction_PlatoonHQ.uc
+++ b/DH_Construction/Classes/DHConstruction_PlatoonHQ.uc
@@ -339,6 +339,7 @@ defaultproperties
     ProgressMax=9
     SupplyCost=750
     MinDamagetoHurt=50
+    OptimalTraceOffset=(Z=40.0)
 
     // Placement
     bCanPlaceIndoors=false

--- a/DH_Construction/Classes/DHConstruction_PlatoonHQ.uc
+++ b/DH_Construction/Classes/DHConstruction_PlatoonHQ.uc
@@ -339,7 +339,7 @@ defaultproperties
     ProgressMax=9
     SupplyCost=750
     MinDamagetoHurt=50
-    OptimalTraceOffset=(Z=40.0)
+    ExplosionDamageTraceOffset=(Z=40.0)
 
     // Placement
     bCanPlaceIndoors=false

--- a/DH_Construction/Classes/DHConstruction_SupplyCache.uc
+++ b/DH_Construction/Classes/DHConstruction_SupplyCache.uc
@@ -165,7 +165,7 @@ defaultproperties
     SupplyAttachmentClass=class'DHConstructionSupplyAttachment_Static'
     MapIconAttachmentClass=class'DH_Engine.DHMapIconAttachment_SupplyCache'
     ConstructionVerb="drop"
-    OptimalTraceOffset=(Z=40.0)
+    ExplosionDamageTraceOffset=(Z=40.0)
 
     // Essentially we are just making this a satchel explosion
     BrokenEmitterClass=class'ROEffects.ROSatchelExplosion'

--- a/DH_Construction/Classes/DHConstruction_SupplyCache.uc
+++ b/DH_Construction/Classes/DHConstruction_SupplyCache.uc
@@ -165,6 +165,7 @@ defaultproperties
     SupplyAttachmentClass=class'DHConstructionSupplyAttachment_Static'
     MapIconAttachmentClass=class'DH_Engine.DHMapIconAttachment_SupplyCache'
     ConstructionVerb="drop"
+    OptimalTraceOffset=(Z=40.0)
 
     // Essentially we are just making this a satchel explosion
     BrokenEmitterClass=class'ROEffects.ROSatchelExplosion'

--- a/DH_Construction/Classes/DHConstruction_VehiclePool.uc
+++ b/DH_Construction/Classes/DHConstruction_VehiclePool.uc
@@ -67,6 +67,7 @@ defaultproperties
     ProgressMax=12
     SupplyCost=1500
     MinDamagetoHurt=5
+    OptimalTraceOffset=(Z=40.0)
 
     // Temp
     StaticMesh=StaticMesh'DH_Construction_stc.Bases.GER_Light_Vehicle_Pool'

--- a/DH_Construction/Classes/DHConstruction_VehiclePool.uc
+++ b/DH_Construction/Classes/DHConstruction_VehiclePool.uc
@@ -67,7 +67,7 @@ defaultproperties
     ProgressMax=12
     SupplyCost=1500
     MinDamagetoHurt=5
-    OptimalTraceOffset=(Z=40.0)
+    ExplosionDamageTraceOffset=(Z=40.0)
 
     // Temp
     StaticMesh=StaticMesh'DH_Construction_stc.Bases.GER_Light_Vehicle_Pool'

--- a/DH_Engine/Classes/DHAntiVehicleProjectile.uc
+++ b/DH_Engine/Classes/DHAntiVehicleProjectile.uc
@@ -624,7 +624,7 @@ function HurtRadius(float DamageAmount, float DamageRadius, class<DamageType> Da
 
         if (C != none)
         {
-            VictimLocation = C.GetOptimalTraceLocation();
+            VictimLocation = C.GetExplosiveDamageTraceLocation();
         }
         else
         {

--- a/DH_Engine/Classes/DHAntiVehicleProjectile.uc
+++ b/DH_Engine/Classes/DHAntiVehicleProjectile.uc
@@ -573,6 +573,7 @@ function HurtRadius(float DamageAmount, float DamageRadius, class<DamageType> Da
 {
     local Actor         Victim, TraceActor;
     local DHVehicle     V;
+    local DHConstruction C;
     local ROPawn        P;
     local array<ROPawn> CheckedROPawns;
     local bool          bAlreadyChecked;
@@ -617,15 +618,25 @@ function HurtRadius(float DamageAmount, float DamageRadius, class<DamageType> Da
             continue;
         }
 
-        // Now we need to check whether there's something in the way that could shield this actor from the blast
-        // Usually we trace to actor's location, but for a vehicle with a cannon we adjust Z location to give a more consistent, realistic tracing height
-        // This is because many vehicles are modelled with their origin on the ground, so even a slight bump in the ground could block all blast damage!
-        VictimLocation = Victim.Location;
-        V = DHVehicle(Victim);
+        // Before tracing the victim, we must adjust its location for certain types of actors
+        // Tracing to origin can be unreliable as it's usually located at the bottom and can sink under the terrain, blocking the blast damage
+        C = DHConstruction(Victim);
 
-        if (V != none && V.Cannon != none && V.Cannon.AttachmentBone != '')
+        if (C != none)
         {
-            VictimLocation.Z = V.GetBoneCoords(V.Cannon.AttachmentBone).Origin.Z;
+            VictimLocation = C.GetOptimalTraceLocation();
+        }
+        else
+        {
+            VictimLocation = Victim.Location;
+
+            V = DHVehicle(Victim);
+
+            if (V != none && V.Cannon != none && V.Cannon.AttachmentBone != '')
+            {
+                // Raise the trace location to the cannon bone height
+                VictimLocation.Z = V.GetBoneCoords(V.Cannon.AttachmentBone).Origin.Z;
+            }
         }
 
         // Trace from explosion point to the actor to check whether anything is in the way that could shield it from the blast

--- a/DH_Engine/Classes/DHArtilleryShell.uc
+++ b/DH_Engine/Classes/DHArtilleryShell.uc
@@ -370,7 +370,7 @@ function HurtRadius(float DamageAmount, float DamageRadius, class<DamageType> Da
 
         if (C != none)
         {
-            VictimLocation = C.GetOptimalTraceLocation();
+            VictimLocation = C.GetExplosiveDamageTraceLocation();
         }
         else
         {

--- a/DH_Engine/Classes/DHConstruction.uc
+++ b/DH_Engine/Classes/DHConstruction.uc
@@ -126,7 +126,7 @@ var     float   FloatToleranceInMeters;             // The distance the construc
 var     float   DuplicateFriendlyDistanceInMeters;  // The distance required between identical constructions of the same type for FRIENDLY constructions.
 var     float   DuplicateEnemyDistanceInMeters;     // The distance required between identical constructions of the same type for ENEMY constructions.
 
-var     vector  OptimalTraceOffset;                 // Optimal location for tracing this actor (relative to origin). Generally, should be near the center of the mesh.
+var     vector  ExplosionDamageTraceOffset;         // Optimal location for tracing this actor when dealing explosive damage (relative to origin)
 
 // Construction
 var private int SupplyCost;                     // The amount of supply points this construction costs
@@ -269,11 +269,11 @@ final function SetTeamIndex(int TeamIndex)
     NetUpdateTime = Level.TimeSeconds - 1.0;
 }
 
-// Return a reliable location for tracing this actor, as tracing origin can
-// fail unexpectedly (for example, if it's sunk under the terrain)
-simulated function vector GetOptimalTraceLocation()
+// Return a reliable location for tracing this actor by explosives, as tracing
+// origin can fail unexpectedly (for example, if it's sunk under the terrain)
+simulated function vector GetExplosiveDamageTraceLocation()
 {
-    return Location + (OptimalTraceOffset >> Rotation);
+    return Location + (ExplosionDamageTraceOffset >> Rotation);
 }
 
 function IncrementProgress(Pawn InstigatedBy)
@@ -1320,7 +1320,7 @@ defaultproperties
     bProjTarget=true
     bPathColliding=true
     bWorldGeometry=true
-    OptimalTraceOffset=(Z=10.0)
+    ExplosionDamageTraceOffset=(Z=10.0)
 
     // Placement
     bCanPlaceInWater=false

--- a/DH_Engine/Classes/DHConstruction.uc
+++ b/DH_Engine/Classes/DHConstruction.uc
@@ -126,6 +126,8 @@ var     float   FloatToleranceInMeters;             // The distance the construc
 var     float   DuplicateFriendlyDistanceInMeters;  // The distance required between identical constructions of the same type for FRIENDLY constructions.
 var     float   DuplicateEnemyDistanceInMeters;     // The distance required between identical constructions of the same type for ENEMY constructions.
 
+var     vector  OptimalTraceOffset;                 // Optimal location for tracing this actor (relative to origin). Generally, should be near the center of the mesh.
+
 // Construction
 var private int SupplyCost;                     // The amount of supply points this construction costs
 var     bool    bDestroyOnConstruction;         // If true, this actor will be destroyed after being fully constructed
@@ -265,6 +267,13 @@ final function SetTeamIndex(int TeamIndex)
     self.TeamIndex = TeamIndex;
     OnTeamIndexChanged();
     NetUpdateTime = Level.TimeSeconds - 1.0;
+}
+
+// Return a reliable location for tracing this actor, as tracing origin can
+// fail unexpectedly (for example, if it's sunk under the terrain)
+simulated function vector GetOptimalTraceLocation()
+{
+    return Location + (OptimalTraceOffset >> Rotation);
 }
 
 function IncrementProgress(Pawn InstigatedBy)
@@ -1311,6 +1320,7 @@ defaultproperties
     bProjTarget=true
     bPathColliding=true
     bWorldGeometry=true
+    OptimalTraceOffset=(Z=10.0)
 
     // Placement
     bCanPlaceInWater=false

--- a/DH_Engine/Classes/DHMortarProjectile.uc
+++ b/DH_Engine/Classes/DHMortarProjectile.uc
@@ -359,7 +359,7 @@ function HurtRadius(float DamageAmount, float DamageRadius, class<DamageType> Da
 
         if (C != none)
         {
-            VictimLocation = C.GetOptimalTraceLocation();
+            VictimLocation = C.GetExplosiveDamageTraceLocation();
         }
         else
         {

--- a/DH_Engine/Classes/DHMortarProjectile.uc
+++ b/DH_Engine/Classes/DHMortarProjectile.uc
@@ -308,6 +308,7 @@ function HurtRadius(float DamageAmount, float DamageRadius, class<DamageType> Da
 {
     local Actor         Victim, TraceActor;
     local DHVehicle     V;
+    local DHConstruction C;
     local ROPawn        P;
     local array<ROPawn> CheckedROPawns;
     local bool          bAlreadyChecked, bAlreadyDead;
@@ -352,15 +353,25 @@ function HurtRadius(float DamageAmount, float DamageRadius, class<DamageType> Da
             continue;
         }
 
-        // Now we need to check whether there's something in the way that could shield this actor from the blast
-        // Usually we trace to actor's location, but for a vehicle with a cannon we adjust Z location to give a more consistent, realistic tracing height
-        // This is because many vehicles are modelled with their origin on the ground, so even a slight bump in the ground could block all blast damage!
-        VictimLocation = Victim.Location;
-        V = DHVehicle(Victim);
+        // Before tracing the victim, we must adjust its location for certain types of actors
+        // Tracing to origin can be unreliable as it's usually located at the bottom and can sink under the terrain, blocking the blast damage
+        C = DHConstruction(Victim);
 
-        if (V != none && V.Cannon != none && V.Cannon.AttachmentBone != '')
+        if (C != none)
         {
-            VictimLocation.Z = V.GetBoneCoords(V.Cannon.AttachmentBone).Origin.Z;
+            VictimLocation = C.GetOptimalTraceLocation();
+        }
+        else
+        {
+            VictimLocation = Victim.Location;
+
+            V = DHVehicle(Victim);
+
+            if (V != none && V.Cannon != none && V.Cannon.AttachmentBone != '')
+            {
+                // Raise the trace location to the cannon bone height
+                VictimLocation.Z = V.GetBoneCoords(V.Cannon.AttachmentBone).Origin.Z;
+            }
         }
 
         // Trace from explosion point to the actor to check whether anything is in the way that could shield it from the blast

--- a/DH_Engine/Classes/DHThrowableExplosiveProjectile.uc
+++ b/DH_Engine/Classes/DHThrowableExplosiveProjectile.uc
@@ -233,7 +233,7 @@ function HurtRadius(float DamageAmount, float DamageRadius, class<DamageType> Da
 
         if (C != none)
         {
-            VictimLocation = C.GetOptimalTraceLocation();
+            VictimLocation = C.GetExplosiveDamageTraceLocation();
         }
         else
         {

--- a/DH_Engine/Classes/DHThrowableExplosiveProjectile.uc
+++ b/DH_Engine/Classes/DHThrowableExplosiveProjectile.uc
@@ -176,6 +176,7 @@ function HurtRadius(float DamageAmount, float DamageRadius, class<DamageType> Da
 {
     local Actor         Victim, TraceActor;
     local DHVehicle     V;
+    local DHConstruction C;
     local ROPawn        P;
     local array<ROPawn> CheckedROPawns;
     local bool          bAlreadyChecked;
@@ -226,15 +227,25 @@ function HurtRadius(float DamageAmount, float DamageRadius, class<DamageType> Da
             continue;
         }
 
-        // Now we need to check whether there's something in the way that could shield this actor from the blast
-        // Usually we trace to actor's location, but for a vehicle with a cannon we adjust Z location to give a more consistent, realistic tracing height
-        // This is because many vehicles are modelled with their origin on the ground, so even a slight bump in the ground could block all blast damage!
-        VictimLocation = Victim.Location;
-        V = DHVehicle(Victim);
+        // Before tracing the victim, we must adjust its location for certain types of actors
+        // Tracing to origin can be unreliable as it's usually located at the bottom and can sink under the terrain, blocking the blast damage
+        C = DHConstruction(Victim);
 
-        if (V != none && V.Cannon != none && V.Cannon.AttachmentBone != '')
+        if (C != none)
         {
-            VictimLocation.Z = V.GetBoneCoords(V.Cannon.AttachmentBone).Origin.Z;
+            VictimLocation = C.GetOptimalTraceLocation();
+        }
+        else
+        {
+            VictimLocation = Victim.Location;
+
+            V = DHVehicle(Victim);
+
+            if (V != none && V.Cannon != none && V.Cannon.AttachmentBone != '')
+            {
+                // Raise the trace location to the cannon bone height
+                VictimLocation.Z = V.GetBoneCoords(V.Cannon.AttachmentBone).Origin.Z;
+            }
         }
 
         // Trace from explosion point to the actor to check whether anything is in the way that could shield it from the blast


### PR DESCRIPTION
Constructions can end up with their origin point wedged under the terrain, which makes them untraceable and immune to blast damage. This is fixed by changing the trace target to a custom location instead of origin.

Fixes #314