### PR TITLE
Fixed AP Bullet Damage Modifiers

### DIFF
--- a/DH_Vehicles/Classes/DH_50CalDamType.uc
+++ b/DH_Vehicles/Classes/DH_50CalDamType.uc
@@ -9,10 +9,10 @@ class DH_50CalDamType extends DHLargeCaliberDamageType
 defaultproperties
 {
     HUDIcon=Texture'InterfaceArt_tex.deathicons.b792mm'
-    TankDamageModifier=0.2
-    APCDamageModifier=0.3
-    VehicleDamageModifier=0.4
-    TreadDamageModifier=0.25  // 0.5 in 234/1, 1.0 in PTRD
+    TankDamageModifier=0.05 // These values are unusually low to compensate for the now significantly increased bullet damage of the .50 cal.
+    APCDamageModifier=0.08
+    VehicleDamageModifier=0.12
+    TreadDamageModifier=0.07  // 0.5 in 234/1, 1.0 in PTRD
     WeaponClass=class'DH_Weapons.DH_30calWeapon' // 50 cal is vehicle only & doesn't have a WeaponClass in DH_Weapons - never mind, just use dummy class & 50 cal specific death strings
     DeathString="%o was killed by %k's .50 cal machine gun."
     FemaleSuicide="%o was killed by her own .50 cal machine gun."

--- a/DH_Vehicles/Classes/DH_50CalVehicleBullet.uc
+++ b/DH_Vehicles/Classes/DH_50CalVehicleBullet.uc
@@ -23,7 +23,6 @@ defaultproperties
     BallisticCoefficient=0.65 // sources vary (as do actual round apparently), but this is about the consensus, with AP rounds a little lower than standard ball ammo
 
 	//Damage
-    ImpactDamage=75
     Damage=450.0
     HullFireChance=0.05
     EngineFireChance=0.07  //assuming that some bullets in the belt are incendiary

--- a/DH_Weapons/Classes/DH_PTRDBullet.uc
+++ b/DH_Weapons/Classes/DH_PTRDBullet.uc
@@ -13,11 +13,10 @@ defaultproperties
     BallisticCoefficient=0.675 // sources vary (as do actual round apparently), but this is about the consensus, with AP rounds a little lower than standard ball ammo
 
     //Damage
-    ImpactDamage=120
     Damage=1000.0  //should leave no one alive, as even if it hits a limb, it should be ripped apart making victim uncapable of continuing fighting
     MyDamageType=class'DH_Weapons.DH_PTRDDamType'
-    HullFireChance=0.12  //although its just a bullet, it has a bit of incendiary part in it which should make it more likely to ignite or detonate something
-    EngineFireChance=0.2
+    HullFireChance=0.15  //although its just a bullet, it has a bit of incendiary part in it which should make it more likely to ignite or detonate something
+    EngineFireChance=0.23
 
     //adjusted penetration, my main source is this https://media.discordapp.net/attachments/339838693617565697/661960666399244320/5450cb284c38.png?width=883&height=621
     //Penetration

--- a/DH_Weapons/Classes/DH_PTRDDamType.uc
+++ b/DH_Weapons/Classes/DH_PTRDDamType.uc
@@ -11,10 +11,10 @@ defaultproperties
     WeaponClass=class'DH_Weapons.DH_PTRDWeapon'
     HUDIcon=Texture'InterfaceArt_tex.deathicons.b762mm'
 
-    TankDamageModifier=0.2
-    APCDamageModifier=0.3
-    VehicleDamageModifier=0.3
-    TreadDamageModifier=0.3
+    TankDamageModifier=0.09
+    APCDamageModifier=0.13
+    VehicleDamageModifier=0.13
+    TreadDamageModifier=0.08
 
     PawnDamageEmitter=class'DH_Effects.DHBloodPuffLargeCaliber'
     bThrowRagdoll=true


### PR DESCRIPTION
.50 Cal:

- Reduced damage modifier to recreate damage output prior to commit b787a8d. Now requires approximately 50 rounds to kill a tank (unless hitting an ammo rack, or RNG shrapnel damage) vs. 10 rounds from the above mentioned commit. 

PTRD: 

- Same as above, reduced damage modifiers to match old damage output. This does significantly reduce the effectiveness of the PTRD, though, and may require further tweaking in the future. To compensate, I slightly increased fire chance modifiers on the round, as it was an incendiary bullet (new values are closer to German 20mm AP (which is solid shot and doesn't actually have any incendiary load).