### PR TITLE
Fixed the bug where rallies are overrun by driven vehicles

### DIFF
--- a/DH_Engine/Classes/DHSpawnPointBase.uc
+++ b/DH_Engine/Classes/DHSpawnPointBase.uc
@@ -441,7 +441,7 @@ function GetPlayerCountsWithinRadius(float RadiusInMeters, optional int SquadInd
 
     foreach RadiusActors(Class'Pawn', P, Class'DHUnits'.static.MetersToUnreal(RadiusInMeters))
     {
-        if (P != none && !P.bHidden && !P.bDeleteMe && P.Health > 0)
+        if (P != none && !P.bHidden && !P.bDeleteMe && P.Health > 0 && P.PlayerReplicationInfo != none)
         {
             if (P.GetTeamNum() == TeamIndex)
             {


### PR DESCRIPTION
This reverts commit 1350781c9213e89dc6bc9d851b3b50de0e5aef6c.

The offending commit also has no effect on detecting friendly bots. Spawn points do count bots just fine.

Tested on rally points in SP and MP.