### PR TITLE
Event Level Updates

### DIFF
--- a/DarkestHourDev/Maps/DH-Klin1941_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Klin1941_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01978a0cc472d13572777fddcd8c246e5b2be3f1a53388cc890ef1fcaef5aa0a
-size 32700975
+oid sha256:d68c49a9fe2dc20cd7622782157d342b87ce4160d0eb2a1ca835d6d98bf1ea23
+size 32699684

--- a/DarkestHourDev/Maps/DH-Kryukovo_Push.rom
+++ b/DarkestHourDev/Maps/DH-Kryukovo_Push.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25ca4d2cb08968f6a088aa1ce2f2b40f990af2e152fd7f6ca8c21d12c36d7ebb
-size 39425674
+oid sha256:c9e17cf14f473f818462c32377f55d7649ca98788385de1afac68e13280e02e2
+size 39426442

--- a/DarkestHourDev/Maps/DH-Kryukovo_Push.rom
+++ b/DarkestHourDev/Maps/DH-Kryukovo_Push.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d2ef7ecf3211cdff8d54e95388573f1baa7eec291be91057778281b2d8de8f9
-size 39404534
+oid sha256:25ca4d2cb08968f6a088aa1ce2f2b40f990af2e152fd7f6ca8c21d12c36d7ebb
+size 39425674

--- a/DarkestHourDev/Maps/DH-Winter_Stalemate_Clash.rom
+++ b/DarkestHourDev/Maps/DH-Winter_Stalemate_Clash.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2b798aab4b7e3d40bf00937b69e188d05476b1176407e7eb81fff92ee44f9b8
-size 44590825
+oid sha256:1c98148251b8a3756812bdfe560113bce05fdbb59f1aec0beb62aaec85309587
+size 44591408

--- a/DarkestHourDev/Maps/DH-Winter_Stalemate_Clash.rom
+++ b/DarkestHourDev/Maps/DH-Winter_Stalemate_Clash.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5fe8aeef09eb4d2a5c7ead3476b89fafcc7e8aeb89b3b5cd7ad7ec95b48e35f
-size 44528725
+oid sha256:a2b798aab4b7e3d40bf00937b69e188d05476b1176407e7eb81fff92ee44f9b8
+size 44590825


### PR DESCRIPTION
Klin 1941:

- Increased Axis ticket modifier by 2.
- Reduced Panzer IV F1 respawn timer from 120 to 90 seconds.
- Increased BT7 respawn timer from 100 to 120 seconds.

Kryukovo:

- Added setup phase with a 60 second timer and new blocking boundaries.
- Increased round time from 20 to 25 minutes.
- Reduced T34/76 respawn timer from 180 to 90 seconds.
- Increased max T34/76 spawns from 3 to 4.
- Increased max Panzer IIIj spawns from 3 to 4.
- Gave Soviets a single very strong artillery strike and added a static radio near their initial spawn point.
- Added spawn protection/noarty minefields to Axis spawns.
- Increased Axis artillery strikes from 1 to 3, but reduced their effectiveness.
- Fixed some misc. bugs (terrain holes, floating trees).
- Disabled Karma collision on fences and small objects.
- Replaced weapon statics with real pickup versions.

Winter Stalemate:

- Added main spawn supply caches for both teams.
- Added gun limits (3 light AT guns) per team.
- Removed KV-1E from Soviets.
- Increased T34/76 spawns from 3 to 5.
- Reduced BT7 and PZIIIJ max active from 2 to 1 and spawns from unlimited to 10.
- Removed Soviet Universal Carrier.
- Increased ticket modifiers of both teams by 2.
- Increased ticket bleed from holding Center objective from 3 to 5 tickets per minute.
- Reworked DZ influences.