### PR TITLE
Slightly diversified sidearm fire rates, depending on recoil and convenience

### DIFF
--- a/DH_Weapons/Classes/DH_BHPFire.uc
+++ b/DH_Weapons/Classes/DH_BHPFire.uc
@@ -13,6 +13,7 @@ defaultproperties
     Spread=185.0
     MaxVerticalRecoilAngle=380
     MaxHorizontalRecoilAngle=235
+    FireRate=0.21
 
     FireSounds(0)=SoundGroup'DH_MN_InfantryWeapons_sound.browninghpfire01'
     FireSounds(1)=SoundGroup'DH_MN_InfantryWeapons_sound.browninghpfire02'

--- a/DH_Weapons/Classes/DH_C96Fire.uc
+++ b/DH_Weapons/Classes/DH_C96Fire.uc
@@ -15,6 +15,7 @@ defaultproperties
     Spread=200.0
     MaxVerticalRecoilAngle=870
     MaxHorizontalRecoilAngle=350
+    FireRate=0.23
 
     ShellEjectClass=Class'ShellEject1st9x19mm'
     ShellHipOffset=(X=0.0,Y=0.0,Z=0.0)

--- a/DH_Weapons/Classes/DH_ColtM1911Fire.uc
+++ b/DH_Weapons/Classes/DH_ColtM1911Fire.uc
@@ -14,6 +14,7 @@ defaultproperties
     Spread=220.0
     MaxVerticalRecoilAngle=600
     MaxHorizontalRecoilAngle=350
+    FireRate=0.23
 
     ShellEjectClass=Class'ShellEject1st9x19mm'
     ShellHipOffset=(X=0.0,Y=0.0,Z=0.0)

--- a/DH_Weapons/Classes/DH_ColtM1914Fire.uc
+++ b/DH_Weapons/Classes/DH_ColtM1914Fire.uc
@@ -14,6 +14,7 @@ defaultproperties
     Spread=220.0
     MaxVerticalRecoilAngle=600
     MaxHorizontalRecoilAngle=350
+    FireRate=0.23
 
     ShellEjectClass=Class'ShellEject1st9x19mm'
     ShellHipOffset=(X=0.0,Y=0.0,Z=0.0)

--- a/DH_Weapons/Classes/DH_EnfieldNo2Fire.uc
+++ b/DH_Weapons/Classes/DH_EnfieldNo2Fire.uc
@@ -13,6 +13,7 @@ defaultproperties
     Spread=250.0
     MaxVerticalRecoilAngle=650
     MaxHorizontalRecoilAngle=100
+    FireRate=0.25
 
     FireSounds(0)=SoundGroup'DH_WeaponSounds.EnfieldNo2_Fire01'
     FireLastAnim="shoot"

--- a/DH_Weapons/Classes/DH_P08LugerFire.uc
+++ b/DH_Weapons/Classes/DH_P08LugerFire.uc
@@ -13,6 +13,7 @@ defaultproperties
     Spread=190.0
     MaxVerticalRecoilAngle=500
     MaxHorizontalRecoilAngle=250
+    FireRate=0.21
 
     FireSounds(0)=SoundGroup'Inf_Weapons.lugerp08_fire01'
     FireSounds(1)=SoundGroup'Inf_Weapons.lugerp08_fire02'

--- a/DH_Weapons/Classes/DH_P38Fire.uc
+++ b/DH_Weapons/Classes/DH_P38Fire.uc
@@ -13,6 +13,7 @@ defaultproperties
     Spread=185.0
     MaxVerticalRecoilAngle=400
     MaxHorizontalRecoilAngle=225
+    FireRate=0.21
 
     FireSounds(0)=SoundGroup'Inf_Weapons.waltherp38_fire01'
     FireSounds(1)=SoundGroup'Inf_Weapons.waltherp38_fire02'

--- a/DH_Weapons/Classes/DH_TT33Fire.uc
+++ b/DH_Weapons/Classes/DH_TT33Fire.uc
@@ -9,11 +9,11 @@ defaultproperties
 {
     ProjectileClass=Class'DH_TT33Bullet'
     AmmoClass=Class'TT33Ammo'
-    FireRate=0.2
 
     Spread=210
     MaxVerticalRecoilAngle=500
     MaxHorizontalRecoilAngle=300
+    FireRate=0.22
 
     FireSounds(0)=Sound'Inf_Weapons.tt33_fire01'
     FireSounds(1)=Sound'Inf_Weapons.tt33_fire02'

--- a/DH_Weapons/Classes/DH_ViSFire.uc
+++ b/DH_Weapons/Classes/DH_ViSFire.uc
@@ -13,6 +13,7 @@ defaultproperties
     Spread=185.0
     MaxVerticalRecoilAngle=450
     MaxHorizontalRecoilAngle=205
+    FireRate=0.21
 
     FireSounds(0)=SoundGroup'DH_old_inf_Weapons.vis_fire01'
     FireSounds(1)=SoundGroup'DH_old_inf_Weapons.vis_fire02'


### PR DESCRIPTION
Beretta is left at 0.20 as a relatively weak .380
9mm pistols are set to 0.21
Colt 1911 is set to 0.23 as more powerful .45
TT is set to 0.22 for its caliber 
C96 is set to 0.23 for its awkward high bore axis 
Enfield no2 is set to the old 0.25 value because its a double action revolver