### PR TITLE
Show main supply count in scoreboard

### DIFF
--- a/DH_Engine/Classes/DHGameReplicationInfo.uc
+++ b/DH_Engine/Classes/DHGameReplicationInfo.uc
@@ -2351,6 +2351,32 @@ simulated function array<SAvailableArtilleryInfoEntry> GetTeamOffMapFireSupportC
     return Result;
 }
 
+simulated function int GetTeamMainSupplyCount(int TeamIndex)
+{
+    local int i;
+
+    for (i = 0; i < arraycount(SupplyPoints); ++i)
+    {
+        if (SupplyPoints[i].ActorClass == none)
+        {
+            continue;
+        }
+
+        // Find the main cache for the team
+        if (SupplyPoints[i].ActorClass.default.bIsMainSupplyCache && SupplyPoints[i].TeamIndex == TeamIndex)
+        {
+            if (SupplyPoints[i].Actor != none)
+            {
+                 // Calculate the supply we can give
+                return SupplyPoints[i].Actor.GetSupplyCount();
+            }
+        }
+    }
+
+    // We did not find a main cache
+    return 0;
+}
+
 function AddKillForTeam(int TeamIndex)
 {
     if (TeamIndex >= 0 && TeamIndex < arraycount(TeamScores))

--- a/DH_Interface/Classes/DHScoreBoard.uc
+++ b/DH_Interface/Classes/DHScoreBoard.uc
@@ -19,6 +19,7 @@ var int MaxPlayersListedPerSide;
 var int MyTeamIndex;
 
 var localized string MunitionPercentageText;
+var localized string SupplyText;
 var localized string PlayersText;
 var localized string TickHealthText;
 var localized string NetHealthText;
@@ -688,6 +689,9 @@ function DHDrawTeam(Canvas C, int TeamIndex, array<DHPlayerReplicationInfo> Team
         // Add the munition percentage
         TeamInfoString $= LargeTabSpaces $ MunitionPercentageText $ ":" @ int(DHGRI.TeamMunitionPercentages[TeamIndex]) $ "%";
 
+        // Add the supplies text
+        TeamInfoString $= LargeTabSpaces $ SupplyText $ ":" @ DHGRI.GetTeamMainSupplyCount(TeamIndex);
+
         // Add the team scale if needed
         if (DHGRI.CurrentAlliedToAxisRatio != 0.5)
         {
@@ -1139,6 +1143,7 @@ defaultproperties
     PlayersText="Players"
     TickHealthText="Tick: "
     NetHealthText="Loss: "
+    SupplyText="Supplies"
     MunitionPercentageText="Munitions"
     PatronLeadMaterial=Texture'DH_InterfaceArt2_tex.Patron_Icons.PATRON_Lead'
     PatronBronzeMaterial=Texture'DH_InterfaceArt2_tex.Patron_Icons.PATRON_Bronze'


### PR DESCRIPTION
Adds "Supplies: " to the scoreboard, to make it easier for both the team and ASL to see how much supplies is left for the team to use.

Just another small commit to make the game easier to play and less of a guesswork on how much supply a logistic truck will spawn with spawn, while the team can also see if the logistic players can still afford to construct buildings.

Similar to https://github.com/DarklightGames/DarkestHour/pull/1673

![scoreboard_supplies_allies](https://github.com/DarklightGames/DarkestHour/assets/6305945/f00ee2a8-fab1-49d9-a87e-b3d8b16ee35d)
![scoreboard_supplies_axis](https://github.com/DarklightGames/DarkestHour/assets/6305945/3b8dc34b-f496-4f83-89bd-0c59c7fdc56c)
