### PR TITLE
Level Updates and Event Maps

### DIFF
--- a/DarkestHourDev/Maps/DH-Armored_Wacht_am_Rhein_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Armored_Wacht_am_Rhein_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:924e5296dc3bdc477f509e1c01334750c0ac058311c762d309cbe789ba667d0f
-size 39569206
+oid sha256:351ad0d7fc2e85edab05e08c5a4d66de900a66b3bb85f0ec4610b6c9e7638186
+size 39340937

--- a/DarkestHourDev/Maps/DH-Bremoy_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Bremoy_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:efbe25978fe8f460726598522b750e149ec55361146f1eee5cddd77e534cf3e3
-size 62398734
+oid sha256:43749c1df1395a41cde68df432a1abfc92a01dbf5310c847a3c18a6d04fb55ec
+size 62386610

--- a/DarkestHourDev/Maps/DH-Gran_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Gran_Advance.rom
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eecff6275d19af1597b28039ec11986c9a7c0384d1357b66dd8be7641219a64b
+size 31398485

--- a/DarkestHourDev/Maps/DH-Kriegstadt_Push_USA.rom
+++ b/DarkestHourDev/Maps/DH-Kriegstadt_Push_USA.rom
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e85eca105e519c19c5569e4d8521209ec7defe2f5a990091bef19138b31d7566
+size 65924513


### PR DESCRIPTION
Bremoy:

- Optimized terrain and deco layers, hopefully increasing performance slightly.
- Added small +2% team balance ratio towards Allies.
- Reworked all objective Danger Zone influences.
- Removed ticket bleed from first objective.
- Reduced Panther max spawns from infinite to 3.
- Reduced Sherman MkII respawn timer from 220 seconds to 180.
- Increased Firefly max spawns from 2 to 3 and reduced respawn timer to 180 seconds.
- Increased Stuart spawns from 1 to 5 and reduced respawn timer to 200 seconds.
- Increased max AT guns for Allies of all types from 1 to 2 and reduced respawn timer to 120 seconds.
- Added Wolverine SP (British M10) with 3 spawns to Allies.

Kriegstadt Push USA:

- Recreated the classic 29th style US faction version.

Gran Advance:

- Infantry version of popular armored map.

Wacht am Rhein:

- Fixed bug where Axis would sometimes spawn under the terrain.
- Added a new objective.