### PR TITLE
Fixed map icons for Autocaretta OM

### DIFF
--- a/DH_Vehicles/Classes/DH_AutocarrettaOM.uc
+++ b/DH_Vehicles/Classes/DH_AutocarrettaOM.uc
@@ -19,7 +19,7 @@ defaultproperties
     VehicleTeam=0
     VehicleMass=2.0
     ReinforcementCost=1
-    MapIconMaterial=Texture'DH_InterfaceArt2_tex.car_topdown'
+    MapIconMaterial=Texture'DH_InterfaceArt2_tex.truck_topdown'
 
     // Hull mesh
     Mesh=SkeletalMesh'DH_AutocarrettaOM_anm.OM33_BODY_TRANSPORT_EXT'

--- a/DH_Vehicles/Classes/DH_AutocarrettaOMSupport.uc
+++ b/DH_Vehicles/Classes/DH_AutocarrettaOMSupport.uc
@@ -10,6 +10,7 @@ class DH_AutoCarrettaOMSupport extends DH_AutocarrettaOM;
 defaultproperties
 {
     VehicleNameString="Autocarretta OM 36Mt (Logistics)"
+    MapIconMaterial=Texture'DH_GUI_tex.supply_point'
 
     Mesh=SkeletalMesh'DH_AutocarrettaOM_anm.OM33_BODY_SUPPORT_EXT'
     


### PR DESCRIPTION
- Replaced OM32 icon so it's properly marked as a logistics vehicle.
- Replaced icon for OM36 with a truck icon to be consistent with OM32 (gameplay-wise it's closer to a truck than a car as well).