### PR TITLE
White Phosphorous Resupply and Minor Bug Fixes for Shermans

### DIFF
--- a/DH_Vehicles/Classes/DH_ChurchillMkVIICannon.uc
+++ b/DH_Vehicles/Classes/DH_ChurchillMkVIICannon.uc
@@ -49,7 +49,7 @@ defaultproperties
 
     MaxPrimaryAmmo=38
     MaxSecondaryAmmo=38
-    MaxTertiaryAmmo=0 //we'll need to find a better solution to limiting WP resupply later
+    MaxTertiaryAmmo=5
 
     SecondarySpread=0.00175
     TertiarySpread=0.0036

--- a/DH_Vehicles/Classes/DH_CromwellCannon.uc
+++ b/DH_Vehicles/Classes/DH_CromwellCannon.uc
@@ -47,7 +47,7 @@ defaultproperties
     InitialTertiaryAmmo=4
     MaxPrimaryAmmo=33
     MaxSecondaryAmmo=26
-    MaxTertiaryAmmo=0 //we'll need to find a better solution to limiting WP resupply later
+    MaxTertiaryAmmo=4
 
     SecondarySpread=0.00175
     TertiarySpread=0.0036

--- a/DH_Vehicles/Classes/DH_ShermanCannon.uc
+++ b/DH_Vehicles/Classes/DH_ShermanCannon.uc
@@ -33,6 +33,7 @@ defaultproperties
     RightArmorFactor=5.1
     LeftArmorFactor=5.1
     RearArmorFactor=5.1
+    FrontArmorSlope=30.0
     RightArmorSlope=5.0
     LeftArmorSlope=5.0
     FrontLeftAngle=316.0
@@ -59,13 +60,13 @@ defaultproperties
     nProjectileDescriptions(1)="M48 HE-T"
     nProjectileDescriptions(2)="M64 WP"
 
-    InitialPrimaryAmmo=40
+    InitialPrimaryAmmo=30
     InitialSecondaryAmmo=20
     InitialTertiaryAmmo=4
 
-    MaxPrimaryAmmo=45
-    MaxSecondaryAmmo=40
-    MaxTertiaryAmmo=0 //we'll need to find a better solution to limiting WP resupply later
+    MaxPrimaryAmmo=36
+    MaxSecondaryAmmo=45
+    MaxTertiaryAmmo=9
 
     SecondarySpread=0.00175
     TertiarySpread=0.0036

--- a/DH_Vehicles/Classes/DH_ShermanCannon_M4A3105_Howitzer.uc
+++ b/DH_Vehicles/Classes/DH_ShermanCannon_M4A3105_Howitzer.uc
@@ -47,7 +47,7 @@ defaultproperties
     InitialSecondaryAmmo=4
     InitialTertiaryAmmo=12
     MaxPrimaryAmmo=45
-    MaxSecondaryAmmo=0 //we'll need to find a better solution to limiting WP resupply later
+    MaxSecondaryAmmo=6
     MaxTertiaryAmmo=15
     Spread=0.003
     SecondarySpread=0.0036

--- a/DH_Vehicles/Classes/DH_ShermanCannon_M4A3E2_Jumbo.uc
+++ b/DH_Vehicles/Classes/DH_ShermanCannon_M4A3E2_Jumbo.uc
@@ -43,12 +43,12 @@ defaultproperties
     nProjectileDescriptions(1)="M48 HE-T"
     nProjectileDescriptions(2)="M64 WP"
 
-    InitialPrimaryAmmo=32
-    InitialSecondaryAmmo=25
+    InitialPrimaryAmmo=30
+    InitialSecondaryAmmo=30
     InitialTertiaryAmmo=4
-    MaxPrimaryAmmo=35
-    MaxSecondaryAmmo=50
-    MaxTertiaryAmmo=0 //we'll need to find a better solution to limiting WP resupply later
+    MaxPrimaryAmmo=42
+    MaxSecondaryAmmo=52
+    MaxTertiaryAmmo=10
 
     SecondarySpread=0.00175
     TertiarySpread=0.0036


### PR DESCRIPTION
All British and American tanks:

- Enabled resupply for White Phosphorous shells.

Sherman 75mm and 105mm variants:

- Changed max ammo to better reflect actual capacities and standard loadout ratios according to official wartime Sherman manual (TM 9-731B). This does not affect initial ammo counts which have been left unchanged for the time being to not alter game balance. (Note that due to the M4A1 and M4A3 sharing cannon classes, the M4A3 technically has less maximum ammo than it should but this issue has always existed and should be corrected when Shermans are remade).

Sherman M4A1 and M4A3(75):

- Added 30 degree slope to the turret front armor value. No turret slope value has ever been entered for these tanks despite having a clear visual slope on the model. 30 degree value is sourced from WW2 Ballistics: Armor and Gunnery, page 69.