### PR TITLE
slightly lowered SRCM35 damage

### DIFF
--- a/DH_Weapons/Classes/DH_SRCMMod35GrenadeProjectile.uc
+++ b/DH_Weapons/Classes/DH_SRCMMod35GrenadeProjectile.uc
@@ -7,7 +7,6 @@ class DH_SRCMMod35GrenadeProjectile extends DHGrenadeProjectile;
 
 defaultproperties
 {
-    // TODO: this is a tiny boy, so the damage probably needs to be reduced
     Damage=120.0 //43 grams
     DamageRadius=700.0 //Blast radius 12m according to page 60 of `Armi Della Fanteria Italiana Nella Seconda Guerra Mondiale`
     MyDamageType=Class'DH_SRCMMod35GrenadeDamageType'


### PR DESCRIPTION
slightly reduced srcm35 damage to make it more consistent with the other offensive grenades (stg24 and rg34); should also help with balance issues.

TO DO: i think the damage radius on this grenade is very questionable and should be changed, but i will leave it for the future global grenade rebalance that will hopefully happen when we set up the dependency between damage and TNT equivalent.