### PR TITLE
Fixed a number of issues with mortar animations

### DIFF
--- a/DH_Engine/Classes/DHMortarVehicleWeaponPawn.uc
+++ b/DH_Engine/Classes/DHMortarVehicleWeaponPawn.uc
@@ -39,6 +39,9 @@ var     float       OverlayKnobRaisingAnimRate;
 var     float       OverlayKnobTurnAnimRate;
 var     int         OverlaySleeveTexNum;
 var     int         OverlayHandTexNum;
+var     name        OverlayPrimaryShellBone;
+var     name        OverlaySecondaryShellBone;
+var     bool        bSwapShellBonesBasedOnSelectedAmmo;
 
 // HUD
 var     texture     HUDArcTexture;           // the elevation display
@@ -779,6 +782,7 @@ simulated state Firing extends Busy
     }
 
 Begin:
+    SetFirstPersonShellDisplay();
     PlayFirstPersonAnimation(OverlayFiringAnim);
     SetCurrentAnimationIndex(FIRING_ANIM_INDEX);
 
@@ -926,6 +930,28 @@ simulated function int GetGunPitchMax()
 ///////////////////////////////////////////////////////////////////////////////////////
 //  *********************************  ANIMATIONS  ********************************  //
 ///////////////////////////////////////////////////////////////////////////////////////
+
+// Display different shell models depending on the selected ammo type
+simulated function SetFirstPersonShellDisplay()
+{
+    if (!bSwapShellBonesBasedOnSelectedAmmo || VehWep == none || HUDOverlay == none)
+    {
+        return;
+    }
+
+    switch (VehWep.GetAmmoIndex())
+    {
+        case 0:
+            // Hide secondary
+            HUDOverlay.SetBoneScale(0, 0.0, OverlaySecondaryShellBone);
+            break;
+        case 1:
+            // Hide primary
+            HUDOverlay.SetBoneScale(0, 0.0, OverlayPrimaryShellBone);
+            break;
+        default:
+    }
+}
 
 // New function to set a new CurrentAnimationIndex & play the relevant animations, & for a net client to replicate the CurrentAnimationIndex to the server
 simulated function SetCurrentAnimationIndex(byte AnimIndex)

--- a/DH_Engine/Classes/DHPawn.uc
+++ b/DH_Engine/Classes/DHPawn.uc
@@ -570,17 +570,14 @@ simulated event AnimEnd(int Channel)
     local name  Anim;
     local float Frame, Rate;
 
-    WA = DHWeaponAttachment(WeaponAttachment);
-
     if (DrivenVehicle != none)
     {
-        if (HasAnim(DrivenVehicle.DriveAnim))
-        {
-            PlayAnim(DrivenVehicle.DriveAnim, 1.0,, 1);
-        }
+        return;
     }
     else if (Channel == 1 && WeaponState != GS_IgnoreAnimend)
     {
+        WA = DHWeaponAttachment(WeaponAttachment);
+
         if (WeaponState == GS_Ready)
         {
             AnimBlendToAlpha(1, 0.0, 0.12);

--- a/DH_Engine/Classes/DHProjectileFire.uc
+++ b/DH_Engine/Classes/DHProjectileFire.uc
@@ -741,12 +741,18 @@ simulated function HandleRecoil()
 // Function used for debugging RecoilGain
 simulated function float GetEffectiveRecoilGain()
 {
+    local DHPlayer DHP;
     local float EffectiveRecoilGain;
 
-    EffectiveRecoilGain = RecoilGain - GetRecoilGainFalloff(Level.TimeSeconds - DHPlayer(Instigator.Controller).LastRecoilTime);
-    EffectiveRecoilGain = FMax(0.0, EffectiveRecoilGain);
+    DHP = DHPlayer(Instigator.Controller);
 
-    return EffectiveRecoilGain;
+    if (DHP != none)
+    {
+        EffectiveRecoilGain = RecoilGain - GetRecoilGainFalloff(Level.TimeSeconds - DHP.LastRecoilTime);
+        EffectiveRecoilGain = FMax(0.0, EffectiveRecoilGain);
+
+        return EffectiveRecoilGain;
+    }
 }
 
 simulated function float GetRecoilGainFalloff(float TimeSeconds)

--- a/DH_Weapons/Classes/DH_M2MortarVehicleWeaponPawn.uc
+++ b/DH_Weapons/Classes/DH_M2MortarVehicleWeaponPawn.uc
@@ -23,4 +23,8 @@ defaultproperties
     HUDSmokeTexture=Texture'DH_Mortars_tex.60mmMortarM2.M302-WP'
     HUDArcTexture=Texture'DH_Mortars_tex.HUD.ArcA'
     ArtillerySpottingScopeClass=class'DH_Weapons.DHArtillerySpottingScope_AlliedMortar'
+
+    bSwapShellBonesBasedOnSelectedAmmo=true
+    OverlayPrimaryShellBone="Shell_HE"
+    OverlaySecondaryShellBone="Shell_WP"
 }

--- a/DarkestHourDev/Animations/DHCharactersGER_anm.ukx
+++ b/DarkestHourDev/Animations/DHCharactersGER_anm.ukx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe928584c3d19604967e0225ae3ac7767f748302bd5ab1a8b69efcf45acb5dad
+oid sha256:b86f6245fa337ee470425cfab6899ae4590b43cc4f771f7b068e52731ed236a6
 size 53827454

--- a/DarkestHourDev/Animations/DH_Mortars_1st.ukx
+++ b/DarkestHourDev/Animations/DH_Mortars_1st.ukx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23beb03f54cca46ce80ac81e1c1f41a5bebb6f115e4a2ccab75a55fcab52e181
-size 1875120
+oid sha256:c508418ca590f1353be3f68ffcf27d350e54481d1fcc83771f13ee7b1f88b37c
+size 2357785


### PR DESCRIPTION
# Changelog

## Bug fixes
* Fixed jittery and out of sync character animations on mortars.
* US M2 mortar now shows a correct shell model when firing in first person.

# Changes in packages
### [DarkestHourDev/Animations/DHCharactersGER_anm.ukx](https://github.com/DarklightGames/DarkestHour/compare/character-animations...bugfix-mortar-animations?expand=1#diff-550eef604b3e8c2774583a8833e5e5403ad3af5f08ff774fb2bd807ce83ea174)

* Reverted the rates for `deploy_fire`, `flinch_return`, and `deploy` animations to values before commit 25bfbc278a1af20b28d72d8db83c1703aa816285. This fixed the issue where the mortar weapon and character anims were out of sync.

* Lowered the rates for `deploy_idle` animations to 0.2 for performance reasons (this prevents triggering `AnimEnd` too often).

### [DarkestHourDev/Animations/DH_Mortars_1st.ukx](https://github.com/DarklightGames/DarkestHour/pull/1699/files#diff-f17c80f3c45ec87c66e3f9c7fece4a72b4fcc6cafd8d4d2cf5c6f538d5042ab6)

* Changed bone naming and hierarchy for shell bones.
* Renamed bone `Bone01` to `Muzzle` and centered it on the barrel (the bone is not used for anything, it was just irritating me).
* Removed unused `fire_HE` and `fire_WP` animations.