### PR TITLE
Fixed lack of vertical tilt on Gundlach periscopes

### DIFF
--- a/DH_Vehicles/Classes/DH_ChurchillMkVIICannonPawn.uc
+++ b/DH_Vehicles/Classes/DH_ChurchillMkVIICannonPawn.uc
@@ -10,7 +10,7 @@ defaultproperties
     GunClass=Class'DH_ChurchillMkVIICannon'
     DriverPositions(0)=(ViewLocation=(X=12.0,Y=-9.5,Z=-0.75),ViewFOV=28.33,bDrawOverlays=true)
     // TODO: make new animations so no need for these camera offsets:
-    DriverPositions(1)=(ViewLocation=(X=44.0,Y=-8.5,Z=3.0),TransitionUpAnim="com_open",ViewPitchUpLimit=1,ViewPitchDownLimit=65535,bDrawOverlays=true)
+    DriverPositions(1)=(ViewLocation=(X=44.0,Y=-8.5,Z=3.0),TransitionUpAnim="com_open",ViewPitchUpLimit=2731,ViewPitchDownLimit=64080,bDrawOverlays=true)
     DriverPositions(2)=(ViewLocation=(X=5.0,Y=3.0,Z=0.0),TransitionDownAnim="com_close",DriverTransitionAnim="stand_idlehip_binoc",ViewPitchUpLimit=10000,ViewPitchDownLimit=63500,ViewPositiveYawLimit=10000,ViewNegativeYawLimit=-10000,bExposed=true)
     DriverPositions(3)=(ViewLocation=(X=5.0,Y=3.0,Z=0.0),ViewFOV=12.0,DriverTransitionAnim="stand_idleiron_binoc",ViewPitchUpLimit=10000,ViewPitchDownLimit=63500,ViewPositiveYawLimit=10000,ViewNegativeYawLimit=-10000,bDrawOverlays=true,bExposed=true)
     PeriscopePositionIndex=1

--- a/DH_Vehicles/Classes/DH_ChurchillMkVIITank.uc
+++ b/DH_Vehicles/Classes/DH_ChurchillMkVIITank.uc
@@ -35,7 +35,7 @@ defaultproperties
 
     // Driver
     DriverPositions(0)=(PositionMesh=SkeletalMesh'DH_Churchill_anm.ChurchillMkVII_body_int',TransitionUpAnim="driver_visionport_close",ViewPitchUpLimit=3000,ViewPitchDownLimit=60500,ViewPositiveYawLimit=5500,ViewNegativeYawLimit=-5500,bExposed=true)
-    DriverPositions(1)=(PositionMesh=SkeletalMesh'DH_Churchill_anm.ChurchillMkVII_body_int',TransitionUpAnim="driver_periscope_out",TransitionDownAnim="driver_visionport_open",ViewPitchUpLimit=1,ViewPitchDownLimit=65535,ViewPositiveYawLimit=5500,ViewNegativeYawLimit=-5500,bDrawOverlays=true)
+    DriverPositions(1)=(PositionMesh=SkeletalMesh'DH_Churchill_anm.ChurchillMkVII_body_int',TransitionUpAnim="driver_periscope_out",TransitionDownAnim="driver_visionport_open",ViewPitchUpLimit=2731,ViewPitchDownLimit=64080,ViewPositiveYawLimit=5500,ViewNegativeYawLimit=-5500,bDrawOverlays=true)
     DriverPositions(2)=(PositionMesh=SkeletalMesh'DH_Churchill_anm.ChurchillMkVII_body_int',TransitionUpAnim="driver_hatch_open",TransitionDownAnim="driver_periscope_in",DriverTransitionAnim="VUC_driver_close",ViewPitchUpLimit=3000,ViewPitchDownLimit=60500,ViewPositiveYawLimit=2500,ViewNegativeYawLimit=-1500)
     DriverPositions(3)=(PositionMesh=SkeletalMesh'DH_Churchill_anm.ChurchillMkVII_body_int',TransitionDownAnim="driver_hatch_close",DriverTransitionAnim="VUC_driver_open",ViewPitchUpLimit=5000,ViewPitchDownLimit=64700,ViewPositiveYawLimit=15000,ViewNegativeYawLimit=-15000,bExposed=true)
     InitialPositionIndex=2

--- a/DH_Vehicles/Classes/DH_CromwellCannonPawn.uc
+++ b/DH_Vehicles/Classes/DH_CromwellCannonPawn.uc
@@ -9,7 +9,7 @@ defaultproperties
 {
     GunClass=Class'DH_CromwellCannon'
     DriverPositions(0)=(ViewLocation=(X=23.0,Y=-20.0,Z=0.0),ViewFOV=28.33,ViewPitchUpLimit=3641,ViewPitchDownLimit=64500,bDrawOverlays=true)
-    DriverPositions(1)=(TransitionUpAnim="com_open",DriverTransitionAnim="stand_idlehip_binoc",ViewPitchUpLimit=1,ViewPitchDownLimit=65535,ViewPositiveYawLimit=12000,ViewNegativeYawLimit=-12000,bDrawOverlays=true)
+    DriverPositions(1)=(TransitionUpAnim="com_open",DriverTransitionAnim="stand_idlehip_binoc",ViewPitchUpLimit=2731,ViewPitchDownLimit=64080,ViewPositiveYawLimit=12000,ViewNegativeYawLimit=-12000,bDrawOverlays=true)
     DriverPositions(2)=(TransitionDownAnim="com_close",DriverTransitionAnim="VT3485_com_open",ViewPitchUpLimit=10000,ViewPitchDownLimit=63500,ViewPositiveYawLimit=10000,ViewNegativeYawLimit=-10000,bExposed=true)
     DriverPositions(3)=(ViewFOV=12.0,DriverTransitionAnim="stand_idleiron_binoc",ViewPitchUpLimit=10000,ViewPitchDownLimit=63500,ViewPositiveYawLimit=10000,ViewNegativeYawLimit=-10000,bDrawOverlays=true,bExposed=true)
     PeriscopePositionIndex=1

--- a/DH_Vehicles/Classes/DH_IS2CannonPawn.uc
+++ b/DH_Vehicles/Classes/DH_IS2CannonPawn.uc
@@ -9,7 +9,7 @@ defaultproperties
 {
     GunClass=Class'DH_IS2Cannon'
     DriverPositions(0)=(ViewLocation=(X=115.0,Y=-20.0,Z=5.0),ViewFOV=22.5,PositionMesh=SkeletalMesh'DH_IS2_anm.IS2-turret_int',ViewPitchUpLimit=6000,ViewPitchDownLimit=64500,ViewPositiveYawLimit=19000,ViewNegativeYawLimit=-20000,bDrawOverlays=true)
-    DriverPositions(1)=(ViewLocation=(X=0.0,Y=0.0,Z=14.0),ViewFOV=75.0,PositionMesh=SkeletalMesh'DH_IS2_anm.IS2-turret_ext',DriverTransitionAnim="VIS2_com_idle_close",ViewPitchUpLimit=1,ViewPitchDownLimit=65535,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536,bDrawOverlays=true)
+    DriverPositions(1)=(ViewLocation=(X=0.0,Y=0.0,Z=14.0),ViewFOV=75.0,PositionMesh=SkeletalMesh'DH_IS2_anm.IS2-turret_ext',DriverTransitionAnim="VIS2_com_idle_close",ViewPitchUpLimit=2731,ViewPitchDownLimit=64080,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536,bDrawOverlays=true)
     //TO-DO: add some animations to transition from periscope view
     DriverPositions(2)=(ViewFOV=75.0,PositionMesh=SkeletalMesh'DH_IS2_anm.IS2-turret_int',DriverTransitionAnim="VIS2_com_close",TransitionUpAnim="com_open",ViewPitchUpLimit=4000,ViewPitchDownLimit=64500,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536)
     DriverPositions(3)=(PositionMesh=SkeletalMesh'DH_IS2_anm.IS2-turret_int',DriverTransitionAnim="VIS2_com_open",TransitionDownAnim="com_close",ViewPitchUpLimit=5000,ViewPitchDownLimit=62000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-10000,bExposed=true)

--- a/DH_Vehicles/Classes/DH_T3476CannonPawn.uc
+++ b/DH_Vehicles/Classes/DH_T3476CannonPawn.uc
@@ -9,7 +9,7 @@ defaultproperties
 {
     GunClass=Class'DH_T3476Cannon'
     DriverPositions(0)=(ViewLocation=(X=115.0,Y=-15.0,Z=0.0),ViewFOV=34.0,PositionMesh=SkeletalMesh'DH_T34_anm.T34-76_turret_int',bDrawOverlays=true)
-    DriverPositions(1)=(ViewLocation=(X=35,Y=-5.0,Z=20.0),ViewFOV=34.0,PositionMesh=SkeletalMesh'DH_T34_anm.T34-76_turret_int',DriverTransitionAnim="VT3476_com_idle_close",TransitionUpAnim="com_open",DriverTransitionAnim="VT3476_com_close",ViewPitchUpLimit=1,ViewPitchDownLimit=65535,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536,bDrawOverlays=true)
+    DriverPositions(1)=(ViewLocation=(X=35,Y=-5.0,Z=20.0),ViewFOV=34.0,PositionMesh=SkeletalMesh'DH_T34_anm.T34-76_turret_int',DriverTransitionAnim="VT3476_com_idle_close",TransitionUpAnim="com_open",DriverTransitionAnim="VT3476_com_close",ViewPitchUpLimit=2731,ViewPitchDownLimit=64080,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536,bDrawOverlays=true)
     //
     DriverPositions(2)=(PositionMesh=SkeletalMesh'DH_T34_anm.T34-76_turret_int',TransitionDownAnim="com_close",DriverTransitionAnim="VT3476_com_open",ViewPitchUpLimit=5000,ViewPitchDownLimit=62000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-10000,bExposed=true)
     DriverPositions(3)=(ViewFOV=12.0,PositionMesh=SkeletalMesh'DH_T34_anm.T34-76_turret_int',DriverTransitionAnim="stand_idleiron_binoc",ViewPitchUpLimit=5000,ViewPitchDownLimit=62000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-10000,bDrawOverlays=true,bExposed=true)

--- a/DH_Vehicles/Classes/DH_T3485CannonPawn.uc
+++ b/DH_Vehicles/Classes/DH_T3485CannonPawn.uc
@@ -9,7 +9,7 @@ defaultproperties
 {
     GunClass=Class'DH_T3485Cannon'
     DriverPositions(0)=(ViewLocation=(X=23.0,Y=-15.0,Z=0.0),ViewFOV=21.25,PositionMesh=SkeletalMesh'DH_T34_anm.T34-85_turret_int',bDrawOverlays=true)
-    DriverPositions(1)=(ViewLocation=(X=0,Y=0,Z=15.0),ViewFOV=75.0,PositionMesh=SkeletalMesh'DH_T34_anm.T34-85_turret_int',DriverTransitionAnim="VT3485_com_close",TransitionUpAnim="com_open",ViewPitchUpLimit=1,ViewPitchDownLimit=65535,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536,bDrawOverlays=true)
+    DriverPositions(1)=(ViewLocation=(X=0,Y=0,Z=15.0),ViewFOV=75.0,PositionMesh=SkeletalMesh'DH_T34_anm.T34-85_turret_int',DriverTransitionAnim="VT3485_com_close",TransitionUpAnim="com_open",ViewPitchUpLimit=2731,ViewPitchDownLimit=64080,ViewPositiveYawLimit=65536,ViewNegativeYawLimit=-65536,bDrawOverlays=true)
     //
     DriverPositions(2)=(PositionMesh=SkeletalMesh'DH_T34_anm.T34-85_turret_int',DriverTransitionAnim="VT3485_com_open",TransitionDownAnim="com_close",ViewPitchUpLimit=5000,ViewPitchDownLimit=62000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-10000,bExposed=true)
     DriverPositions(3)=(ViewFOV=12.0,PositionMesh=SkeletalMesh'DH_T34_anm.T34-85_turret_int',DriverTransitionAnim="stand_idleiron_binoc",ViewPitchUpLimit=5000,ViewPitchDownLimit=62000,ViewPositiveYawLimit=6000,ViewNegativeYawLimit=-10000,bDrawOverlays=true,bExposed=true)


### PR DESCRIPTION
Pitch limits are set to -8/+15 degrees on:
- T-34/76 commander periscope (MK-4)
- T-34/85 commander periscope (MK-4)
- IS-2 commander periscope (MK-4)
- Cromwell commander periscope (No8 MkI)
- Churchill driver periscope (No6 MkI)
- Churchill gunner periscope (No6 MkI)