### PR TITLE
LMG adjustments

### DIFF
--- a/DH_Weapons/Classes/DH_BARFire.uc
+++ b/DH_Weapons/Classes/DH_BARFire.uc
@@ -15,14 +15,14 @@ defaultproperties
     MuzzleBone=MuzzleNew
 
     // Spread
-    HipSpreadModifier=6.0
+    HipSpreadModifier=5.0
     Spread=65.0
 
     // Recoil
     RecoilRate=0.1
-    MaxVerticalRecoilAngle=670
+    MaxVerticalRecoilAngle=660
     MaxHorizontalRecoilAngle=180
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=2.0,OutVal=0.8),(InVal=3.0,OutVal=1.0),(InVal=6.0,OutVal=1.2),(InVal=16.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=3.0,OutVal=1.0),(InVal=6.0,OutVal=1.2),(InVal=16.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=4.0
     RecoilFallOffFactor=40.0
 

--- a/DH_Weapons/Classes/DH_BARNoBipodFire.uc
+++ b/DH_Weapons/Classes/DH_BARNoBipodFire.uc
@@ -15,14 +15,13 @@ defaultproperties
     MuzzleBone=MuzzleNew
 
     // Spread
-    HipSpreadModifier=6.0
     Spread=65.0
 
     // Recoil //adjusted from full variant
     RecoilRate=0.1
-    MaxVerticalRecoilAngle=688
-    MaxHorizontalRecoilAngle=140
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.66),(InVal=4.0,OutVal=1.0),(InVal=8.0,OutVal=1.1),(InVal=16.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=660
+    MaxHorizontalRecoilAngle=150
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.66),(InVal=3.0,OutVal=1.0),(InVal=5.0,OutVal=1.1),(InVal=9.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=4.0
     RecoilFallOffFactor=40.0
 

--- a/DH_Weapons/Classes/DH_Breda30Fire.uc
+++ b/DH_Weapons/Classes/DH_Breda30Fire.uc
@@ -21,9 +21,9 @@ defaultproperties
 
     // Recoil
     RecoilRate=0.05
-    MaxVerticalRecoilAngle=500
-    MaxHorizontalRecoilAngle=200
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.66),(InVal=2.0,OutVal=0.8),(InVal=3.0,OutVal=1.0),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=480
+    MaxHorizontalRecoilAngle=150
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.60),(InVal=3.0,OutVal=0.9),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=2.0
     RecoilFallOffFactor=6.0
 

--- a/DH_Weapons/Classes/DH_Breda30Weapon.uc
+++ b/DH_Weapons/Classes/DH_Breda30Weapon.uc
@@ -170,7 +170,7 @@ defaultproperties
 
     MaxNumPrimaryMags=15        // The backpack that the machine-gunner carries holds 15 slots for stripper clips.
     InitialNumPrimaryMags=10
-    NumMagsToResupply=2
+    NumMagsToResupply=3
 
     IdleToBipodDeploy="deploy"
     BipodDeployToIdle="undeploy"

--- a/DH_Weapons/Classes/DH_BrenFire.uc
+++ b/DH_Weapons/Classes/DH_BrenFire.uc
@@ -22,7 +22,7 @@ defaultproperties
     RecoilRate=0.05
     MaxVerticalRecoilAngle=580
     MaxHorizontalRecoilAngle=230
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.66),(InVal=2.0,OutVal=0.8),(InVal=3.0,OutVal=1.0),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=2.0
     RecoilFallOffFactor=6.0
 

--- a/DH_Weapons/Classes/DH_DP27Fire.uc
+++ b/DH_Weapons/Classes/DH_DP27Fire.uc
@@ -18,9 +18,9 @@ defaultproperties
     // Recoil
     RecoilRate=0.05
     PctBipodDeployRecoil=0.1
-    MaxVerticalRecoilAngle=540
-    MaxHorizontalRecoilAngle=265
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.7),(InVal=8.0,OutVal=1.1),(InVal=14.0,OutVal=0.9),(InVal=50.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=610 
+    MaxHorizontalRecoilAngle=260
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=9.0,OutVal=1.1),(InVal=16.0,OutVal=0.9),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=4.0
     RecoilFallOffFactor=24.0
 

--- a/DH_Weapons/Classes/DH_DP27LateFire.uc
+++ b/DH_Weapons/Classes/DH_DP27LateFire.uc
@@ -17,10 +17,10 @@ defaultproperties
 
     // Recoil
     RecoilRate=0.05
-    PctBipodDeployRecoil=0.075 // 0.1 by default
-    MaxVerticalRecoilAngle=840  // these values are high because of custom recoil modifier for bipod being 0.075
-    MaxHorizontalRecoilAngle=340
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=10.0,OutVal=1.2),(InVal=16.0,OutVal=0.8),(InVal=10000000000.0,OutVal=1.0)))
+    PctBipodDeployRecoil=0.1
+    MaxVerticalRecoilAngle=610 
+    MaxHorizontalRecoilAngle=260
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=9.0,OutVal=1.1),(InVal=16.0,OutVal=0.9),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=4.0
     RecoilFallOffFactor=24.0
 

--- a/DH_Weapons/Classes/DH_DT29Fire.uc
+++ b/DH_Weapons/Classes/DH_DT29Fire.uc
@@ -18,9 +18,9 @@ defaultproperties
     // Recoil
     RecoilRate=0.05
     PctBipodDeployRecoil=0.1
-    MaxVerticalRecoilAngle=555
-    MaxHorizontalRecoilAngle=275
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.7),(InVal=8.0,OutVal=1.1),(InVal=14.0,OutVal=0.9),(InVal=50.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    MaxVerticalRecoilAngle=630 
+    MaxHorizontalRecoilAngle=270
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=8.0,OutVal=1.1),(InVal=14.0,OutVal=0.9),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=4.0
     RecoilFallOffFactor=24.0
 

--- a/DH_Weapons/Classes/DH_FG42Fire.uc
+++ b/DH_Weapons/Classes/DH_FG42Fire.uc
@@ -46,7 +46,7 @@ defaultproperties
     RecoilRate=0.05
     MaxVerticalRecoilAngle=520
     MaxHorizontalRecoilAngle=180
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=3.0,OutVal=0.75),(InVal=9.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=3.0,OutVal=0.8),(InVal=8.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     PctProneIronRecoil=0.50
     PctRestDeployRecoil=0.50
     PctBipodDeployRecoil=0.30

--- a/DH_Weapons/Classes/DH_ZB30AutoFire.uc
+++ b/DH_Weapons/Classes/DH_ZB30AutoFire.uc
@@ -20,7 +20,7 @@ defaultproperties
     RecoilRate=0.05
     MaxVerticalRecoilAngle=590
     MaxHorizontalRecoilAngle=220
-    RecoilCurve=(Points=((InVal=0.0,OutVal=0.66),(InVal=2.0,OutVal=0.8),(InVal=3.0,OutVal=1.0),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
+    RecoilCurve=(Points=((InVal=0.0,OutVal=0.6),(InVal=6.0,OutVal=1.0),(InVal=10000000000.0,OutVal=1.0)))
     RecoilFallOffExponent=2.0
     RecoilFallOffFactor=6.0
 


### PR DESCRIPTION
Recoil adjusted to bring more consistency. Among the most affected is the DP-27, which for some bizarre reason was very different between late and regular version (they were supposed to be identical). Breda recoil was also reduced, as it is rightfully one of the few advantages it should have over the others (low powered cartridge in a heavy machinegun). The rest are mostly minor adjustments

Increased breda resupply to 60 rounds, which is more consistent with other LMGs