### PR TITLE
Raised the health and modifiers of the sdkfz10/5

### DIFF
--- a/DH_Vehicles/Classes/DH_Sdkfz105Transport.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz105Transport.uc
@@ -78,8 +78,8 @@ defaultproperties
     //AmmoIgnitionProbability=0.2  // 0.75 default; 20mm ammo is unlikely to explode
     //TurretDetonationThreshold=5000.0 // increased from 1750
     //above properties dont compile
-    DamagedEffectHealthFireFactor=0.9
-    EngineHealth=50
+    DamagedEffectHealthFireFactor=0.8
+    EngineHealth=100
     VehHitpoints(0)=(PointRadius=20.0,PointBone="Body",PointOffset=(X=93.0,Y=0.0,Z=9.0)) // engine
     VehHitpoints(1)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_F_R",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel
     VehHitpoints(2)=(PointRadius=22.0,PointScale=1.0,PointBone="Wheel_F_L",DamageMultiplier=1.0,HitPointType=HP_Driver) // wheel

--- a/DH_Vehicles/Classes/DH_Sdkfz105TransportArmored.uc
+++ b/DH_Vehicles/Classes/DH_Sdkfz105TransportArmored.uc
@@ -29,5 +29,5 @@ defaultproperties
     VehicleAttachments(0)=(StaticMesh=none) // remove windscreen attachment
     DriverPositions(0)=(TransitionUpAnim="Driver_out")  // to lean forward for a better view through vision slot in armoured shield
     DriverPositions(1)=(TransitionDownAnim="Driver_in") // for reference: camera moves X+25, Z-1
-
+    DamagedEffectHealthFireFactor=0.7
 }


### PR DESCRIPTION
The 105 is kinda relegated to a neusance at worst and a gimmick at best, moved the health up to 100 and changed the damage modifiers to hopefully allow it to be a bit more competative.

-health raised from 50 to 100 (the SDKFZ251 has 150 for reference) 
-lowered the engine fire modifier on the regular 105 to 0.8 
-lowered the engine fire modifier on the ARMORED 105 to 0.7

Now on average the armored variant actually does what it looks like and can take a little more fire, rather than being stopped dead from a tommygun burst.