### PR TITLE
SL can only place constructions when squad members are near

### DIFF
--- a/DH_Construction/Classes/DHCommandMenu_ConstructionGroup.uc
+++ b/DH_Construction/Classes/DHCommandMenu_ConstructionGroup.uc
@@ -22,6 +22,7 @@ var localized string BusyText;
 var localized string ExhaustedText;
 var localized string RemainingText;
 var localized string MaxActiveText;
+var localized string NoSquadMembersNearbyText;
 var localized string MoreText;
 
 var class<DHConstructionGroup> GroupClass;
@@ -243,6 +244,10 @@ function GetOptionRenderInfo(int OptionIndex, out OptionRenderInfo ORI)
             ORI.InfoIcon = default.SquadIcon;
             ORI.InfoText[0] = string(SquadMemberCount) $ "/" $ string(ConstructionClass.default.SquadMemberCountMinimum);
             break;
+        case ERROR_SLCantBuildAlone:
+            ORI.InfoIcon = default.SquadIcon;
+            ORI.InfoText[0] = default.NoSquadMembersNearbyText;
+            break;
         default:
             ORI.InfoIcon = SuppliesIcon;
             ORI.InfoText[0] = string(ConstructionClass.static.GetSupplyCost(Context));
@@ -293,6 +298,7 @@ defaultproperties
     ExhaustedText="Exhausted"
     RemainingText="{0} Remaining"
     MaxActiveText="{0}/{1} Active"
+    NoSquadMembersNearbyText="Squad absent"
     BusyText="Busy"
     MoreText="More"
     SlotCountOverride=8

--- a/DH_Engine/Classes/DHConstruction.uc
+++ b/DH_Engine/Classes/DHConstruction.uc
@@ -38,7 +38,8 @@ enum EConstructionErrorType
     ERROR_Exhausted,                // Your team cannot place any more of these this round.
     ERROR_SocketOccupied,           // The construction socket is already occupied.
     ERROR_Custom,                   // Custom error type (provide an error message in OptionalString)
-    ERROR_Other
+    ERROR_Other,
+    ERROR_SLCantBuildAlone,         // There are no squad members within 50 meters
 };
 
 var struct ConstructionError
@@ -1202,6 +1203,12 @@ static function ConstructionError GetPlayerError(DHActorProxy.Context Context)
     {
         E.Type = ERROR_SquadTooSmall;
         E.OptionalInteger = default.SquadMemberCountMinimum;
+        return E;
+    }
+    
+    if (!P.CanSquadPlaceConstruction())
+    {
+        E.Type = ERROR_SLCantBuildAlone;
         return E;
     }
 

--- a/DH_Engine/Classes/DHConstructionProxy.uc
+++ b/DH_Engine/Classes/DHConstructionProxy.uc
@@ -438,7 +438,7 @@ function DHConstruction.ConstructionError GetPositionError()
 
     GRI = DHGameReplicationInfo(PlayerOwner.GameReplicationInfo);
 
-    if (Level.NetMode != NM_DedicatedServer && !bHidden)
+    if (Level != none && Level.NetMode != NM_DedicatedServer && !bHidden)
     {
         foreach TouchingActors(Class'DHConstructionProxy', CP)
         {

--- a/DH_Engine/Classes/DHPawn.uc
+++ b/DH_Engine/Classes/DHPawn.uc
@@ -7593,13 +7593,13 @@ exec function BigHead(float V)
     SetHeadScale(V);
 }
 
-simulated function bool CanBuildWithShovel()
+simulated function bool CanSquadPlaceConstruction()
 {
     local DHPlayerReplicationInfo PRI;
 
     PRI = DHPlayerReplicationInfo(PlayerReplicationInfo);
 
-    return Level.NetMode == NM_Standalone ||
+    return Level != none && Level.NetMode == NM_Standalone ||
            IsDebugModeAllowed() ||
            !PRI.IsSquadLeader() ||
            HasSquadmatesWithinDistance(50.0); // TODO: This shouldn't be a literal!

--- a/DH_Equipment/Classes/DHShovelBuildFireMode.uc
+++ b/DH_Equipment/Classes/DHShovelBuildFireMode.uc
@@ -49,13 +49,6 @@ simulated function bool AllowFire()
         return false;
     }
     
-    Pawn = DHPawn(Instigator);
-
-    if (Pawn != none && !Pawn.CanBuildWithShovel())
-    {
-        return false;
-    }
-
     return  (Construction.GetTeamIndex() == NEUTRAL_TEAM_INDEX || Construction.GetTeamIndex() == Instigator.GetTeamNum()) && Construction.CanBeBuilt();
 }
 

--- a/DH_Equipment/Classes/DHShovelItem.uc
+++ b/DH_Equipment/Classes/DHShovelItem.uc
@@ -17,13 +17,6 @@ simulated function Fire(float F)
 
     P = DHPawn(Instigator);
 
-    if (P != none && !P.CanBuildWithShovel())
-    {
-        // "You must have another squadmate nearby to use your shovel to build!"
-        P.ReceiveLocalizedMessage(Class'DHShovelWarningMessage', 1);
-        return;
-    }
-
     if (Instigator != none && Instigator.bIsCrawling)
     {
         Class'DHShovelWarningMessage'.static.ClientReceive(PlayerController(Instigator.Controller), 0);

--- a/DH_Equipment/Classes/DHShovelWarningMessage.uc
+++ b/DH_Equipment/Classes/DHShovelWarningMessage.uc
@@ -7,7 +7,6 @@ class DHShovelWarningMessage extends ROCriticalMessage
     abstract;
 
 var localized string CannotBeCrawling;
-var localized string NeedMoreFriendliesToBuildMessage;
 
 static function string GetString(optional int Switch, optional PlayerReplicationInfo RelatedPRI_1, optional PlayerReplicationInfo RelatedPRI_2, optional Object OptionalObject)
 {
@@ -15,8 +14,6 @@ static function string GetString(optional int Switch, optional PlayerReplication
     {
         case 0:
             return default.CannotBeCrawling;
-        case 1:
-            return default.NeedMoreFriendliesToBuildMessage;
         default:
             return "";
     }
@@ -25,6 +22,5 @@ static function string GetString(optional int Switch, optional PlayerReplication
 defaultproperties
 {
     CannotBeCrawling="You cannot dig while crawling."
-    NeedMoreFriendliesToBuildMessage="You must have another squadmate nearby to use your shovel to build!"
 }
 


### PR DESCRIPTION
There's been a few times where I'm SL and I place down a cannon or a Command Post.
All goes well until squad member Joe decides that the flowers nearby are more important than being near the CP.
Or Joe took a bullet in the face and I can no longer build the HQ.

There's also been several times where a new player selects the SL role, select a logi truck and then goes and places an AT gun, realizes they can't build and just leaves the truck over there.

--
This changes the logic check to see if the SL is near squad members before they can place something, while at the same time allowing them to still construct something if their squad members are killed / leave out of range.