### PR TITLE
Fixed inconsistencies between DHArmoredVehicle and DHVehicleCannon:

### DIFF
--- a/DH_Vehicles/Classes/DH_PanzerIIILCannon_Camo.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIIILCannon_Camo.uc
@@ -8,6 +8,7 @@ class DH_PanzerIIILCannon_Camo extends DH_PanzerIIILCannon;
 defaultproperties
 {
     bHasAddedSideArmor=true
+    bHasAddedRearArmor=true
     Skins(1)=Texture'DH_VehiclesGE_tex2.ext_vehicles.panzer3_armor_camo1'
     CollisionStaticMeshes(0)=(CollisionStaticMesh=StaticMesh'DH_German_vehicles_stc2.Panzer3.Panzer3L_turret_armor_Coll')
 }

--- a/DH_Vehicles/Classes/DH_PanzerIIINCannon_CamoOne.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIIINCannon_CamoOne.uc
@@ -8,6 +8,7 @@ class DH_PanzerIIINCannon_CamoOne extends DH_PanzerIIINCannon;
 defaultproperties
 {
     bHasAddedSideArmor=true
+    bHasAddedRearArmor=true
     Skins(1)=Texture'DH_VehiclesGE_tex2.ext_vehicles.panzer3_armor_camo1'
     CollisionStaticMeshes(0)=(CollisionStaticMesh=StaticMesh'DH_German_vehicles_stc2.Panzer3.Panzer3N_turret_armor_Coll')
 }

--- a/DH_Vehicles/Classes/DH_PanzerIVGEarlyCannon.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIVGEarlyCannon.uc
@@ -19,6 +19,7 @@ defaultproperties
 
     // Turret armor
     bHasAddedSideArmor=true
+    bHasAddedRearArmor=true
     FrontArmorFactor=5.0
     RightArmorFactor=3.1
     LeftArmorFactor=3.1

--- a/DH_Vehicles/Classes/DH_PanzerIVGLateCannon.uc
+++ b/DH_Vehicles/Classes/DH_PanzerIVGLateCannon.uc
@@ -19,6 +19,7 @@ defaultproperties
 
     // Turret armor
     bHasAddedSideArmor=true
+    bHasAddedRearArmor=true
     FrontArmorFactor=5.0
     RightArmorFactor=3.1
     LeftArmorFactor=3.1


### PR DESCRIPTION
- DHVehicleCannon (turret) schurzen now uses the same behavior as DHArmoredVehicle (hull).
- Turret schurzen now blocks AP bullets (PTRD) and HE shells under 8.5cm in caliber.
- Turret schurzen now only defeats HEAT projectiles if the angle of incidence is over 45 degrees.
- Added new bHasAddedRearArmor variable and applied this to the respective German vehicles that have it (Panzer IV and late Panzer III models). This means that the rear of these vehicle's turrets will now also correctly benefit from schurzen.