### PR TITLE
Fixed naming for German Pak, Flak, and KwK guns

### DIFF
--- a/DH_Guns/Classes/DH_Flak38Gun.uc
+++ b/DH_Guns/Classes/DH_Flak38Gun.uc
@@ -7,7 +7,7 @@ class DH_Flak38Gun extends DHATGun;
 
 defaultproperties
 {
-    VehicleNameString="2,0cm FlaK 38"
+    VehicleNameString="2,0cm Flak 38"
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_Vehicles.DH_Flak38CannonPawn',WeaponBone="turret_placement")
     Mesh=SkeletalMesh'DH_Flak38_anm.Flak38_base_static'
     Skins(0)=Texture'DH_Artillery_tex.Flak38_gun'

--- a/DH_Guns/Classes/DH_Flak88Gun.uc
+++ b/DH_Guns/Classes/DH_Flak88Gun.uc
@@ -7,7 +7,7 @@ class DH_Flak88Gun extends DHATGun;
 
 defaultproperties
 {
-    VehicleNameString="8,8cm FlaK 36"
+    VehicleNameString="8,8cm Flak 36"
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_Guns.DH_Flak88CannonPawn',WeaponBone="Turret_placement")
     Mesh=SkeletalMesh'DH_Flak88_anm.flak88_base'
     Skins(0)=Texture'MilitaryAxisSMT.flak_88'

--- a/DH_Guns/Classes/DH_Pak36ATGun.uc
+++ b/DH_Guns/Classes/DH_Pak36ATGun.uc
@@ -10,7 +10,7 @@ class DH_Pak36ATGun extends DHATGun;
 
 defaultproperties
 {
-    VehicleNameString="3,7cm PaK 36"
+    VehicleNameString="3,7cm Pak 36"
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_Guns.DH_Pak36CannonPawn',WeaponBone="Turret_placement")
     Mesh=SkeletalMesh'DH_Pak36_anm.pak36_body_ext'
     Skins(0)=Texture'DH_Pak36_tex.pak36_ext_gray'

--- a/DH_Guns/Classes/DH_Pak36CannonShellHEAT.uc
+++ b/DH_Guns/Classes/DH_Pak36CannonShellHEAT.uc
@@ -3,7 +3,7 @@
 // Darkest Hour: Europe '44-'45
 // Copyright (c) Darklight Games.  All rights reserved.
 //==============================================================================
-// Stielgranate 41 for PaK 36
+// Stielgranate 41 for Pak 36
 // [1] https://en.wikipedia.org/wiki/Stielgranate_41
 //==============================================================================
 

--- a/DH_Guns/Classes/DH_Pak38ATGun.uc
+++ b/DH_Guns/Classes/DH_Pak38ATGun.uc
@@ -7,7 +7,7 @@ class DH_Pak38ATGun extends DHATGun;
 
 defaultproperties
 {
-    VehicleNameString="5,0cm PaK 38"
+    VehicleNameString="5,0cm Pak 38"
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_Guns.DH_Pak38CannonPawn',WeaponBone="Turret_placement")
     Mesh=SkeletalMesh'DH_Pak38_anm.pak38_body_ext'
     Skins(0)=Texture'DH_Pak38_tex.pak38_ext_yellow'

--- a/DH_Guns/Classes/DH_Pak39Gun.uc
+++ b/DH_Guns/Classes/DH_Pak39Gun.uc
@@ -7,7 +7,7 @@ class DH_Pak39Gun extends DHATGun;
 
 defaultproperties
 {
-    VehicleNameString="5.0cm KwK 39 gun"
+    VehicleNameString="5,0cm KwK 39"
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_Pak39CannonPawn',WeaponBone="turret_placement")
     Mesh=SkeletalMesh'DH_Pak39_anm.pak39_body'
     Skins(0)=Texture'DH_Pak39_tex.pak39_body'

--- a/DH_Guns/Classes/DH_Pak40ATGun.uc
+++ b/DH_Guns/Classes/DH_Pak40ATGun.uc
@@ -9,7 +9,7 @@ class DH_Pak40ATGun extends DHATGun;
 
 defaultproperties
 {
-    VehicleNameString="7,5cm PaK 40"
+    VehicleNameString="7,5cm Pak 40"
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_Guns.DH_Pak40CannonPawn',WeaponBone="Turret_placement")
     Mesh=SkeletalMesh'DH_Pak40_anm.Pak40_body_ext'
     Skins(0)=Texture'DH_Pak40_tex.Pak40.pak40_ext_gray'

--- a/DH_Guns/Classes/DH_Pak43ATGun.uc
+++ b/DH_Guns/Classes/DH_Pak43ATGun.uc
@@ -7,7 +7,7 @@ class DH_Pak43ATGun extends DHATGun;
 
 defaultproperties
 {
-    VehicleNameString="8,8cm PaK 43/41"
+    VehicleNameString="8,8cm Pak 43/41"
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_Guns.DH_Pak43CannonPawn',WeaponBone="Turret_placement")
     Mesh=SkeletalMesh'DH_Pak43_anm.pak43_body_ext'
     Skins(0)=Texture'DH_Pak43_tex.pak43_ext_yellow'

--- a/DH_Guns/Classes/DH_Pak43ATGun.uc
+++ b/DH_Guns/Classes/DH_Pak43ATGun.uc
@@ -7,7 +7,7 @@ class DH_Pak43ATGun extends DHATGun;
 
 defaultproperties
 {
-    VehicleNameString="8,8-cm PaK 43"
+    VehicleNameString="8,8cm PaK 43/41"
     PassengerWeapons(0)=(WeaponPawnClass=Class'DH_Guns.DH_Pak43CannonPawn',WeaponBone="Turret_placement")
     Mesh=SkeletalMesh'DH_Pak43_anm.pak43_body_ext'
     Skins(0)=Texture'DH_Pak43_tex.pak43_ext_yellow'

--- a/DH_Guns/Classes/DH_Sdkfz105Cannon.uc
+++ b/DH_Guns/Classes/DH_Sdkfz105Cannon.uc
@@ -10,7 +10,7 @@ simulated function InitializeVehicleBase()
 {
     if (DHVehicle(Base) != none)
     {
-        DHVehicle(Base).CannonSkins[0] = Base.Skins[2]; // match to the texture of the FlaK 38 gun mount on the hull
+        DHVehicle(Base).CannonSkins[0] = Base.Skins[2]; // match to the texture of the Flak 38 gun mount on the hull
     }
 
     super.InitializeVehicleBase();


### PR DESCRIPTION
- Fixed naming inconsistencies.
- Renamed Pak 43 to Pak 43/41.
- Changed Pak and Flak last letters to lowercase.
  > WOPLF:
  > Pak and Flak are accepted kurzwoerter (also listed as such in Duden)
  > so they should not be capitlized as abbreviations (like KwK) would be