### PR TITLE
Explosives rework (WIP)

### DIFF
--- a/DH_Weapons/Classes/DH_RG42GrenadeAmmo.uc
+++ b/DH_Weapons/Classes/DH_RG42GrenadeAmmo.uc
@@ -1,0 +1,14 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_RG42GrenadeAmmo extends DHAmmunition;
+
+defaultproperties
+{
+    MaxAmmo=3
+    InitialAmount=2
+    IconMaterial=Material'InterfaceArt_tex.HUD.F1nade_ammo' //CHANGE THIS
+    IconCoords=(X1=445,Y1=75,X2=544,Y2=149)
+}

--- a/DH_Weapons/Classes/DH_RG42GrenadeAttachment.uc
+++ b/DH_Weapons/Classes/DH_RG42GrenadeAttachment.uc
@@ -1,0 +1,14 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_RG42GrenadeAttachment extends DHThrowableExplosiveAttachment;
+
+defaultproperties
+{
+    //Mesh=SkeletalMesh'Weapons3rd_anm.RG42Grenade'
+    MenuImage=Texture'DH_InterfaceArt_tex.weapon_icons.f1grenade_icon'   //CHANGE THIS
+    WA_Idle="idle_F1"
+    WA_Fire="idle_F1"
+}

--- a/DH_Weapons/Classes/DH_RG42GrenadeDamType.uc
+++ b/DH_Weapons/Classes/DH_RG42GrenadeDamType.uc
@@ -1,0 +1,13 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_RG42GrenadeDamType extends DHThrowableExplosiveDamageType
+    abstract;
+
+defaultproperties
+{
+    WeaponClass=class'DH_Weapons.DH_RG42GrenadeWeapon'
+    HUDIcon=Texture'InterfaceArt_tex.deathicons.rusgrenade'  //CHANGE THIS
+}

--- a/DH_Weapons/Classes/DH_RG42GrenadeFire.uc
+++ b/DH_Weapons/Classes/DH_RG42GrenadeFire.uc
@@ -1,0 +1,12 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_RG42GrenadeFire extends DHThrownExplosiveFire;
+
+defaultproperties
+{
+    ProjectileClass=class'DH_Weapons.DH_RG42GrenadeProjectile'
+    AmmoClass=class'DH_Weapons.DH_RG42GrenadeAmmo'
+}

--- a/DH_Weapons/Classes/DH_RG42GrenadePickup.uc
+++ b/DH_Weapons/Classes/DH_RG42GrenadePickup.uc
@@ -1,0 +1,12 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_RG42GrenadePickup extends DHOneShotWeaponPickup;
+
+defaultproperties
+{
+    InventoryType=class'DH_Weapons.DH_RG42GrenadeWeapon'
+    StaticMesh=StaticMesh'WeaponPickupSM.Projectile.F1Grenade'  //CHANGE THIS
+}

--- a/DH_Weapons/Classes/DH_RG42GrenadeProjectile.uc
+++ b/DH_Weapons/Classes/DH_RG42GrenadeProjectile.uc
@@ -1,0 +1,17 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_RG42GrenadeProjectile extends DHGrenadeProjectile;
+
+defaultproperties
+{
+    Damage=150.0
+    DamageRadius=700.0
+    MyDamageType=class'DH_Weapons.DH_RG42GrenadeDamType'
+    //StaticMesh=StaticMesh'WeaponPickupSM.Projectile.F1grenade-throw'  CHANGE THIS
+    ExplosionSound(0)=SoundGroup'Inf_Weapons.stielhandgranate24.stielhandgranate24_explode01'  //this should have a slightly lowered volume, but i couldnt find the value responsible for this
+    ExplosionSound(1)=SoundGroup'Inf_Weapons.stielhandgranate24.stielhandgranate24_explode02'
+    ExplosionSound(2)=SoundGroup'Inf_Weapons.stielhandgranate24.stielhandgranate24_explode03'
+}

--- a/DH_Weapons/Classes/DH_RG42GrenadeTossFire.uc
+++ b/DH_Weapons/Classes/DH_RG42GrenadeTossFire.uc
@@ -1,0 +1,12 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_RG42GrenadeTossFire extends DH_M1GrenadeTossFire;
+
+defaultproperties
+{
+    ProjectileClass=class'DH_Weapons.DH_RG42GrenadeProjectile'
+    AmmoClass=class'DH_Weapons.DH_RG42GrenadeAmmo'
+}

--- a/DH_Weapons/Classes/DH_RG42GrenadeWeapon.uc
+++ b/DH_Weapons/Classes/DH_RG42GrenadeWeapon.uc
@@ -1,0 +1,29 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Darklight Games (c) 2008-2023
+//==============================================================================
+
+class DH_RG42GrenadeWeapon extends DHExplosiveWeapon;
+
+defaultproperties
+{
+    ItemName="RG-42 Grenade"
+    NativeItemName="RG-42 Granata"
+    FireModeClass(0)=class'DH_Weapons.DH_RG42GrenadeFire'
+    FireModeClass(1)=class'DH_Weapons.DH_RG42GrenadeTossFire'
+    AttachmentClass=class'DH_Weapons.DH_RG42GrenadeAttachment'
+    PickupClass=class'DH_Weapons.DH_RG42GrenadePickup'
+
+    Mesh=SkeletalMesh'DH_RG42_1st.RG42_Mesh'
+
+    bUseHighDetailOverlayIndex=false
+
+    FuzeLength=4.0
+    bHasReleaseLever=true
+    LeverReleaseSound=Sound'Inf_Weapons_Foley.F1.f1_handle'
+    LeverReleaseVolume=1.0
+    LeverReleaseRadius=200.0
+    DisplayFOV=80.0
+
+    GroupOffset=0
+}

--- a/DarkestHourDev/Animations/DH_RG42_1st.ukx
+++ b/DarkestHourDev/Animations/DH_RG42_1st.ukx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5aada78d913f11a37f963514bceae134a0ecdc9983c313a0c3f988710d13225a
+size 784916

--- a/DarkestHourDev/Textures/DH_RG42_tex.utx
+++ b/DarkestHourDev/Textures/DH_RG42_tex.utx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25f58df3cffb211a265e55fbcaf673b6a1f4bc588548ec3c007aa199c1e1f6bf
+size 175333


### PR DESCRIPTION
This branch has several main goals:
- add fragmentation effect to explosives that are supposed to have it (this doesnt include HEAT, offensive grenades, satchels and similar). I've talked to basnett and we've planned to work on a simple frag effect that works like a second explosion with greater radius but a random chance of hitting people. Chance does not change with range, but the damage does in the same manner as on regular explosions.

- add new explosives (primarily new offensive/defensive grenades for every nation and the previously worked on nation-specific satchels). Every nation is supposed to have at least one type of offensive and one type of defensive grenade (notable exception is italy, which apparently employed no defensive grenades in ww2), and ideally a specific satchel. This new differentiation is also to be represented in the new role loadouts, where riflemen will get the more capable defensive grenades unlike assaults and most roles, which should give this role a benefit.

- redesign **all** explosives' stats to be consistent relatively to each other. Basically, this means that within a category, a stronger explosive has higher radius and damage than a weaker explosive. For this purpose i've written an excel doc where these stats are generated from base values and TNT equivalent per explosive: https://docs.google.com/spreadsheets/d/1RQDVWjuFQVfzvi7P43DJfL1wfNWGSPdWnquiZy43ZtU/edit?usp=sharing

Explosion stats scale according to cubic root formula. For example, an 800 gramm explosive will have 2 times greater radius and damage than 100 gramm explosive. Base damage and radius values are taken for a 1kg explosive and are then automatically calculated for every individual explosive. There is also suppression stats on the right half of the sheet which are generated from 550gramm instead (its the current german mortar).

The simple idea is that we play with the base values (damage, radius, frag radius multiplier, frag hit chance, suppression values), see how it affects the entire list of explosives, and change them untill we find the new stats to be satisfactory. That way no matter what standard we choose, all explosives will be mathematically consistent according to their type and TNT equivalent and there wont be any stupid arguments about personal bias towards specific explosives.

The base values currently set in the doc is what i have played with and considered a good result, but i am open to suggestions for different values.

Some things to consider:

- I chose to give a different, smaller frag radius multiplier to cannon fired shells. The justification for this is that these shells travel at a significant speed, and when they explode, they transfer their speed and direction to the fragments, which means that more fragments end up hitting the ground/wall that the shell hit, and the rest of fragments are less dense and fly at a lower speed. The actual motivation behind this is that the heaviest shells ended up having pretty big radiuses, while defensive grenades still had pretty low; with the new differentiation the lower and higher ends seem more balanced.

- Panzerfaust, (un)surprisingly, is actually strong, and 1600 grams of TNT are actually 1600 grams. Similar thing can be said for RPG-43 that packs 650 grams compared to 180 of the german stick grenade. Contrary to popular belief, these HEAT explosives are actually supposed to be significantly stronger than the significantly weaker explosives, and it isnt just AAZism. You can see that clearly in the excel doc because the new value, which was generated with mathematical consistency without any personal bias, has GREATER radius than the live version, which was edited by me years ago.

What can be done about this?

I have been thinking of adding another differentiation for explicit non-frag explosives (i.e. HEAT, satchels). Basically, we can declare that the normal explosion radius on offensive grenades represents not just the blast itself, but also the minor fragmentation that these grenades usually do have. Its small fragments that are more evenly distributed and have a low range, comparable to the blast. Therefore, explosives like satchels, fausts and RPG-43 should have a reduced radius compared to the rest of explosives that have some kind of fragmentation. Well, either that, or the difference exists only for _balance reasons..._ it is up to you to decide.

Alternatively, we can set offensive grenades to have the same "full" frag effect that the defensive grenades have, but set its radius to be the same as the normal explosion radius. That way offensive grenades will basically have a random chance of doubled damage without any radius increase, while non-frag types wont have it. But that's just another idea.

- the increased variety of grenades will also serve as a new tool of balancing the maps or setting more historical role loadouts. Depending on mapper's wishes, a role can spawn with up to 4 grenades, or may be even more. With this, however, i think we should set all grenades to have max carried 2 instead of 3, and spawn with 1 instead of 2.

- HEAT's unique ability to penetrate walls... Which, i believe, really makes no sense and would have made far more sense if this was a unique property of APHE shells, that are actually designed to explode post-penetration. If anything, HEAT is the least capable of all AP shells to produce anything similar to an explosion

- There is a concern that strong explosives (satchels primarily) do too much damage to heavy armor over a significant distance. This was partially solved by adding weak spots for engine and tracks, but the "main" damage is still done in the same way as it is done to infantry. I think this problem can be solved by adding a second explosion to those explosives that would have very small radius and very high damage against vehicles specifically. This way a satchel would be able to defeat heavy armor if it lies on top of it, but wont do much to it if its 5 meters away.