### PR TITLE
Feature/ammocrates resupply grenades

### DIFF
--- a/DH_Engine/Classes/DHMortarWeapon.uc
+++ b/DH_Engine/Classes/DHMortarWeapon.uc
@@ -351,7 +351,7 @@ defaultproperties
     Priority=99 // super high value so mortar is always ranked as best/preferred weapon to bring up
     bCanThrow=false
     bCanSway=false
-
+    bCanResupplyWhenEmpty=false
     SelectAnim="Draw"
     PutDownAnim="putaway"
     DeployAnimation="Deploy"

--- a/DH_Engine/Classes/DHPawn.uc
+++ b/DH_Engine/Classes/DHPawn.uc
@@ -5663,6 +5663,7 @@ function ResupplyMissingGrenadesAndItems(int TimeSeconds)
 {
     local int i;
     local DHRoleInfo RI;
+    local class<Weapon> WeaponClass;
 
     RI = GetRoleInfo();
     if (RI == none)
@@ -5680,12 +5681,15 @@ function ResupplyMissingGrenadesAndItems(int TimeSeconds)
         }
     }
 
-    //Resupplying of satchels etc
+    //Resupplying of thrown items, satchels etc
     for (i = 0; i < RI.GivenItems.Length; i++)
     {
         if (RI.GivenItems[i] != "")
         {
-            ServerGiveWeapon(RI.GivenItems[i], false);
+	        WeaponClass = class<Weapon>(DynamicLoadObject(RI.GivenItems[i], class'Class'));
+            if (WeaponClass.default.bCanThrow) {
+                ServerGiveWeapon(RI.GivenItems[i], false);
+            }
         }
     }
 }

--- a/DH_Engine/Classes/DHPawn.uc
+++ b/DH_Engine/Classes/DHPawn.uc
@@ -5663,7 +5663,7 @@ function ResupplyMissingGrenadesAndItems(int TimeSeconds)
 {
     local int i;
     local DHRoleInfo RI;
-    local class<Weapon> WeaponClass;
+    local class<DHWeapon> WeaponClass;
 
     RI = GetRoleInfo();
     if (RI == none)
@@ -5686,8 +5686,8 @@ function ResupplyMissingGrenadesAndItems(int TimeSeconds)
     {
         if (RI.GivenItems[i] != "")
         {
-	        WeaponClass = class<Weapon>(DynamicLoadObject(RI.GivenItems[i], class'Class'));
-            if (WeaponClass.default.bCanThrow) {
+	        WeaponClass = class<DHWeapon>(DynamicLoadObject(RI.GivenItems[i], class'Class'));
+            if (WeaponClass != none && WeaponClass.default.bCanResupplyWhenEmpty) {
                 ServerGiveWeapon(RI.GivenItems[i], false);
             }
         }

--- a/DH_Engine/Classes/DHWeapon.uc
+++ b/DH_Engine/Classes/DHWeapon.uc
@@ -34,6 +34,7 @@ var     bool            bHasBeenDrawn;
 
 var     float           ResupplyInterval;
 var     int             LastResupplyTimestamp;
+var     bool            bCanResupplyWhenEmpty;
 
 // For some absolutely fucked reason, RO sets their sprint animation rates at 1.5x by default.
 // We allow ourselves the ability to override this nonsense.
@@ -1107,7 +1108,7 @@ defaultproperties
     bCanHaveInitialNumMagsChanged=true
 
     bUsesIronsightFOV=true
-
+    bCanResupplyWhenEmpty=true
     ResupplyInterval=2.5
 
     SprintStartAnimRate=1.5

--- a/DH_Equipment/Classes/DHRadioItem.uc
+++ b/DH_Equipment/Classes/DHRadioItem.uc
@@ -127,5 +127,6 @@ defaultproperties // TODO: perhaps make this remote role none so it doesn't repl
     AttachBoneName="hip"
     RadioClass=class'DH_Engine.DHInfantryRadio'
     bCanThrow=false
+    bCanResupplyWhenEmpty=false
     bCanSway=false
 }

--- a/DH_Equipment/Classes/DHShovelItem.uc
+++ b/DH_Equipment/Classes/DHShovelItem.uc
@@ -94,6 +94,7 @@ defaultproperties
 
     DisplayFOV=80.0
     bCanSway=false
+    bCanResupplyWhenEmpty=false
 
     CrawlStartAnim="crawl_in"
     CrawlEndAnim="crawl_out"

--- a/DH_Equipment/Classes/DHWireCuttersItem.uc
+++ b/DH_Equipment/Classes/DHWireCuttersItem.uc
@@ -230,6 +230,7 @@ defaultproperties
     ZoomOutTime=0.2
     bUsesFreeAim=false
     bCanSway=false
+    bCanResupplyWhenEmpty=false
 
     SelectAnim="Draw" // TODO: rename anims to standard, inherited names & then delete these properties
     PutDownAnim="putaway"

--- a/DH_Weapons/Classes/DH_M9530Weapon.uc
+++ b/DH_Weapons/Classes/DH_M9530Weapon.uc
@@ -3,7 +3,7 @@
 // Darklight Games (c) 2008-2023
 //==============================================================================
 
-class DH_M9530Weapon extends DHBoltActionWeapon; 
+class DH_M9530Weapon extends DHBoltActionWeapon;
 //Austrian 1930 modification of Mannlicher M95
 //Meant for volkssturm loadouts
 //8x56R ammo was non-standard for Germany, so this weapon cannot be resupplied
@@ -42,9 +42,9 @@ defaultproperties
     MaxNumPrimaryMags=3
     InitialNumPrimaryMags=3
     bCanHaveInitialNumMagsChanged=false  //will always spawn with 3 clips no matter the munitions
-    
-    IronBringUpRest="iron_inrest"
 
+    IronBringUpRest="iron_inrest"
+    bCanResupplyWhenEmpty=false
     bHasBayonet=true
     BayonetBoneName="bayonet"
     BayoAttachAnim="Bayonet_on"


### PR DESCRIPTION
Apply changes from fork to feature resupply grenades branch.
Resupplying of empty given items now check bCanResupplyWhenEmpty before giving the weapon