### PR TITLE
Feature/medium at guns 1 person

### DIFF
--- a/DH_Guns/Classes/DH_17PounderGun.uc
+++ b/DH_Guns/Classes/DH_17PounderGun.uc
@@ -21,7 +21,8 @@ defaultproperties
     ExitPositions(1)=(X=-100.0,Y=0.0,Z=10.0)
     VehicleMass=11.0
     bCanBeRotated=true
-    PlayersNeededToRotate=2
+    RotationGunWeight=3000
+    PlayersNeededToRotate=1
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.at_topdown'
 
     Begin Object Class=KarmaParamsRBFull Name=KParams0

--- a/DH_Guns/Classes/DH_45mmM1937Gun.uc
+++ b/DH_Guns/Classes/DH_45mmM1937Gun.uc
@@ -23,5 +23,6 @@ defaultproperties
     ExitPositions(1)=(X=-88.0,Y=-8.0,Z=25.0)
     VehicleMass=8.0
     bCanBeRotated=true
+    RotationGunWeight=560
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.at_topdown'
 }

--- a/DH_Guns/Classes/DH_AT57Gun.uc
+++ b/DH_Guns/Classes/DH_AT57Gun.uc
@@ -21,6 +21,7 @@ defaultproperties
     ExitPositions(1)=(X=-100.0,Y=0.0,Z=0.0)
     VehicleMass=11.0
     bCanBeRotated=true
+    RotationGunWeight=1140
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.at_topdown'
 
     Begin Object Class=KarmaParamsRBFull Name=KParams0

--- a/DH_Guns/Classes/DH_Cannone4732Gun.uc
+++ b/DH_Guns/Classes/DH_Cannone4732Gun.uc
@@ -29,6 +29,7 @@ defaultproperties
     ExitPositions(2)=(X=-200,Y=0,Z=50)
     VehicleMass=3.0
     bCanBeRotated=true
+    RotationGunWeight=277
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.at_topdown'
     ShadowZOffset=10.0
     Begin Object Class=KarmaParamsRBFull Name=KParams0

--- a/DH_Guns/Classes/DH_Fiat1435Gun.uc
+++ b/DH_Guns/Classes/DH_Fiat1435Gun.uc
@@ -11,6 +11,7 @@ defaultproperties
     VehicleNameString="Fiat-Revelli modello 14/35"
     Mesh=SkeletalMesh'DH_Fiat1435_anm.FIAT1435_TRIPOD_3RD'
     bCanBeRotated=true
+    RotationGunWeight=40
     CollisionRadius=36.0
     CollisionHeight=36.0
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_Fiat1435MGPawn',WeaponBone=turret_placement)

--- a/DH_Guns/Classes/DH_Flak38Gun_Trailer.uc
+++ b/DH_Guns/Classes/DH_Flak38Gun_Trailer.uc
@@ -14,6 +14,7 @@ defaultproperties
     VehicleHudImage=Texture'DH_Artillery_tex.flak38_body_trailer'
     ExitPositions(1)=(X=-30.0,Y=85.0,Z=50.0)
     bCanBeRotated=true
+    RotationGunWeight=420
 
     Begin Object Class=KarmaParamsRBFull Name=KParams0
         KInertiaTensor(0)=1.0

--- a/DH_Guns/Classes/DH_Granatwerfer34Mortar.uc
+++ b/DH_Guns/Classes/DH_Granatwerfer34Mortar.uc
@@ -15,6 +15,7 @@ defaultproperties
     Skins(0)=Texture'DH_Granatwerfer34_tex.grw34_ext_yellow'
     CannonSkins(0)=Texture'DH_Granatwerfer34_tex.grw34_ext_yellow'
 
+    RotationGunWeight=62
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_Granatwerfer34CannonPawn',WeaponBone="TURRET_PLACEMENT")
     CollisionRadius=32.0
     CollisionHeight=8.0

--- a/DH_Guns/Classes/DH_LeIG18Gun.uc
+++ b/DH_Guns/Classes/DH_LeIG18Gun.uc
@@ -24,6 +24,7 @@ defaultproperties
     ExitPositions(1)=(X=-35.00,Y=-65.00,Z=60.00)
     VehicleMass=11.0 // TODO: replace
     bCanBeRotated=true
+    RotationGunWeight=400
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.artillery_topdown'
     RotateCooldown=2
     ShadowZOffset=10

--- a/DH_Guns/Classes/DH_M116Gun.uc
+++ b/DH_Guns/Classes/DH_M116Gun.uc
@@ -21,6 +21,7 @@ defaultproperties
     ExitPositions(2)=(X=-78.00,Y=50.00,Z=48.00)
     VehicleMass=11.0
     bCanBeRotated=true
+    RotationGunWeight=653
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.artillery_topdown'
     ShadowZOffset=10.0
     RotateCooldown=2

--- a/DH_Guns/Classes/DH_M1919A4Gun.uc
+++ b/DH_Guns/Classes/DH_M1919A4Gun.uc
@@ -13,6 +13,7 @@ defaultproperties
     VehicleNameString="M1919A4 Browning Machine Gun"
     Mesh=SkeletalMesh'DH_M1919_anm.M1919A4_M2_BODY_EXT'
     bCanBeRotated=true
+    RotationGunWeight=20
     CollisionRadius=36.0
     CollisionHeight=36.0
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_M1919A4MGPawn',WeaponBone="turret_placement")

--- a/DH_Guns/Classes/DH_M1927Gun.uc
+++ b/DH_Guns/Classes/DH_M1927Gun.uc
@@ -21,6 +21,7 @@ defaultproperties
     ExitPositions(2)=(X=-75.00,Y=35.00,Z=50.00)
     VehicleMass=11.0
     bCanBeRotated=true
+    RotationGunWeight=780
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.artillery_topdown'
     ShadowZOffset=20.0
     bIsArtilleryVehicle=true

--- a/DH_Guns/Classes/DH_M5Gun.uc
+++ b/DH_Guns/Classes/DH_M5Gun.uc
@@ -22,6 +22,7 @@ defaultproperties
     ExitPositions(1)=(X=-100.00,Y=-30.00,Z=35.00)
     VehicleMass=11.0
     bCanBeRotated=true
-    PlayersNeededToRotate=2
+    RotationGunWeight=2210
+    PlayersNeededToRotate=1
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.at_topdown'
 }

--- a/DH_Guns/Classes/DH_ML3InchMortar.uc
+++ b/DH_Guns/Classes/DH_ML3InchMortar.uc
@@ -12,6 +12,7 @@ defaultproperties
     VehicleNameString="Ordnance ML 3-inch Mortar"
     VehicleTeam=1
     Mesh=SkeletalMesh'DH_ML3InchMortar_anm.ml3inch_body_ext'
+    RotationGunWeight=50
     //Skins(0)=Texture'DH_Granatwerfer34_tex.grw34_ext_yellow'
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_ML3InchCannonPawn',WeaponBone="TURRET_PLACEMENT")
     CollisionRadius=32.0

--- a/DH_Guns/Classes/DH_Model35Mortar.uc
+++ b/DH_Guns/Classes/DH_Model35Mortar.uc
@@ -11,6 +11,7 @@ defaultproperties
     VehicleTeam=0
     Mesh=SkeletalMesh'DH_Model35Mortar_anm.model35mortar_base'
     Skins(0)=Texture'DH_Model35Mortar_tex.Model35Mortar_ext'
+    RotationGunWeight=60
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_Model35MortarCannonPawn',WeaponBone="TURRET_PLACEMENT")
     CollisionRadius=32.0
     CollisionHeight=8.0

--- a/DH_Guns/Classes/DH_Pak38ATGun.uc
+++ b/DH_Guns/Classes/DH_Pak38ATGun.uc
@@ -34,6 +34,7 @@ defaultproperties
     ExitPositions(1)=(X=-84.00,Y=-27.00,Z=43.00)
     VehicleMass=11.0
     bCanBeRotated=true
+    RotationGunWeight=1000
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.at_topdown'
 
     Begin Object Class=KarmaParamsRBFull Name=KParams0

--- a/DH_Guns/Classes/DH_Pak40ATGun.uc
+++ b/DH_Guns/Classes/DH_Pak40ATGun.uc
@@ -20,6 +20,7 @@ defaultproperties
     ExitPositions(1)=(X=-84.00,Y=-27.00,Z=43.00)
     VehicleMass=11.0
     bCanBeRotated=true
+    RotationGunWeight=1425
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.at_topdown'
 
     Begin Object Class=KarmaParamsRBFull Name=KParams0

--- a/DH_Guns/Classes/DH_Pak43ATGun.uc
+++ b/DH_Guns/Classes/DH_Pak43ATGun.uc
@@ -21,6 +21,7 @@ defaultproperties
     ExitPositions(1)=(X=-105.00,Y=-37.00,Z=28.00)
     VehicleMass=11.0
     bCanBeRotated=true
+    RotationGunWeight=3650
     PlayersNeededToRotate=2
     RotationsPerSecond=0.05
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.at_topdown'

--- a/DH_Guns/Classes/DH_ZiS2Gun.uc
+++ b/DH_Guns/Classes/DH_ZiS2Gun.uc
@@ -21,6 +21,7 @@ defaultproperties
     ExitPositions(1)=(X=-120.00,Y=-38.00,Z=30.00)
     VehicleMass=11.0
     bCanBeRotated=true
+    RotationGunWeight=1250
     PlayersNeededToRotate=1
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.at_topdown'
 

--- a/DH_Guns/Classes/DH_ZiS3Gun.uc
+++ b/DH_Guns/Classes/DH_ZiS3Gun.uc
@@ -21,6 +21,7 @@ defaultproperties
     ExitPositions(1)=(X=-120.00,Y=-38.00,Z=30.00)
     VehicleMass=11.0
     bCanBeRotated=true
+    RotationGunWeight=1160
     PlayersNeededToRotate=1
     MapIconMaterial=Texture'DH_InterfaceArt2_tex.at_topdown'
 


### PR DESCRIPTION
Allows players to rotate all guns without the need for more players, but it will be faster the more players you have around the gun.
Will need to tweak the rotation values and rotation calculation.