### PR TITLE
Added squad member index to player's own icon on the map

### DIFF
--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -4145,7 +4145,7 @@ function DrawPlayerIconsOnMap(Canvas C, AbsoluteCoordsInfo SubCoords, float MyMa
                 IconScale = PlayerIconLargeScale;
             }
 
-            DrawPlayerIconOnMap(C, SubCoords, MyMapScale, A.Location, MapCenter, Viewport, PlayerYaw, SelfColor, IconScale);
+            DrawPlayerIconOnMap(C, SubCoords, MyMapScale, A.Location, MapCenter, Viewport, PlayerYaw, SelfColor, IconScale, PRI.GetNamePrefix());
         }
     }
 }


### PR DESCRIPTION
When player is in a squad, their map icon will show their number or role (SL/A) within the squad.