### PR TITLE
Global bans

### DIFF
--- a/DH_Engine/Classes/DHAccessControl.uc
+++ b/DH_Engine/Classes/DHAccessControl.uc
@@ -15,6 +15,7 @@ struct Patron
 
 var private array<string>           DeveloperIDs;
 var private array<Patron>           Patrons; // A list of patreon ROIDs for users that are on MAC and don't work with normal system
+var private array<string>           GloballyBannedIDs;
 
 function bool AdminLogin(PlayerController P, string Username, string Password)
 {
@@ -125,6 +126,19 @@ static function bool IsDeveloper(string ROID)
     return false;
 }
 
+static function bool IsGloballyBanned(string ROID)
+{
+    local int i;
+
+    for (i = 0; i < default.GloballyBannedIDs.Length; ++i)
+    {
+        if (ROID ~= default.GloballyBannedIDs[i])
+        {
+            return true;
+        }
+    }
+}
+
 // This only gets the patron level off the PatreonIDs array in the default properties below, not from the webserver
 // This is used to fix an issue with MAC/Linux not being able to properly use the HTTP request function
 static function string GetPatronTier(string ROID)
@@ -140,6 +154,52 @@ static function string GetPatronTier(string ROID)
     }
 
     return "";
+}
+
+// Overriden to add global bans
+function int CheckID(string CDHash)
+{
+    local int i;
+    local string id;
+
+    if (IsGloballyBanned(CDHash))
+    {
+        return 2;
+    }
+
+    for (i = 0; i < BannedIDs.Length; i++)
+    {
+        id = Left(BannedIDs[i], InStr(BannedIDs[i], " "));
+
+        // Use the old system if the Steam system isn't enabled
+        if (id == "")
+        {
+            id = Left(BannedIDs[i], 32);
+        }
+
+        if (CDHash ~= id)//STEAMAUTH -- ~=Left(BannedIDs[i],32) )
+        {
+            return 2;
+        }
+    }
+
+    for (i = 0; i < SessionBannedIDs.Length; i++)
+    {
+        id = Left(SessionBannedIDs[i], InStr(SessionBannedIDs[i], " "));
+
+        // Use the old system if the Steam system isn't enabled
+        if (id == "")
+        {
+            id = Left(SessionBannedIDs[i], 32);
+        }
+
+        if (CDHash ~= id)//STEAMAUTH -- ~=Left(SessionBannedIDs[i],32) )
+        {
+            return 1;
+        }
+    }
+
+    return 0;
 }
 
 defaultproperties
@@ -169,4 +229,36 @@ defaultproperties
     Patrons(4)=(ROID="76561197981301331",Tier="lead") // Monni
     Patrons(5)=(ROID="76561198256117403",Tier="lead") // Vic
     Patrons(6)=(ROID="76561198847955145",Tier="lead") // MaDeuce
+
+    // GLOBAL BANS
+    // Double check that ID is correct before adding it to the list!
+
+    // 76561197984321708 alts
+    GloballyBannedIDs(0)="76561197984321708"
+    GloballyBannedIDs(1)="76561198054652352"
+    GloballyBannedIDs(2)="76561198799736606"
+    GloballyBannedIDs(3)="76561199092962089"
+    GloballyBannedIDs(4)="76561199215637308"
+    GloballyBannedIDs(5)="76561199469229247"
+    GloballyBannedIDs(6)="76561199487793588"
+    GloballyBannedIDs(7)="76561199500513625"
+    GloballyBannedIDs(8)="76561199501293525"
+    GloballyBannedIDs(9)="76561199521424863"
+    GloballyBannedIDs(10)="76561199539630085"
+    GloballyBannedIDs(11)="76561199553169889"
+    GloballyBannedIDs(12)="76561199574520909"
+    GloballyBannedIDs(13)="76561199634932689"
+    GloballyBannedIDs(14)="76561199640196259"
+
+    // 76561198202576201 alts
+    GloballyBannedIDs(15)="76561198202576201"
+    GloballyBannedIDs(16)="76561199385553208"
+    GloballyBannedIDs(17)="76561199474852956"
+    GloballyBannedIDs(18)="76561199488873541"
+    GloballyBannedIDs(19)="76561199563295062"
+    GloballyBannedIDs(20)="76561199645254168"
+
+    // 76561197995652829 alts
+    GloballyBannedIDs(21)="76561197995652829"
+    GloballyBannedIDs(22)="76561198201322109"
 }


### PR DESCRIPTION
Users in the global ban list are blocked from playing on any server.

The IDs are hardcoded as a stopgap solution until some kind of an authentication backend is implemented.