### PR TITLE
Fixed Unfinished and Incorrect Armor Values for M4A3E2 Jumbo:

### DIFF
--- a/DH_Vehicles/Classes/DH_ShermanCannon_M4A3E2_Jumbo.uc
+++ b/DH_Vehicles/Classes/DH_ShermanCannon_M4A3E2_Jumbo.uc
@@ -16,8 +16,8 @@ defaultproperties
     CollisionStaticMeshes(0)=(CollisionStaticMesh=StaticMesh'DH_allies_vehicles_stc3.M4A3E2_turret_coll')
     FireEffectOffset=(X=0.0,Y=0.0,Z=-10.0)
 
-    // Turret armor
-    FrontArmorFactor=16.6
+    // Turret armor. Sources: Page 69 of WWII Ballistics: Armor and Gunnery and http://the.shadock.free.fr/sherman_minutia/manufacturer/m4a3e2jumbo/m4a3e2.html
+    FrontArmorFactor=17.8
     RightArmorFactor=15.2
     LeftArmorFactor=15.2
     RearArmorFactor=15.2

--- a/DH_Vehicles/Classes/DH_ShermanTank_M4A3E2_Jumbo.uc
+++ b/DH_Vehicles/Classes/DH_ShermanTank_M4A3E2_Jumbo.uc
@@ -16,14 +16,19 @@ defaultproperties
     DriverPositions(0)=(PositionMesh=SkeletalMesh'DH_ShermanM4A3_anm.ShermanM4A3E2_body_int')
     DriverPositions(1)=(PositionMesh=SkeletalMesh'DH_ShermanM4A3_anm.ShermanM4A3E2_body_int')
     DriverPositions(2)=(PositionMesh=SkeletalMesh'DH_ShermanM4A3_anm.ShermanM4A3E2_body_int')
-    FrontArmor(0)=(Thickness=13.97)
-    FrontArmor(1)=(Thickness=13.97)
-    FrontArmor(2)=(Thickness=11.43)
-    FrontArmor(3)=(Thickness=8.7) // TODO: Bird & Livingston says 64mm plus 38mm for front, & 38mm + 38mm for upper sides
+
+    //Armor Values. Sources: Page 69 of WWII Ballistics: Armor and Gunnery and http://the.shadock.free.fr/sherman_minutia/manufacturer/m4a3e2jumbo/m4a3e2.html
+    FrontArmor(0)=(Thickness=11.43,Slope=-45.0,MaxRelativeHeight=41.0,LocationName="lower nose")
+    FrontArmor(1)=(Thickness=13.97,MaxRelativeHeight=55.0,LocationName="mid nose") // represents flattest, front facing part of rounded nose plate
+    FrontArmor(2)=(Thickness=11.43,Slope=56.0,MaxRelativeHeight=73.0,LocationName="upper nose")
+    FrontArmor(3)=(Thickness=10.2,Slope=47.0,LocationName="upper")
     RightArmor(0)=(Thickness=3.81,MaxRelativeHeight=69.7,LocationName="lower")
-    RightArmor(1)=(Thickness=5.8,LocationName="upper")
+    RightArmor(1)=(Thickness=7.6,LocationName="upper")
     LeftArmor(0)=(Thickness=3.81,MaxRelativeHeight=69.7,LocationName="lower")
-    LeftArmor(1)=(Thickness=5.8,LocationName="upper")
+    LeftArmor(1)=(Thickness=7.6,LocationName="upper")
+    RearArmor(0)=(Thickness=3.81,Slope=-10.0,MaxRelativeHeight=61.0,LocationName="lower")
+    RearArmor(1)=(Thickness=3.81,Slope=22.0,LocationName="upper")
+
     DestroyedVehicleMesh=StaticMesh'DH_allies_vehicles_stc3.M4A3E2_dest'
     GearRatios(4)=0.67
     TransRatio=0.07


### PR DESCRIPTION
- Upper hull/front glacis plate is now 102mm thick (up from 87mm) and sloped at 47 degrees, as per page 69 of WW2 Ballistics: Armor and Gunnery.
- Hull sides are 76mm thick (up from 58mm), same source as above.
- Turret front armor changed to account for 178mm thick mantlet which covers 70% of the turret face (up from 166mm), same source as above.