### PR TITLE
Weapon adjustments 2025

### DIFF
--- a/DH_Weapons/Classes/DH_BARFire.uc
+++ b/DH_Weapons/Classes/DH_BARFire.uc
@@ -15,14 +15,14 @@ defaultproperties
     MuzzleBone=MuzzleNew
 
     // Spread
-    HipSpreadModifier=6.0
+    HipSpreadModifier=5.0
     Spread=65.0
 
     // Recoil
     RecoilRate=0.1
-    MaxVerticalRecoilAngle=670
+    MaxVerticalRecoilAngle=660
     MaxHorizontalRecoilAngle=180
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=2.0,OutVal=0.8),(InVal=3.0,OutVal=1.0),(InVal=6.0,OutVal=1.2),(InVal=16.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=3.0,OutVal=1.0),(InVal=6.0,OutVal=1.2),(InVal=16.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=4.0
     RecoilFallOffFactor=40.0
 

--- a/DH_Weapons/Classes/DH_BARNoBipodFire.uc
+++ b/DH_Weapons/Classes/DH_BARNoBipodFire.uc
@@ -15,14 +15,13 @@ defaultproperties
     MuzzleBone=MuzzleNew
 
     // Spread
-    HipSpreadModifier=6.0
     Spread=65.0
 
     // Recoil //adjusted from full variant
     RecoilRate=0.1
-    MaxVerticalRecoilAngle=688
-    MaxHorizontalRecoilAngle=140
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.66),(InVal=4.0,OutVal=1.0),(InVal=8.0,OutVal=1.1),(InVal=16.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=660
+    MaxHorizontalRecoilAngle=150
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.66),(InVal=3.0,OutVal=1.0),(InVal=5.0,OutVal=1.1),(InVal=9.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=4.0
     RecoilFallOffFactor=40.0
 

--- a/DH_Weapons/Classes/DH_BHPFire.uc
+++ b/DH_Weapons/Classes/DH_BHPFire.uc
@@ -13,6 +13,7 @@ defaultproperties
     Spread=185.0
     MaxVerticalRecoilAngle=380
     MaxHorizontalRecoilAngle=235
+    FireRate=0.21
 
     FireSounds(0)=SoundGroup'DH_MN_InfantryWeapons_sound.browninghpfire01'
     FireSounds(1)=SoundGroup'DH_MN_InfantryWeapons_sound.browninghpfire02'

--- a/DH_Weapons/Classes/DH_BHPWeapon.uc
+++ b/DH_Weapons/Classes/DH_BHPWeapon.uc
@@ -27,6 +27,7 @@ defaultproperties
 
     MaxNumPrimaryMags=3
     InitialNumPrimaryMags=3
+    bCanHaveInitialNumMagsChanged=false
 
     SelectEmptyAnim="Draw_empty"
     PutDownEmptyAnim="put_away_empty"

--- a/DH_Weapons/Classes/DH_BerettaM1934Weapon.uc
+++ b/DH_Weapons/Classes/DH_BerettaM1934Weapon.uc
@@ -32,6 +32,7 @@ defaultproperties
 
     InitialNumPrimaryMags=3
     MaxNumPrimaryMags=3
+    bCanHaveInitialNumMagsChanged=false
 
     MagEmptyReloadAnims(0)="reload_empty"
     MagPartialReloadAnims(0)="reload"

--- a/DH_Weapons/Classes/DH_Breda30Bullet.uc
+++ b/DH_Weapons/Classes/DH_Breda30Bullet.uc
@@ -9,6 +9,6 @@ defaultproperties
 {
     Speed=37418.24              // 620m/s (https://en.wikipedia.org/wiki/Breda_30)
     BallisticCoefficient=0.276  // https://www.topgun.es/punta-65-carcano-160gr-hornady.html
-    Damage=100.0                // Intermediate cartridge, lower damage than other rifles.
+    Damage=107.0                // Intermediate cartridge, lower damage than other rifles.
     MyDamageType=Class'DH_Breda30DamType'
 }

--- a/DH_Weapons/Classes/DH_Breda30Fire.uc
+++ b/DH_Weapons/Classes/DH_Breda30Fire.uc
@@ -21,9 +21,9 @@ defaultproperties
 
     // Recoil
     RecoilRate=0.05
-    MaxVerticalRecoilAngle=500
-    MaxHorizontalRecoilAngle=200
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.66),(InVal=2.0,OutVal=0.8),(InVal=3.0,OutVal=1.0),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=480
+    MaxHorizontalRecoilAngle=150
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.60),(InVal=3.0,OutVal=0.9),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=2.0
     RecoilFallOffFactor=6.0
 

--- a/DH_Weapons/Classes/DH_Breda30Weapon.uc
+++ b/DH_Weapons/Classes/DH_Breda30Weapon.uc
@@ -170,7 +170,7 @@ defaultproperties
 
     MaxNumPrimaryMags=15        // The backpack that the machine-gunner carries holds 15 slots for stripper clips.
     InitialNumPrimaryMags=10
-    NumMagsToResupply=2
+    NumMagsToResupply=3
 
     IdleToBipodDeploy="deploy"
     BipodDeployToIdle="undeploy"

--- a/DH_Weapons/Classes/DH_BrenFire.uc
+++ b/DH_Weapons/Classes/DH_BrenFire.uc
@@ -22,7 +22,7 @@ defaultproperties
     RecoilRate=0.05
     MaxVerticalRecoilAngle=580
     MaxHorizontalRecoilAngle=230
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.66),(InVal=2.0,OutVal=0.8),(InVal=3.0,OutVal=1.0),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=2.0
     RecoilFallOffFactor=6.0
 

--- a/DH_Weapons/Classes/DH_C96Fire.uc
+++ b/DH_Weapons/Classes/DH_C96Fire.uc
@@ -15,6 +15,7 @@ defaultproperties
     Spread=200.0
     MaxVerticalRecoilAngle=870
     MaxHorizontalRecoilAngle=350
+    FireRate=0.22
 
     ShellEjectClass=Class'ShellEject1st9x19mm'
     ShellHipOffset=(X=0.0,Y=0.0,Z=0.0)

--- a/DH_Weapons/Classes/DH_CarcanoM9138CarbineBullet.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM9138CarbineBullet.uc
@@ -10,6 +10,6 @@ defaultproperties
 {
     Speed=38323.52              // 635m/s (https://en.wikipedia.org/wiki/Carcano)
     BallisticCoefficient=0.276  // https://www.topgun.es/punta-65-carcano-160gr-hornady.html
-    Damage=110.0                // Almost an intermediate cartridge, lower damage than other rifles.
+    Damage=107.0                // Almost an intermediate cartridge, lower damage than other rifles.
     MyDamageType=Class'DH_CarcanoM9138CarbineDamType'
 }

--- a/DH_Weapons/Classes/DH_CarcanoM9138CarbineMeleeFire.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM9138CarbineMeleeFire.uc
@@ -7,7 +7,7 @@ class DH_CarcanoM9138CarbineMeleeFire extends DHMeleeFire;
 
 defaultproperties
 {
-    BayonetTraceRange=118.0 // -23% from Fucile mod. 91
+    BayonetTraceRange=130.0 // -10 (only ~150mm shorter than kar98k)
     FireRate=0.23 // -0.02
     DamageType=Class'DH_Weapons.DH_CarcanoM9138CarbineBashDamType'
     BayonetDamageType=Class'DH_Weapons.DH_CarcanoM9138CarbineBayonetDamType'

--- a/DH_Weapons/Classes/DH_CarcanoM9138CarbineWeapon.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM9138CarbineWeapon.uc
@@ -8,8 +8,8 @@ class DH_CarcanoM9138CarbineWeapon extends DHBoltActionWeapon;
 defaultproperties
 {
     ItemName="Carcano Moschetto mod. 91/38"
-    SwayModifyFactor=0.63 // +0.03
-    SwayBayonetModifier=1.28
+    SwayModifyFactor=0.49 // -0.11
+    SwayBayonetModifier=1.06
     FireModeClass(0)=Class'DH_CarcanoM9138CarbineFire'
     FireModeClass(1)=Class'DH_CarcanoM9138CarbineMeleeFire'
     AttachmentClass=Class'DH_CarcanoM9138CarbineAttachment'

--- a/DH_Weapons/Classes/DH_CarcanoM9138ShortRifleBullet.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM9138ShortRifleBullet.uc
@@ -10,6 +10,6 @@ defaultproperties
 {
     Speed=40254.78              // 667m/s (calculated based on M91/38 carbine and M91 muzzle velocities)
     BallisticCoefficient=0.276  // https://www.topgun.es/punta-65-carcano-160gr-hornady.html
-    Damage=110.0                // Almost an intermediate cartridge, lower damage than other rifles.
+    Damage=108.0                // Almost an intermediate cartridge, lower damage than other rifles.
     MyDamageType=Class'DH_CarcanoM9138ShortRifleDamType'
 }

--- a/DH_Weapons/Classes/DH_CarcanoM9138TSCarbineBullet.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM9138TSCarbineBullet.uc
@@ -10,6 +10,6 @@ defaultproperties
 {
     Speed=38323.52              // 635m/s (https://en.wikipedia.org/wiki/Carcano)
     BallisticCoefficient=0.276  // https://www.topgun.es/punta-65-carcano-160gr-hornady.html
-    Damage=110.0                // Almost an intermediate cartridge, lower damage than other rifles.
+    Damage=107.0                // Almost an intermediate cartridge, lower damage than other rifles.
     MyDamageType=Class'DH_CarcanoM9138TSCarbineDamType'
 }

--- a/DH_Weapons/Classes/DH_CarcanoM91Bullet.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM91Bullet.uc
@@ -9,6 +9,6 @@ defaultproperties
 {
     Speed=42246.4               // 700m/s (https://en.wikipedia.org/wiki/Carcano)
     BallisticCoefficient=0.276  // https://www.topgun.es/punta-65-carcano-160gr-hornady.html
-    Damage=110.0                // Almost an intermediate cartridge, lower damage than other rifles.
+    Damage=108.0                // Almost an intermediate cartridge, lower damage than other rifles.
     MyDamageType=Class'DH_CarcanoM91DamType'
 }

--- a/DH_Weapons/Classes/DH_ColtM1911Fire.uc
+++ b/DH_Weapons/Classes/DH_ColtM1911Fire.uc
@@ -14,6 +14,7 @@ defaultproperties
     Spread=220.0
     MaxVerticalRecoilAngle=600
     MaxHorizontalRecoilAngle=350
+    FireRate=0.23
 
     ShellEjectClass=Class'ShellEject1st9x19mm'
     ShellHipOffset=(X=0.0,Y=0.0,Z=0.0)

--- a/DH_Weapons/Classes/DH_ColtM1911Weapon.uc
+++ b/DH_Weapons/Classes/DH_ColtM1911Weapon.uc
@@ -27,6 +27,7 @@ defaultproperties
 
     MaxNumPrimaryMags=3
     InitialNumPrimaryMags=3
+    bCanHaveInitialNumMagsChanged=false
 
     SelectEmptyAnim="Draw_empty"
     PutDownAnim="put_away"

--- a/DH_Weapons/Classes/DH_ColtM1914Fire.uc
+++ b/DH_Weapons/Classes/DH_ColtM1914Fire.uc
@@ -14,6 +14,7 @@ defaultproperties
     Spread=220.0
     MaxVerticalRecoilAngle=600
     MaxHorizontalRecoilAngle=350
+    FireRate=0.23
 
     ShellEjectClass=Class'ShellEject1st9x19mm'
     ShellHipOffset=(X=0.0,Y=0.0,Z=0.0)

--- a/DH_Weapons/Classes/DH_ColtM1914Weapon.uc
+++ b/DH_Weapons/Classes/DH_ColtM1914Weapon.uc
@@ -26,6 +26,7 @@ defaultproperties
 
     MaxNumPrimaryMags=3
     InitialNumPrimaryMags=3
+    bCanHaveInitialNumMagsChanged=false
 
     SelectEmptyAnim="Draw_empty"
     PutDownAnim="put_away"

--- a/DH_Weapons/Classes/DH_DP27Fire.uc
+++ b/DH_Weapons/Classes/DH_DP27Fire.uc
@@ -18,9 +18,9 @@ defaultproperties
     // Recoil
     RecoilRate=0.05
     PctBipodDeployRecoil=0.1
-    MaxVerticalRecoilAngle=540
-    MaxHorizontalRecoilAngle=265
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.7),(InVal=8.0,OutVal=1.1),(InVal=14.0,OutVal=0.9),(InVal=50.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=610 
+    MaxHorizontalRecoilAngle=260
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=9.0,OutVal=1.1),(InVal=16.0,OutVal=0.9),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=4.0
     RecoilFallOffFactor=24.0
 

--- a/DH_Weapons/Classes/DH_DP27LateFire.uc
+++ b/DH_Weapons/Classes/DH_DP27LateFire.uc
@@ -17,10 +17,10 @@ defaultproperties
 
     // Recoil
     RecoilRate=0.05
-    PctBipodDeployRecoil=0.075 // 0.1 by default
-    MaxVerticalRecoilAngle=840  // these values are high because of custom recoil modifier for bipod being 0.075
-    MaxHorizontalRecoilAngle=340
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=10.0,OutVal=1.2),(InVal=16.0,OutVal=0.8),(InVal=10000000000.0,OutVal=1.0)))
+    PctBipodDeployRecoil=0.1
+    MaxVerticalRecoilAngle=610 
+    MaxHorizontalRecoilAngle=260
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=9.0,OutVal=1.1),(InVal=16.0,OutVal=0.9),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=4.0
     RecoilFallOffFactor=24.0
 

--- a/DH_Weapons/Classes/DH_DT29Fire.uc
+++ b/DH_Weapons/Classes/DH_DT29Fire.uc
@@ -18,9 +18,9 @@ defaultproperties
     // Recoil
     RecoilRate=0.05
     PctBipodDeployRecoil=0.1
-    MaxVerticalRecoilAngle=555
-    MaxHorizontalRecoilAngle=275
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.7),(InVal=8.0,OutVal=1.1),(InVal=14.0,OutVal=0.9),(InVal=50.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=630 
+    MaxHorizontalRecoilAngle=270
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=8.0,OutVal=1.1),(InVal=14.0,OutVal=0.9),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=4.0
     RecoilFallOffFactor=24.0
 

--- a/DH_Weapons/Classes/DH_EnfieldNo2Fire.uc
+++ b/DH_Weapons/Classes/DH_EnfieldNo2Fire.uc
@@ -13,6 +13,7 @@ defaultproperties
     Spread=250.0
     MaxVerticalRecoilAngle=650
     MaxHorizontalRecoilAngle=100
+    FireRate=0.25
 
     FireSounds(0)=SoundGroup'DH_WeaponSounds.EnfieldNo2_Fire01'
     FireLastAnim="shoot"

--- a/DH_Weapons/Classes/DH_FG42Fire.uc
+++ b/DH_Weapons/Classes/DH_FG42Fire.uc
@@ -46,7 +46,7 @@ defaultproperties
     RecoilRate=0.05
     MaxVerticalRecoilAngle=520
     MaxHorizontalRecoilAngle=180
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=3.0,OutVal=0.75),(InVal=9.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=3.0,OutVal=0.8),(InVal=8.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     PctProneIronRecoil=0.50
     PctRestDeployRecoil=0.50
     PctBipodDeployRecoil=0.30

--- a/DH_Weapons/Classes/DH_G98Fire.uc
+++ b/DH_Weapons/Classes/DH_G98Fire.uc
@@ -12,6 +12,7 @@ defaultproperties
     FireRate=2.6
     FAProjSpawnOffset=(X=-30.0)
     Spread=45.0   //worn-out barrel
+    AddedPitch=20.0 // should be zeroed to 300m (this is an approximation though)
     FireSounds(0)=SoundGroup'DH_CC_Inf_Weapons.G98_shootA'
     FireSounds(1)=SoundGroup'DH_CC_Inf_Weapons.G98_shootB'
     

--- a/DH_Weapons/Classes/DH_LtypeGrenadeFire.uc
+++ b/DH_Weapons/Classes/DH_LtypeGrenadeFire.uc
@@ -9,7 +9,7 @@ defaultproperties
 {
     ProjectileClass=Class'DH_LTypeGrenadeProjectile'
     AmmoClass=Class'DH_LTypeGrenadeAmmo'
-    MinHoldTime=1.0
+    MinHoldTime=0.4
     bSplashDamage=false
     bRecommendSplashDamage=false
     AddedFuseTime=9.0  // should be enough for the grenade to fly and land somewhere, so if it doesnt explode for some reason it will few seconds after

--- a/DH_Weapons/Classes/DH_LtypeGrenadeProjectile.uc
+++ b/DH_Weapons/Classes/DH_LtypeGrenadeProjectile.uc
@@ -10,8 +10,8 @@ class DH_LTypeGrenadeProjectile extends DHThrowableHEATProjectile;
 
 defaultproperties
 {
-    Speed=750.0  // reduced from 1100 as it was a VERY heavy grenade
-    MaxSpeed=780.0
+    Speed=600.0  // reduced from 1100 as it was a VERY heavy grenade
+    MaxSpeed=600.0
     ShellDiameter=10.5
     LifeSpan=10.0       // used in case the grenade fails to detonate on impact (will lie around for a bit for effect, then disappear)
     PickupClass=Class'DH_LTypeGrenadePickup'
@@ -25,17 +25,18 @@ defaultproperties
 
     // Armour penetration
     //Not a HEAT grenade but still an AT grenade
-    DHPenetrationTable(0)=1.0
-    DHPenetrationTable(1)=1.0
-    DHPenetrationTable(2)=1.0
-    DHPenetrationTable(3)=1.0
-    DHPenetrationTable(4)=1.0
-    DHPenetrationTable(5)=1.0
-    DHPenetrationTable(6)=1.0
-    DHPenetrationTable(7)=1.0
-    DHPenetrationTable(8)=1.0
-    DHPenetrationTable(9)=1.0
-    DHPenetrationTable(10)=1.0
+    //This penetration should ideally not depend on the impact angle
+    DHPenetrationTable(0)=2.5
+    DHPenetrationTable(1)=2.5
+    DHPenetrationTable(2)=2.5
+    DHPenetrationTable(3)=2.5
+    DHPenetrationTable(4)=2.5
+    DHPenetrationTable(5)=2.5
+    DHPenetrationTable(6)=2.5
+    DHPenetrationTable(7)=2.5
+    DHPenetrationTable(8)=2.5
+    DHPenetrationTable(9)=2.5
+    DHPenetrationTable(10)=2.5
 
     // Damage
     ImpactDamage=600

--- a/DH_Weapons/Classes/DH_M1A1CarbineFire.uc
+++ b/DH_Weapons/Classes/DH_M1A1CarbineFire.uc
@@ -10,11 +10,12 @@ defaultproperties
     ProjectileClass=Class'DH_M1A1CarbineBullet'
     AmmoClass=Class'DH_M1CarbineAmmo'
     Spread=75.0
-    MaxVerticalRecoilAngle=450
-    MaxHorizontalRecoilAngle=107
     RecoilRate=0.06
-    RecoilCurve=(Points=((InVal=0.0,OutVal=1.0),(InVal=4.0,OutVal=1.37),(InVal=12.0,OutVal=1.6),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=525  //keep in mind the first shot gets 0.8 coefficient
+    MaxHorizontalRecoilAngle=130
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.8),(InVal=3.0,OutVal=1.3),(InVal=12.0,OutVal=1.1),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=18.0
+
     
     
     FireSounds(0)=SoundGroup'DH_WeaponSounds.CarbineFire01'

--- a/DH_Weapons/Classes/DH_M1CarbineFire.uc
+++ b/DH_Weapons/Classes/DH_M1CarbineFire.uc
@@ -21,8 +21,8 @@ defaultproperties
     MuzzleBone="MuzzleNew2"
     
     RecoilRate=0.06
-    MaxVerticalRecoilAngle=555  //keep in mind the first shot gets 0.8 coefficient
-    MaxHorizontalRecoilAngle=120
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.8),(InVal=4.0,OutVal=1.1),(InVal=12.0,OutVal=1.3),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=500  //keep in mind the first shot gets 0.8 coefficient
+    MaxHorizontalRecoilAngle=110
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.8),(InVal=5.0,OutVal=1.3),(InVal=12.0,OutVal=1.1),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=18.0
 }

--- a/DH_Weapons/Classes/DH_M1T17CarbineFire.uc
+++ b/DH_Weapons/Classes/DH_M1T17CarbineFire.uc
@@ -28,10 +28,11 @@ defaultproperties
     FireIronAnim="Iron_Shoot"
 
     RecoilRate=0.06
-    MaxVerticalRecoilAngle=555  //keep in mind the first shot gets 0.8 coefficient
-    MaxHorizontalRecoilAngle=120
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.8),(InVal=4.0,OutVal=1.1),(InVal=12.0,OutVal=1.3),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=500  //keep in mind the first shot gets 0.8 coefficient
+    MaxHorizontalRecoilAngle=110
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.8),(InVal=5.0,OutVal=1.3),(InVal=12.0,OutVal=1.1),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=18.0
+
 
     FireRate=0.09 // 739 rpm (value had to be found experimentally due to an engine bug)
     bHasSemiAutoFireRate=true

--- a/DH_Weapons/Classes/DH_M34GrenadeFire.uc
+++ b/DH_Weapons/Classes/DH_M34GrenadeFire.uc
@@ -12,4 +12,5 @@ defaultproperties
     bSplashDamage=false
     bRecommendSplashDamage=false
     AddedFuseTime=9.0  // should be enough for the grenade to fly and land somewhere, so if it doesnt explode for some reason it will few seconds after
+    MinHoldTime=0.29
 }

--- a/DH_Weapons/Classes/DH_M34GrenadeProjectile.uc
+++ b/DH_Weapons/Classes/DH_M34GrenadeProjectile.uc
@@ -5,9 +5,6 @@
 
 class DH_M34GrenadeProjectile extends DHGrenadeProjectile;
 
-// Extends a HEAT projectile to make use of the impact fuze.
-// This is NOT an anti-tank grenade, so penetration values are small.
-
 defaultproperties
 {
     StaticMesh=StaticMesh'DH_WeaponPickups.m34_throw'

--- a/DH_Weapons/Classes/DH_MAB38Fire.uc
+++ b/DH_Weapons/Classes/DH_MAB38Fire.uc
@@ -21,7 +21,7 @@ defaultproperties
     RecoilRate=0.04285
     MaxVerticalRecoilAngle=230
     MaxHorizontalRecoilAngle=66
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=8.0,OutVal=1.1),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=8.0,OutVal=1.1),(InVal=11.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=13.0
 
     FlashEmitterClass=Class'MuzzleFlash1stMP'

--- a/DH_Weapons/Classes/DH_MAB42Fire.uc
+++ b/DH_Weapons/Classes/DH_MAB42Fire.uc
@@ -10,15 +10,16 @@ defaultproperties
     ProjectileClass=Class'DH_MAB42Bullet'
     AmmoClass=Class'DH_MAB42Ammo'
     FAProjSpawnOffset=(X=-28.0)
-    FireRate=0.1 //600 per minute
+    FireRate=0.125 // ~532 rpm (value had to be found experimentally due to an engine bug)
+    
 
-    Spread=180.0    // shorter barrel than the MAB38
+    Spread=140.0    // shorter barrel than the MAB38; late-war lower quality
 
     // Recoil
     RecoilRate=0.04285
-    MaxVerticalRecoilAngle=230
-    MaxHorizontalRecoilAngle=66
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=8.0,OutVal=1.1),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=250  //slightly worse than mab38
+    MaxHorizontalRecoilAngle=70
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=7.0,OutVal=1.1),(InVal=15.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffFactor=13.0
 
     FlashEmitterClass=Class'MuzzleFlash1stMP'

--- a/DH_Weapons/Classes/DH_MAB42Weapon.uc
+++ b/DH_Weapons/Classes/DH_MAB42Weapon.uc
@@ -28,6 +28,8 @@ defaultproperties
     IronSightDisplayFOV=60.0
     ZoomOutTime=0.1
     FreeAimRotationSpeed=7.0
+    
+    SwayModifyFactor=0.62 // -0.08, almost 1kg lighter than mab38
 
     MaxNumPrimaryMags=8
     InitialNumPrimaryMags=8

--- a/DH_Weapons/Classes/DH_P08LugerFire.uc
+++ b/DH_Weapons/Classes/DH_P08LugerFire.uc
@@ -13,6 +13,7 @@ defaultproperties
     Spread=190.0
     MaxVerticalRecoilAngle=500
     MaxHorizontalRecoilAngle=250
+    FireRate=0.21
 
     FireSounds(0)=SoundGroup'Inf_Weapons.lugerp08_fire01'
     FireSounds(1)=SoundGroup'Inf_Weapons.lugerp08_fire02'

--- a/DH_Weapons/Classes/DH_P08LugerWeapon.uc
+++ b/DH_Weapons/Classes/DH_P08LugerWeapon.uc
@@ -24,6 +24,7 @@ defaultproperties
 
     MaxNumPrimaryMags=3
     InitialNumPrimaryMags=3
+    bCanHaveInitialNumMagsChanged=false
 
     IdleEmptyAnim="idle_empty"
     IronIdleEmptyAnim="iron_idle_empty"

--- a/DH_Weapons/Classes/DH_P38Fire.uc
+++ b/DH_Weapons/Classes/DH_P38Fire.uc
@@ -13,6 +13,7 @@ defaultproperties
     Spread=185.0
     MaxVerticalRecoilAngle=400
     MaxHorizontalRecoilAngle=225
+    FireRate=0.21
 
     FireSounds(0)=SoundGroup'Inf_Weapons.waltherp38_fire01'
     FireSounds(1)=SoundGroup'Inf_Weapons.waltherp38_fire02'

--- a/DH_Weapons/Classes/DH_P38Weapon.uc
+++ b/DH_Weapons/Classes/DH_P38Weapon.uc
@@ -24,6 +24,7 @@ defaultproperties
 
     MaxNumPrimaryMags=3
     InitialNumPrimaryMags=3
+    bCanHaveInitialNumMagsChanged=false
 
     SelectEmptyAnim="Draw_empty"
     PutDownEmptyAnim="put_away_empty"

--- a/DH_Weapons/Classes/DH_SRCMMod35GrenadeFire.uc
+++ b/DH_Weapons/Classes/DH_SRCMMod35GrenadeFire.uc
@@ -7,6 +7,7 @@ class DH_SRCMMod35GrenadeFire extends DHThrownExplosiveFire;
 
 defaultproperties
 {
+    MinHoldTime=0.17
     ProjectileClass=Class'DH_SRCMMod35GrenadeProjectile'
     AmmoClass=Class'DH_SRCMMod35GrenadeAmmo'
 }

--- a/DH_Weapons/Classes/DH_SRCMMod35GrenadeProjectile.uc
+++ b/DH_Weapons/Classes/DH_SRCMMod35GrenadeProjectile.uc
@@ -8,7 +8,7 @@ class DH_SRCMMod35GrenadeProjectile extends DHGrenadeProjectile;
 defaultproperties
 {
     // TODO: this is a tiny boy, so the damage probably needs to be reduced
-    Damage=150.0 //43 grams
+    Damage=120.0 //43 grams
     DamageRadius=700.0 //Blast radius 12m according to page 60 of `Armi Della Fanteria Italiana Nella Seconda Guerra Mondiale`
     MyDamageType=Class'DH_SRCMMod35GrenadeDamageType'
     StaticMesh=StaticMesh'DH_SRCMMod35_stc.srcm_frag_projectile'

--- a/DH_Weapons/Classes/DH_TT33Fire.uc
+++ b/DH_Weapons/Classes/DH_TT33Fire.uc
@@ -9,7 +9,6 @@ defaultproperties
 {
     ProjectileClass=Class'DH_TT33Bullet'
     AmmoClass=Class'TT33Ammo'
-    FireRate=0.2
 
     Spread=210
     MaxVerticalRecoilAngle=500

--- a/DH_Weapons/Classes/DH_TT33Fire.uc
+++ b/DH_Weapons/Classes/DH_TT33Fire.uc
@@ -14,6 +14,7 @@ defaultproperties
     Spread=210
     MaxVerticalRecoilAngle=500
     MaxHorizontalRecoilAngle=300
+    FireRate=0.22
 
     FireSounds(0)=Sound'Inf_Weapons.tt33_fire01'
     FireSounds(1)=Sound'Inf_Weapons.tt33_fire02'

--- a/DH_Weapons/Classes/DH_TT33Weapon.uc
+++ b/DH_Weapons/Classes/DH_TT33Weapon.uc
@@ -23,6 +23,7 @@ defaultproperties
 
     InitialNumPrimaryMags=3
     MaxNumPrimaryMags=3
+    bCanHaveInitialNumMagsChanged=false
 
     IdleEmptyAnim="idle-empty"
     IronIdleEmptyAnim="iron_idle_empty"

--- a/DH_Weapons/Classes/DH_VG15Fire.uc
+++ b/DH_Weapons/Classes/DH_VG15Fire.uc
@@ -12,7 +12,7 @@ defaultproperties
     Spread=85.0
     MaxVerticalRecoilAngle=340
     MaxHorizontalRecoilAngle=150
-    FireRate=0.21
+    FireRate=0.20
 
     FireSounds(0)=SoundGroup'DH_old_inf_Weapons.vg15shot1'
     FireSounds(1)=SoundGroup'DH_old_inf_Weapons.vg15shot2'

--- a/DH_Weapons/Classes/DH_ViSFire.uc
+++ b/DH_Weapons/Classes/DH_ViSFire.uc
@@ -13,6 +13,7 @@ defaultproperties
     Spread=185.0
     MaxVerticalRecoilAngle=450
     MaxHorizontalRecoilAngle=205
+    FireRate=0.21
 
     FireSounds(0)=SoundGroup'DH_old_inf_Weapons.vis_fire01'
     FireSounds(1)=SoundGroup'DH_old_inf_Weapons.vis_fire02'

--- a/DH_Weapons/Classes/DH_ViSWeapon.uc
+++ b/DH_Weapons/Classes/DH_ViSWeapon.uc
@@ -30,6 +30,7 @@ defaultproperties
 
     MaxNumPrimaryMags=3
     InitialNumPrimaryMags=3
+    bCanHaveInitialNumMagsChanged=false
 
     SelectEmptyAnim="Draw_empty"
     PutDownEmptyAnim="put_away_empty"

--- a/DH_Weapons/Classes/DH_Wz35Bullet.uc
+++ b/DH_Weapons/Classes/DH_Wz35Bullet.uc
@@ -16,8 +16,10 @@ defaultproperties
     BallisticCoefficient=0.504  // http://gundata.org/ballistic-coefficient-calculator/#spitzer (boat-tail shape, 226gr, .32 diameter, 0.818 length, 0.504 BC)
 
     //Damage
-    ImpactDamage=120
-    Damage=1000.0  //should leave no one alive, as even if it hits a limb, it should be ripped apart making victim uncapable of continuing fighting
+    //ImpactDamage=120
+    Damage=700.0  //should leave no one alive, as even if it hits a limb, it should be ripped apart making victim uncapable of continuing fighting
+    HullFireChance=0.02
+    EngineFireChance=0.03  //as far as i know, these bullets were non-incendiary, so fire chances are low
     MyDamageType=Class'DH_Wz35DamType'
 
     //Penetration

--- a/DH_Weapons/Classes/DH_Wz35Fire.uc
+++ b/DH_Weapons/Classes/DH_Wz35Fire.uc
@@ -7,7 +7,7 @@ class DH_Wz35Fire extends DHBoltFire;
 
 defaultproperties
 {
-    ProjectileClass=Class'DH_PTRDBullet' // TODO: replace with WZ35 bullet
+    ProjectileClass=Class'DH_Wz35Bullet' 
     AmmoClass=Class'DH_Wz35Ammo'
     bUsePreLaunchTrace=false
     Spread=75.0

--- a/DH_Weapons/Classes/DH_ZB30AutoFire.uc
+++ b/DH_Weapons/Classes/DH_ZB30AutoFire.uc
@@ -20,7 +20,7 @@ defaultproperties
     RecoilRate=0.05
     MaxVerticalRecoilAngle=590
     MaxHorizontalRecoilAngle=220
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.66),(InVal=2.0,OutVal=0.8),(InVal=3.0,OutVal=1.0),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=2.0
     RecoilFallOffFactor=6.0
 

--- a/DarkestHourDev/Animations/DH_Carcano_anm.ukx
+++ b/DarkestHourDev/Animations/DH_Carcano_anm.ukx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:caef4599f3acbbb7829ca1843b370985904b80993838197d787ad043c0d3f93d
+oid sha256:db157717370ef93deef6fd7082e2ee2c879f0320d6a86781b8d7cd66f39224da
 size 5908288

--- a/DarkestHourDev/Animations/DH_MAB_anm.ukx
+++ b/DarkestHourDev/Animations/DH_MAB_anm.ukx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6653493af04237bd8c4d87c2ce803a3b4f90597b5215ae9f2cda68520ff50b55
-size 3641144
+oid sha256:291821fdceedc51abfed79f47e5283a58a9c0dcf43b9d7094e37cae8fd2b2528
+size 3641070


### PR DESCRIPTION
- Adjusted carcano carbine bolting to be slightly faster in iron sights and slightly slower in hip (the same logic applies to other straight/curved bolt handle pairs)
- Adjusted carcano carbine sway to be consistent with other carbines
- Adjusted carcano carbine bayonet range to be more consistent with other bayonets
- Carcanos and Breda damage is now set to 107-108 depending on barrel length
- Adjusted G98 zeroing for a higher range 
- Slightly increased fire rate on VG 1-5
- Changed bolting sounds on MABs so that the sliding cover doesnt sound like the bolt moving forward
- Slightly diversified fire rates on pistols, it now varies between 0.20 - 0.23 depending on caliber; Enfield No2 is set to 0.25 because its a double action revolver
- Pistol magazines no longer scale with team munitions (you always spawn with 3)
- Adjustments to LMGs recoil for consistency; especially DP-27 (lowered and made consistent) and Breda (lowered)
- Breda is now resupplied with 3 clips which is more consistent with other LMGs
- Reduced recoil on M1, M1A1, M1 T17 Carbines
- Fixed MAB42 incorrect fire rate; also introduced some difference in stats between 38 and 42
- Made Wz35 use its own bullet class with its own stats

Grenades:
- RG-34 and SRCM-35 now use minholdtime that prevents an instant throw; it's value was adjusted on Type L to be consistent with the throw animation
- Type L throw speed is slightly reduced; its penetration is increased to 25mm (it's an incorrect HEAT type penetration that depends on impact angle, but shouldnt for this type of grenade)
- Reduced SRCM-35 damage to better correspond to its tiny filler
