### PR TITLE
Show avaliable fire support on scoreboard for each team

### DIFF
--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -2351,6 +2351,29 @@ simulated function array<SAvailableArtilleryInfoEntry> GetTeamOffMapFireSupportC
     return Result;
 }
 
+simulated function int GetTeamOffMapFireSupportCount(int TeamIndex)
+{
+    local int i, FireSupportCount;
+    local DH_LevelInfo LI;
+
+    LI = class'DH_LevelInfo'.static.GetInstance(Level);
+
+    if (LI == none)
+    {
+        return 0;
+    }
+
+    for (i = 0; i < LI.ArtilleryTypes.Length; ++i)
+    {
+        if (LI.ArtilleryTypes[i].TeamIndex == TeamIndex && ArtilleryTypeInfos[i].bIsAvailable)
+        {
+            FireSupportCount += ArtilleryTypeInfos[i].Limit - ArtilleryTypeInfos[i].UsedCount;
+        }
+    }
+
+    return FireSupportCount;
+}
+
 function AddKillForTeam(int TeamIndex)
 {
     if (TeamIndex >= 0 && TeamIndex < arraycount(TeamScores))

--- a/DH_Interface/Classes/DHScoreBoard.uc
+++ b/DH_Interface/Classes/DHScoreBoard.uc
@@ -19,6 +19,7 @@ var int MaxPlayersListedPerSide;
 var int MyTeamIndex;
 
 var localized string MunitionPercentageText;
+var localized string FireSupportCountText;
 var localized string PlayersText;
 var localized string TickHealthText;
 var localized string NetHealthText;
@@ -688,6 +689,10 @@ function DHDrawTeam(Canvas C, int TeamIndex, array<DHPlayerReplicationInfo> Team
         // Add the munition percentage
         TeamInfoString $= LargeTabSpaces $ MunitionPercentageText $ ":" @ int(DHGRI.TeamMunitionPercentages[TeamIndex]) $ "%";
 
+        //Add the artillery count
+
+        TeamInfoString $= LargeTabSpaces $ FireSupportCountText $ ":" @ DHGRI.GetTeamOffMapFireSupportCount(TeamIndex);
+
         // Add the team scale if needed
         if (DHGRI.CurrentAlliedToAxisRatio != 0.5)
         {
@@ -1140,6 +1145,7 @@ defaultproperties
     TickHealthText="Tick: "
     NetHealthText="Loss: "
     MunitionPercentageText="Munitions"
+    FireSupportCountText="Fire Support"
     PatronLeadMaterial=Texture'DH_InterfaceArt2_tex.Patron_Icons.PATRON_Lead'
     PatronBronzeMaterial=Texture'DH_InterfaceArt2_tex.Patron_Icons.PATRON_Bronze'
     PatronSilverMaterial=Texture'DH_InterfaceArt2_tex.Patron_Icons.PATRON_Silver'


### PR DESCRIPTION
Adds "Fire Support: " to the scoreboard, to make it easier for both the team and squad leaders to see how much fire support is left for the team to use.

Just another small commit to make the game easier to play and requiring less questions in the chat like "How much arty do we have left?" :)
![scoreboard_allies](https://github.com/DarklightGames/DarkestHour/assets/6305945/22ac4d37-691e-4a5e-b345-e584573b2bdd)
![scoreboard_axis](https://github.com/DarklightGames/DarkestHour/assets/6305945/163f033c-b1f7-4f21-bfc8-fbb7bcd23357)