### PR TITLE
Fixed a bug where players lose score after rejoining a match

### DIFF
--- a/DH_Engine/Classes/DHPlayer.uc
+++ b/DH_Engine/Classes/DHPlayer.uc
@@ -310,8 +310,6 @@ simulated event PostBeginPlay()
 
     if (Role == ROLE_Authority)
     {
-        ScoreManager = new class'DHScoreManager';
-
         if (DarkestHourGame(Level.Game) != none && DarkestHourGame(Level.Game).bBigBalloony)
         {
             IQManager = Spawn(class'DHIQManager', self);
@@ -349,6 +347,16 @@ simulated event PostNetBeginPlay()
         }
 
         ServerSetClientGUID(ClientGUID);
+    }
+}
+
+// Called by PostLogin event
+function OnPlayerLogin()
+{
+    // Create score manager if it wasn't recovered from a previous session
+    if (ScoreManager == none)
+    {
+        ScoreManager = new class'DHScoreManager';
     }
 }
 
@@ -3220,20 +3228,33 @@ function OnTeamChanged()
         }
     }
 
-    // Update the player's linked score manager to their new team's score manager.
-    if (ScoreManager != none)
-    {
-        TeamIndex = GetTeamNum();
+    LinkTeamScoreManager();
+}
 
-        if (TeamIndex >= 0 && TeamIndex < arraycount(G.TeamScoreManagers))
-        {
-            ScoreManager.NextScoreManager = G.TeamScoreManagers[TeamIndex];
-        }
-        else
-        {
-            // Player joined spectators, clear the next score manager.
-            ScoreManager.NextScoreManager = none;
-        }
+// Update the player's linked score manager to their new team's score manager
+function LinkTeamScoreManager()
+{
+    local DarkestHourGame G;
+    local int TeamIndex;
+
+    G = DarkestHourGame(Level.Game);
+
+    if (G == none || ScoreManager == none)
+    {
+        Log("Failed to link team score manager");
+        return;
+    }
+
+    TeamIndex = GetTeamNum();
+
+    if (TeamIndex >= 0 && TeamIndex < arraycount(G.TeamScoreManagers))
+    {
+        ScoreManager.NextScoreManager = G.TeamScoreManagers[TeamIndex];
+    }
+    else
+    {
+        // Player joined spectators, clear the next score manager
+        ScoreManager.NextScoreManager = none;
     }
 }
 

--- a/DH_Engine/Classes/DHPlayerSession.uc
+++ b/DH_Engine/Classes/DHPlayerSession.uc
@@ -10,9 +10,118 @@ var int         WeaponLockViolations;
 var int         WeaponUnlockTime;
 var int         LastKilledTime;
 var int         Kills;
-var int         TotalScore;
-var int         CategoryScores[2];
 var int         Deaths;
 var int         NextChangeTeamTime;
 var byte        TeamIndex;
 
+var DHScoreManager ScoreManager;
+
+function Save(DHPlayer PC)
+{
+    local DHPlayerReplicationInfo PRI;
+
+    if (PC == none)
+    {
+        Log("Failed to save player session: No constroller");
+        return;
+    }
+
+    PRI = DHPlayerReplicationInfo(PC.PlayerReplicationInfo);
+
+    if (PRI == none)
+    {
+        Log("Failed to save player session: No PRI");
+        return;
+    }
+
+    // Scores
+    ScoreManager = PC.ScoreManager;
+    Deaths = PRI.Deaths;
+    Kills = PRI.Kills;
+
+    // Misc
+    LastKilledTime = PC.LastKilledTime;
+    NextChangeTeamTime = PC.NextChangeTeamTime;
+
+    // Weapon lock
+    WeaponUnlockTime = PC.WeaponUnlockTime;
+    WeaponLockViolations = PC.WeaponLockViolations;
+
+    // Save current team
+    if (PRI.Team != none)
+    {
+        TeamIndex = PRI.Team.TeamIndex;
+    }
+}
+
+function Load(DHPlayer PC)
+{
+    local DHPlayerReplicationInfo PRI;
+    local DHGameReplicationInfo GRI;
+    local DarkestHourGame DHG;
+    local int i;
+
+    if (PC == none)
+    {
+        Log("Failed to load player session: No controller");
+        return;
+    }
+
+    PRI = DHPlayerReplicationInfo(PC.PlayerReplicationInfo);
+
+    if (PRI == none)
+    {
+        Log("Failed to load player session: No PRI");
+        return;
+    }
+
+    if (ScoreManager != none)
+    {
+        PC.ScoreManager = ScoreManager;
+    }
+    else
+    {
+        Log("Error when loading player session: Missing ScoreManager");
+    }
+
+    // Scores
+    PRI.Deaths = Deaths;
+    PRI.Kills = Kills;
+    PRI.DHKills = Kills;
+    PRI.Score = ScoreManager.TotalScore;
+    PRI.TotalScore = ScoreManager.TotalScore;
+
+    for (i = 0; i < arraycount(PRI.CategoryScores); ++i)
+    {
+        PRI.CategoryScores[i] = ScoreManager.CategoryScores[i];
+    }
+
+    // Misc
+    PC.LastKilledTime = LastKilledTime;
+    PC.NextChangeTeamTime = NextChangeTeamTime;
+
+    // Weapon lock
+    PC.WeaponLockViolations = WeaponLockViolations;
+
+    GRI = DHGameReplicationInfo(PC.GameReplicationInfo);
+
+    if (GRI != none && WeaponUnlockTime > GRI.ElapsedTime)
+    {
+        PC.LockWeapons(WeaponUnlockTime - GRI.ElapsedTime);
+    }
+
+    DHG = DarkestHourGame(PC.Level.Game);
+
+    if (DHG != none)
+    {
+        // Add player back to the old team
+        DHG.Teams[TeamIndex].AddToTeam(PC);
+    }
+    else
+    {
+        Log("Failed to add to player to the team from the previous session: Game is none");
+    }
+
+    // Ensure a correct team score manager is linked
+    PC.LinkTeamScoreManager();
+}

--- a/DH_Engine/Classes/DarkestHourGame.uc
+++ b/DH_Engine/Classes/DarkestHourGame.uc
@@ -5312,26 +5312,7 @@ event PostLogin(PlayerController NewPlayer)
 
             if (S != none)
             {
-                PRI.Deaths = S.Deaths;
-                PRI.DHKills = S.Kills;
-                PRI.Score = S.TotalScore;
-                PRI.TotalScore = S.TotalScore;
-
-                for (i = 0; i < arraycount(PRI.CategoryScores); ++i)
-                {
-                    PRI.CategoryScores[i] = S.CategoryScores[i];
-                }
-
-                Teams[S.TeamIndex].AddToTeam(PC);
-
-                PC.LastKilledTime = S.LastKilledTime;
-                PC.WeaponLockViolations = S.WeaponLockViolations;
-                PC.NextChangeTeamTime = S.NextChangeTeamTime;
-
-                if (GameReplicationInfo != none && S.WeaponUnlockTime > GameReplicationInfo.ElapsedTime)
-                {
-                    PC.LockWeapons(S.WeaponUnlockTime - GameReplicationInfo.ElapsedTime);
-                }
+                S.Load(PC);
             }
         }
 
@@ -5348,9 +5329,10 @@ event PostLogin(PlayerController NewPlayer)
     if (PC != none)
     {
         PC.bSpectateAllowViewPoints = bSpectateAllowViewPoints && ViewPoints.Length > 0;
-    }
+        class'DHGeolocationService'.static.GetIpData(PC);
 
-    class'DHGeolocationService'.static.GetIpData(PC);
+        PC.OnPlayerLogin();
+    }
 }
 
 // Override to leave hash and info in PlayerData, basically to save PRI data for the session
@@ -5384,6 +5366,7 @@ function Logout(Controller Exiting)
         return;
     }
 
+    // Save the current session info
     if (PC.ROIDHash != "" && !PlayerSessions.Get(PC.ROIDHash, O))
     {
         O = new class'DHPlayerSession';
@@ -5394,24 +5377,7 @@ function Logout(Controller Exiting)
 
     if (S != none)
     {
-        S.Deaths = PRI.Deaths;
-        S.Kills = PRI.DHKills;
-        S.TotalScore = PRI.TotalScore;
-
-        for (i = 0; i < arraycount(S.CategoryScores); ++i)
-        {
-            S.CategoryScores[i] = PRI.CategoryScores[i];
-        }
-
-        S.LastKilledTime = PC.LastKilledTime;
-        S.WeaponUnlockTime = PC.WeaponUnlockTime;
-        S.WeaponLockViolations = PC.WeaponLockViolations;
-        S.NextChangeTeamTime = PC.NextChangeTeamTime;
-
-        if (PRI.Team != none)
-        {
-            S.TeamIndex = PRI.Team.TeamIndex;
-        }
+        S.Save(PC);
     }
 }
 


### PR DESCRIPTION
Fixes #1663

Other changes:
- Player score managers now persist between client sessions.
- Moved code for saving and restoring sessions into the `DHPlayerSession` class.