### PR TITLE
Carcano adjustments 2025

### DIFF
--- a/DH_Weapons/Classes/DH_Breda30Bullet.uc
+++ b/DH_Weapons/Classes/DH_Breda30Bullet.uc
@@ -9,6 +9,6 @@ defaultproperties
 {
     Speed=37418.24              // 620m/s (https://en.wikipedia.org/wiki/Breda_30)
     BallisticCoefficient=0.276  // https://www.topgun.es/punta-65-carcano-160gr-hornady.html
-    Damage=100.0                // Intermediate cartridge, lower damage than other rifles.
+    Damage=107.0                // Intermediate cartridge, lower damage than other rifles.
     MyDamageType=Class'DH_Breda30DamType'
 }

--- a/DH_Weapons/Classes/DH_CarcanoM9138CarbineBullet.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM9138CarbineBullet.uc
@@ -10,6 +10,6 @@ defaultproperties
 {
     Speed=38323.52              // 635m/s (https://en.wikipedia.org/wiki/Carcano)
     BallisticCoefficient=0.276  // https://www.topgun.es/punta-65-carcano-160gr-hornady.html
-    Damage=110.0                // Almost an intermediate cartridge, lower damage than other rifles.
+    Damage=107.0                // Almost an intermediate cartridge, lower damage than other rifles.
     MyDamageType=Class'DH_CarcanoM9138CarbineDamType'
 }

--- a/DH_Weapons/Classes/DH_CarcanoM9138CarbineMeleeFire.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM9138CarbineMeleeFire.uc
@@ -7,7 +7,7 @@ class DH_CarcanoM9138CarbineMeleeFire extends DHMeleeFire;
 
 defaultproperties
 {
-    BayonetTraceRange=118.0 // -23% from Fucile mod. 91
+    BayonetTraceRange=130.0 // -10 (only ~150mm shorter than kar98k)
     FireRate=0.23 // -0.02
     DamageType=Class'DH_Weapons.DH_CarcanoM9138CarbineBashDamType'
     BayonetDamageType=Class'DH_Weapons.DH_CarcanoM9138CarbineBayonetDamType'

--- a/DH_Weapons/Classes/DH_CarcanoM9138CarbineWeapon.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM9138CarbineWeapon.uc
@@ -8,8 +8,8 @@ class DH_CarcanoM9138CarbineWeapon extends DHBoltActionWeapon;
 defaultproperties
 {
     ItemName="Carcano Moschetto mod. 91/38"
-    SwayModifyFactor=0.63 // +0.03
-    SwayBayonetModifier=1.28
+    SwayModifyFactor=0.49 // -0.11
+    SwayBayonetModifier=1.06
     FireModeClass(0)=Class'DH_CarcanoM9138CarbineFire'
     FireModeClass(1)=Class'DH_CarcanoM9138CarbineMeleeFire'
     AttachmentClass=Class'DH_CarcanoM9138CarbineAttachment'

--- a/DH_Weapons/Classes/DH_CarcanoM9138ShortRifleBullet.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM9138ShortRifleBullet.uc
@@ -10,6 +10,6 @@ defaultproperties
 {
     Speed=40254.78              // 667m/s (calculated based on M91/38 carbine and M91 muzzle velocities)
     BallisticCoefficient=0.276  // https://www.topgun.es/punta-65-carcano-160gr-hornady.html
-    Damage=110.0                // Almost an intermediate cartridge, lower damage than other rifles.
+    Damage=108.0                // Almost an intermediate cartridge, lower damage than other rifles.
     MyDamageType=Class'DH_CarcanoM9138ShortRifleDamType'
 }

--- a/DH_Weapons/Classes/DH_CarcanoM9138TSCarbineBullet.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM9138TSCarbineBullet.uc
@@ -10,6 +10,6 @@ defaultproperties
 {
     Speed=38323.52              // 635m/s (https://en.wikipedia.org/wiki/Carcano)
     BallisticCoefficient=0.276  // https://www.topgun.es/punta-65-carcano-160gr-hornady.html
-    Damage=110.0                // Almost an intermediate cartridge, lower damage than other rifles.
+    Damage=107.0                // Almost an intermediate cartridge, lower damage than other rifles.
     MyDamageType=Class'DH_CarcanoM9138TSCarbineDamType'
 }

--- a/DH_Weapons/Classes/DH_CarcanoM91Bullet.uc
+++ b/DH_Weapons/Classes/DH_CarcanoM91Bullet.uc
@@ -9,6 +9,6 @@ defaultproperties
 {
     Speed=42246.4               // 700m/s (https://en.wikipedia.org/wiki/Carcano)
     BallisticCoefficient=0.276  // https://www.topgun.es/punta-65-carcano-160gr-hornady.html
-    Damage=110.0                // Almost an intermediate cartridge, lower damage than other rifles.
+    Damage=108.0                // Almost an intermediate cartridge, lower damage than other rifles.
     MyDamageType=Class'DH_CarcanoM91DamType'
 }

--- a/DarkestHourDev/Animations/DH_Carcano_anm.ukx
+++ b/DarkestHourDev/Animations/DH_Carcano_anm.ukx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:caef4599f3acbbb7829ca1843b370985904b80993838197d787ad043c0d3f93d
+oid sha256:db157717370ef93deef6fd7082e2ee2c879f0320d6a86781b8d7cd66f39224da
 size 5908288


### PR DESCRIPTION
- Gave carcano carbine an appropriate sway that is consistent with other carbines
- adjusted carcano carbine bayonet range to be more consistent with other bayonet weapons
- improved damage consistency for 6.5mm bullets: they are now 107-108 depending on barrel length, previously was 100 or 110 and inconsistent with the barrel length.
- Adjusted carcano carbine bolting to be slightly faster in iron sights and slightly slower in hip (the same logic applies to other straight/curved bolt handle pairs like kar98 and vz24)