### PR TITLE
Update to Sherman 105 and StuH42:

### DIFF
--- a/DH_Vehicles/Classes/DH_ShermanM4A3105CannonShellHEAT.uc
+++ b/DH_Vehicles/Classes/DH_ShermanM4A3105CannonShellHEAT.uc
@@ -14,8 +14,8 @@ defaultproperties
 
     //Damage
     ImpactDamage=650  //1.6 KG TNT
-    Damage=700.0
-    DamageRadius=1000.0
+    Damage=415.0
+    DamageRadius=700.0
 
     //Effects
     DrawScale=1.5

--- a/DH_Vehicles/Classes/DH_ShermanTank_M4A3105_Howitzer.uc
+++ b/DH_Vehicles/Classes/DH_ShermanTank_M4A3105_Howitzer.uc
@@ -16,7 +16,7 @@ defaultproperties
     SpawnOverlay(0)=Material'DH_InterfaceArt_tex.Vehicles.sherman_m4a3_105'
 
     // Damage
-	// Compared to M4A375W: 105mm ammo is more likely to explode
-	AmmoIgnitionProbability=0.88  // 0.75 default
+    // Compared to M4A375W: 105mm ammo is more likely to explode
+    AmmoIgnitionProbability=0.88  // 0.75 default
 
 }

--- a/DH_Vehicles/Classes/DH_StuH42Cannon.uc
+++ b/DH_Vehicles/Classes/DH_StuH42Cannon.uc
@@ -18,9 +18,9 @@ defaultproperties
     ProjectileDescriptions(1)="Smoke"
     ProjectileDescriptions(2)="HEAT"
 
-    nProjectileDescriptions(0)="Sprgr.Patr."
+    nProjectileDescriptions(0)="F.H.Gr."
     nProjectileDescriptions(1)="F.H.Gr.Nb."
-    nProjectileDescriptions(2)="Gr.38 Hl/C"
+    nProjectileDescriptions(2)="Gr.39 Hl/C"
 
     InitialPrimaryAmmo=18
     InitialSecondaryAmmo=5

--- a/DH_Vehicles/Classes/DH_StuH42CannonShellHEAT.uc
+++ b/DH_Vehicles/Classes/DH_StuH42CannonShellHEAT.uc
@@ -13,8 +13,8 @@ defaultproperties
     BallisticCoefficient=2.96
 
     //Damage
-    ImpactDamage=373  //~~600 gramms TNT
-    Damage=300.0
+    ImpactDamage=650 // 1.49kg of PETN: UK HANDBOOK OF ENEMY AMMUNITION PAMPHLET No. 14
+    Damage=415.0
     DamageRadius=700.0
 
     bDebugInImperial=false

--- a/DH_Vehicles/Classes/DH_StuH42Destroyer.uc
+++ b/DH_Vehicles/Classes/DH_StuH42Destroyer.uc
@@ -20,10 +20,10 @@ defaultproperties
     SpawnOverlay(0)=Material'DH_InterfaceArt_tex.Vehicles.stuh42'
 
     // Damage
-	// cons: petrol fuel; 105mm ammo is more likely to explode
-	// 4 men crew
-	AmmoIgnitionProbability=0.88  // 0.75 default
+    // cons: petrol fuel; 105mm ammo is more likely to explode
+    // 4 men crew
+    AmmoIgnitionProbability=0.88  // 0.75 default
     Health=525
     HealthMax=525.0
-	EngineHealth=300
+    EngineHealth=300
 }

--- a/DH_Vehicles/Classes/DH_Stug3GDestroyer.uc
+++ b/DH_Vehicles/Classes/DH_Stug3GDestroyer.uc
@@ -60,11 +60,11 @@ defaultproperties
     MaxCriticalSpeed=729.0 // 43 kph
 
     // Damage
-	// cons: petrol fuel;
-	// 4 men crew
+    // cons: petrol fuel;
+    // 4 men crew
     Health=525
     HealthMax=525.0
-	EngineHealth=300
+    EngineHealth=300
     EngineToHullFireChance=0.1  //increased from 0.05 for all petrol engines
     DisintegrationHealth=-800.0 //petrol
     VehHitpoints(0)=(PointRadius=20.0,PointHeight=25.0,PointOffset=(X=-90.0)) // engine


### PR DESCRIPTION
Sherman 105:

- Reduced damage and damage radius of 105 HEAT shell to old values. This projectile has a large HE filler, but it's still a shaped charge, not HE-frag. Even the old values are possibly overperforming, but I suppose 11.5 meter lethal radius is acceptable.
- Fixed some spacing errors in the comments of the Sherman 105.

StuH42:

- Reverted damage and impact damage to old values for StuH42 HEAT shell (matches Sherman 105, which is a roughly equivelant shell in performance). Also added comment correcting the previously erroneous filler value with source.
- Updated native names for StuH projectiles. StuH 42 fired Feld Haubitze Granate for HE (and this was even reflected in the smoke shell name already) and fires Gr.39 for HEAT (distinct from the Gr.38 used in 7.5cm guns and possibly what lead to confusion over performance of the shell used in this vehicle).
- Fixed some spacing errors in the comments for StuG3 and StuH42.