### PR TITLE
Squad name is reset to default when a new squad leader is assigned

### DIFF
--- a/DH_Engine/Classes/DHSquadReplicationInfo.uc
+++ b/DH_Engine/Classes/DHSquadReplicationInfo.uc
@@ -808,6 +808,7 @@ function int CreateSquad(DHPlayerReplicationInfo PRI, optional string Name)
 }
 
 // Changes the squad leader. Returns true if the squad leader was successfully changed.
+// NOTE: Duplicates functionality of `ComandeerSquad` function.
 function bool ChangeSquadLeader(DHPlayerReplicationInfo PRI, int TeamIndex, int SquadIndex, DHPlayerReplicationInfo NewSquadLeader)
 {
     local DHBot Bot;
@@ -1117,6 +1118,10 @@ function bool CommandeerSquad(DHPlayerReplicationInfo PRI, int TeamIndex, int Sq
         BroadcastSquadLocalizedMessage(PRI.Team.TeamIndex, PRI.SquadIndex, SquadMessageClass, 35, PRI);
 
         UpdateSquadLeaderNoRallyPointsTime(PRI.Team.TeamIndex, PRI.SquadIndex);
+
+        // Reset the squad name to prevent squad leaders being blamed for
+        // unsavory names they can inherit.
+        SetName(TeamIndex, SquadIndex, "");
     }
 
     return bResult;


### PR DESCRIPTION
Done to ensure that squad leaders can't be blamed for bad squad names set by their predecessors.