### PR TITLE
Added Developer Hit Material

### DIFF
--- a/DH_Effects/Classes/DHBulletHitEffect.uc
+++ b/DH_Effects/Classes/DHBulletHitEffect.uc
@@ -33,4 +33,5 @@ defaultproperties
     HitEffects(22)=(HitDecal=class'BulletHoleCloth',HitEffect=class'DHBulletHitSandBagEffect',HitSound=Sound'ProjectileSounds.Bullets.Impact_Gravel') //Sand Bags EST_Custom02
     HitEffects(23)=(HitDecal=class'BulletHoleConcrete',HitEffect=class'DHBulletHitBrickEffect',HitSound=Sound'ProjectileSounds.Bullets.Impact_Asphalt') //Brick EST_Custom03
     HitEffects(24)=(HitDecal=class'BulletHoleDirt',HitEffect=class'DHBulletHitHedgeEffect',HitSound=Sound'ProjectileSounds.Bullets.Impact_Dirt') //Hedgerow-Bush EST_Custom04
+    HitEffects(25)=(HitDecal=class'DHBulletHoleDev',HitEffect=class'DHBulletHitMetalArmorEffect',HitSound=Sound'ProjectileSounds.Bullets.Impact_Metal') //Purple Hit-Visibility decal (Dev) EST_Custom05
 }

--- a/DH_Effects/Classes/DHBulletHoleDev.uc
+++ b/DH_Effects/Classes/DHBulletHoleDev.uc
@@ -1,0 +1,17 @@
+//=============================================================================
+// BulletHoleDev
+//=============================================================================
+// Projector for bullet impacts on Dev Material (visibility of where shots landed)
+//=============================================================================
+
+class DHBulletHoleDev extends ROBulletHole;
+
+//=============================================================================
+// defaultproperties
+//=============================================================================
+
+defaultproperties
+{
+    ProjTexture=Texture'DH_FX_Tex.Effects.DevImpact' //Purple Square impact to show off where a bullet landed
+    LifeSpan=30.0
+}

--- a/DarkestHourDev/Textures/DH_FX_Tex.utx
+++ b/DarkestHourDev/Textures/DH_FX_Tex.utx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:638901f248548b4284be107e4343d021ef27bb1bbbcc6ab0c8454ff6dae499f4
-size 11474039
+oid sha256:31ee0ca66f97257949028be3a7c4e6d208b3ed36d50f60835ea1c156d0745be5
+size 11476979


### PR DESCRIPTION
-Added DevImpact to DH_FX_Tex.Effects
-Added DHBulletHoleDEV
-Made EST_Custom05 into a developer material that displays a purple square when a bullet impacts it

LifeSpan is set to 30 and overrides the decal stay time setting, does not affect other decal stay times

Idea behind this addition, is to add a dev specific material that makes the bullet impacts far more visible that before.

Reasoning for this is that it is quite hard to see your bullet impacts or spray patterns when testing out weapons, this change would make them more visible, allowing you to better understand your spread or recoil on the weapon.

### **DOES NOT** come with a **specific texture** set to this material, you have to make a texture in your myLevel package and attach EST_Custom05 too it.



https://github.com/user-attachments/assets/7d0a59f6-143c-47d6-8c49-dc2f0627db4e


