### PR TITLE
Removed stagnation death from sandbags:

### DIFF
--- a/DH_Construction/Classes/DHConstruction_Sandbags.uc
+++ b/DH_Construction/Classes/DHConstruction_Sandbags.uc
@@ -17,6 +17,8 @@ defaultproperties
     bIsNeutral=true
     bAcceptsProjectors=false
 
+    bCanDieOfStagnation=false
+
     // Damage
     DamageTypeScales(0)=(DamageType=class'DHShellAPImpactDamageType',Scale=0.33)            // AP Impact
     DamageTypeScales(1)=(DamageType=class'DHRocketImpactDamage',Scale=0.33)                 // AT Rocket Impact


### PR DESCRIPTION
- Partially built sandbags will now live indefinitely. Given that partially constructed sandbags can potentially be more useful in some scenarios than fully built ones, this allows players the choice for instance of if they want a half wall or full wall, or covered bunker vs. open bunker.