### PR TITLE
Feature/hints squadlead

### DIFF
--- a/DH_Engine/Classes/DHHintManager.uc
+++ b/DH_Engine/Classes/DHHintManager.uc
@@ -207,6 +207,7 @@ defaultproperties
     Hints(54)=(Title="Find a Radio",Text="You have marked a target for long-range fire support. Find a radio so that you can call it in!")
 
     Hints(60)=(Title="Firing Range",Text="This weapon has an adjustable sight! Press %SWITCHFIREMODE% to change the range of the sight.")
-    Hints(61)=(Title="Desperate measures",Text="This weapon uses non-standard ammunition that cannot be resupplied. Don't waste your shots!")
+    Hints(61)=(Title="Desperate Measures",Text="This weapon uses non-standard ammunition that cannot be resupplied. Don't waste your shots!")
+    Hints(62)=(Title="Squad Rally",Text="Squad leaders can place down squad rally points for their squad. Press %PLACERALLYPOINT% to place down a squad rally point that your squad members can spawn from.")
 }
 

--- a/DH_Engine/Classes/DHHintManager.uc
+++ b/DH_Engine/Classes/DHHintManager.uc
@@ -12,7 +12,7 @@ struct HintInfo
     var localized string    Text;  // hint display text
 };
 
-const                   HINT_COUNT = 64;
+const                   HINT_COUNT = 65;
 
 var     HintInfo        Hints[HINT_COUNT];        // array of hints in default properties
 var     array<byte>     QueuedHintIndices;        // queue of hints waiting to be displayed in turn
@@ -209,5 +209,7 @@ defaultproperties
     Hints(60)=(Title="Firing Range",Text="This weapon has an adjustable sight! Press %SWITCHFIREMODE% to change the range of the sight.")
     Hints(61)=(Title="Desperate Measures",Text="This weapon uses non-standard ammunition that cannot be resupplied. Don't waste your shots!")
     Hints(62)=(Title="Squad Rally",Text="Squad leaders can place down squad rally points for their squad. Press %PLACERALLYPOINT% to place down a squad rally point that your squad members can spawn from.")
+    Hints(63)=(Title="Smoke Grenades",Text="Squad leaders are equipped with Smoke Grenades. Press %SwitchWeapon 4% and throw them to provide cover for your squad.")
+    Hints(64)=(Title="Fire Support",Text="Squad leaders can mark down fire support and mortar targets. Press %SwitchWeapon 6% to equip your binoculars.")
 }
 

--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -5672,6 +5672,7 @@ function DrawRallyPointStatus(Canvas C)
         case ERROR_None:
             ErrorIcon = default.RallyPointIconKey;
             ErrorString = class'DarkestHourGame'.static.ParseLoadingHintNoColor("Press [%PLACERALLYPOINT%]", PC);
+            PC.QueueHint(62, false);
             break;
         default:
             break;

--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -5672,7 +5672,10 @@ function DrawRallyPointStatus(Canvas C)
         case ERROR_None:
             ErrorIcon = default.RallyPointIconKey;
             ErrorString = class'DarkestHourGame'.static.ParseLoadingHintNoColor("Press [%PLACERALLYPOINT%]", PC);
+            //Squad leader specific hints
             PC.QueueHint(62, false);
+            PC.QueueHint(63, false);
+            PC.QueueHint(64, false);
             break;
         default:
             break;


### PR DESCRIPTION
The squad leader is a class with many utilities, but new players may not even know of what features they possess.
This is a small step on the way to help the player understand what they can do.

Adds three hints to the squad leader:
**Squad Rally**: _Squad leaders can place down squad rally points for their squad. Press %PLACERALLYPOINT% to place down a squad rally point that your squad members can spawn from._

**Smoke Grenades**: _Squad leaders are equipped with Smoke Grenades. Press %SwitchWeapon 4% and throw them to provide cover for your squad._

**Fire Support**: _Squad leaders can mark down fire support and mortar targets. Press %SwitchWeapon 6% to equip your binoculars._