### PR TITLE
VS Code Tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,9 @@ XWebAdmin/
 UserLogs
 *.rus
 .vs/
-.vscode/
+.vscode/*
+!.vscode/tasks.json
+!.vscode/extensions.json
 *.log
 umodel.cfg
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "EliotVU.uc",
+        "rioj7.command-variable",
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,81 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build",
+            "type": "shell",
+            "command": "py",
+            "args": ["tools/make/make.py", "-mod", "DarkestHourDev", "."],
+            "problemMatcher": {
+                "owner": "unrealscript",
+                "fileLocation": "absolute",
+                "source": "ucc",
+                "severity": "info",
+                "pattern": {
+                        "regexp": "(^.+(?=\\(\\d+\\)\\s:))\\((\\d+)\\)\\s:\\s(Warning|Error),\\s(.+$)",
+                        "file": 1,
+                        "line": 2,
+                        "severity": 3,
+                        "message": 4
+                }
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Build and Run",
+            "command": "./RedOrchestraLargeAddressAware.exe -mod=DarkestHourDev",
+            "type": "shell",
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/System"
+            },
+            "dependsOn": [
+                "build"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "Build and Run Map",
+            "command": "./RedOrchestraLargeAddressAware.exe ${input:pickMap}?quickstart=true -mod=DarkestHourDev",
+            "type": "shell",
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/System"
+            },
+            "dependsOn": [
+                "build"
+            ],
+            "problemMatcher": []
+        },
+    ],
+    "inputs": [
+        {
+            "id": "pickMap",
+            "type": "command",
+            "command": "extension.commandvariable.pickStringRemember",
+            "args": {
+                "description": "Run map",
+                "options": [
+                    ["Use last map", "${remember:lastMapName}"],
+                    ["Select map", "${pickFile:mapName}"]
+                ],
+                "rememberTransformed": true,
+                "key": "lastMapName",
+                "pickFile": {
+                    "mapName": {
+                        "description": "Select a map",
+                        "include": "DarkestHourDev/Maps/**/*.rom",
+                        "keyRemember": "mapName",
+                        "display": "fileName",
+                        "transform": { "text": "${fileBasename}" }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,54 +6,151 @@
         {
             "label": "Build",
             "type": "shell",
-            "command": "py",
-            "args": ["tools/make/make.py", "-mod", "DarkestHourDev", "."],
-            "problemMatcher": {
-                "owner": "unrealscript",
-                "fileLocation": "absolute",
-                "source": "ucc",
-                "severity": "info",
-                "pattern": {
-                        "regexp": "(^.+(?=\\(\\d+\\)\\s:))\\((\\d+)\\)\\s:\\s(Warning|Error),\\s(.+$)",
+            "command": "py tools/make/make.py -mod DarkestHourDev .",
+            "problemMatcher": [
+                {
+                    "owner": "unrealscript",
+                    "fileLocation": "absolute",
+                    "source": "ucc",
+                    "pattern": {
+                        "regexp": "(?!.*Class names shouldn't end in a digit)(^.+(?=\\(\\d+\\)\\s:))\\((\\d+)\\)\\s:\\s(Warning|Error),\\s(.+$)",
                         "file": 1,
                         "line": 2,
                         "severity": 3,
                         "message": 4
+                    }
+                },
+                {
+                    "owner": "unrealscript",
+                    "fileLocation": "absolute",
+                    "source": "ucc",
+                    "severity": "info",
+                    "pattern": {
+                        "regexp": "^(.+(?=\\(\\d+\\)\\s:))\\((\\d+)\\)\\s:\\sWarning,\\s(Class names shouldn't end in a digit)$",
+                        "file": 1,
+                        "line": 2,
+                        "message": 3
+                    }
                 }
-            },
+            ],
             "group": {
                 "kind": "build",
                 "isDefault": true
             }
         },
         {
-            "label": "Build and Run",
+            "label": "Build with Parameters",
+            "type": "shell",
+            "command": "py tools/make/make.py ${input:buildArgs} -mod DarkestHourDev .",
+            "problemMatcher": [
+                {
+                    "owner": "unrealscript",
+                    "fileLocation": "absolute",
+                    "source": "ucc",
+                    "pattern": {
+                        "regexp": "^(?!.*Class names shouldn't end in a digit)(.+(?=\\(\\d+\\)\\s:))\\((\\d+)\\)\\s:\\s(Warning|Error),\\s(.+)$",
+                        "file": 1,
+                        "line": 2,
+                        "severity": 3,
+                        "message": 4
+                    }
+                },
+                {
+                    "owner": "unrealscript",
+                    "fileLocation": "absolute",
+                    "source": "ucc",
+                    "severity": "info",
+                    "pattern": {
+                        "regexp": "^(.+(?=\\(\\d+\\)\\s:))\\((\\d+)\\)\\s:\\sWarning,\\s(Class names shouldn't end in a digit)$",
+                        "file": 1,
+                        "line": 2,
+                        "message": 3
+                    }
+                }
+            ],
+            "group": "build"
+        },
+        {
+            "label": "Run",
             "command": "./RedOrchestraLargeAddressAware.exe -mod=DarkestHourDev",
             "type": "shell",
-            "group": "build",
+            "group": "test",
+            "problemMatcher": [],
             "options": {
                 "cwd": "${workspaceFolder}/System"
-            },
+            }
+        },
+        {
+            "label": "Run Map",
+            "command": "./RedOrchestraLargeAddressAware.exe ${input:pickMap}?quickstart=true -mod=DarkestHourDev",
+            "type": "shell",
+            "group": "test",
+            "problemMatcher": [],
+            "options": {
+                "cwd": "${workspaceFolder}/System"
+            }
+        },
+        {
+            "label": "Run Map",
+            "command": "./RedOrchestraLargeAddressAware.exe ${input:pickMap}?quickstart=true -mod=DarkestHourDev",
+            "type": "shell",
+            "group": "test",
+            "problemMatcher": [],
+            "options": {
+                "cwd": "${workspaceFolder}/System"
+            }
+        },
+        {
+            "label": "Run Default Map",
+            "command": "./RedOrchestraLargeAddressAware.exe DH-Target_Range.rom?quickstart=true -mod=DarkestHourDev",
+            "type": "shell",
+            "group": "test",
+            "problemMatcher": [],
+            "options": {
+                "cwd": "${workspaceFolder}/System"
+            }
+        },
+        {
+            "label": "Build and Run",
+            "dependsOrder": "sequence",
             "dependsOn": [
-                "build"
+                "Build",
+                "Run"
             ],
+            "group": "test",
             "problemMatcher": []
         },
         {
             "label": "Build and Run Map",
-            "command": "./RedOrchestraLargeAddressAware.exe ${input:pickMap}?quickstart=true -mod=DarkestHourDev",
-            "type": "shell",
-            "group": "build",
-            "options": {
-                "cwd": "${workspaceFolder}/System"
-            },
+            "dependsOrder": "sequence",
             "dependsOn": [
-                "build"
+                "Build",
+                "Run Map"
             ],
+            "group": "test",
             "problemMatcher": []
         },
+        {
+            "label": "Build and Run Default Map",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "Build",
+                "Run Default Map"
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        }
     ],
     "inputs": [
+        {
+            "type": "promptString",
+            "id": "buildArgs",
+            "description": "Optional: Type-in extra build parameters",
+            "default": ""
+        },
         {
             "id": "pickMap",
             "type": "command",


### PR DESCRIPTION
Added tasks for building (with problem matching) and launching the game in VS Code.

### Tasks
- **Build**: Compiles the game. Compiler errors/warnings are sent to the "Problems" view. *Set as default build task.*
- **Build with Parameters**: Same as **Build** but shows a prompt before compiling for passing additional parameters to `make.py`.
- **Run**: Launches the game.
- **Run Map**: Quick loads a selected map.
- **Run Default Map**: Quick loads "Target Range". Added as a shortcut to skip the map selection prompt  (would be nice to make the default map configurable in the future).
- **Build and Run**: Combines **Build** and **Run**.
- **Build and Run Map**: Combines **Build** and **Run Map**.
- **Build and Run Default Map**: Combines **Build** and **Run Default Map**. *Set as default test task.*

### How to use?
To run a task, open the command palette (<kbd>Ctrl+Shift+P</kbd>) and select `Tasks: Run Task`. To run the default tasks use `Tasks: Run Build Task` or `Tasks: Run Test Task`.

### Dependencies
Map selection prompts depend on [Command Variables](https://marketplace.visualstudio.com/items?itemName=rioj7.command-variable) extension. It has been added to project's recommended extensions  (in `extensions.json`) along with [UnrealScript](https://marketplace.visualstudio.com/items?itemName=EliotVU.uc).