### PR TITLE
Reduced speed and enabled staggering for berserkers

### DIFF
--- a/DH_GerPlayers/Classes/DH_ZombieBerserkerPawn.uc
+++ b/DH_GerPlayers/Classes/DH_ZombieBerserkerPawn.uc
@@ -8,12 +8,11 @@ class DH_ZombieBerserkerPawn extends DH_ZombiePawn;
 
 defaultproperties
 {
-    GroundSpeed=250
+    GroundSpeed=205
     WalkingPct=0.3
     Health=300
     Stamina=500
     MinHurtSpeed=700.0
-    bNeverStaggers=true
     bAlwaysSeverBodyparts=true
 
     Hitpoints(1)=(DamageMultiplier=6.0) // head

--- a/DH_GerPlayers/Classes/DH_ZombieLeaderPawn.uc
+++ b/DH_GerPlayers/Classes/DH_ZombieLeaderPawn.uc
@@ -20,7 +20,7 @@ defaultproperties
     ShovelClass=Class'DHShovelItem_German'
     BinocsClass=Class'DHBinocularsItemGerman'
 
-    GroundSpeed=250
+    GroundSpeed=225
     WalkingPct=0.3
     Health=500
     Stamina=500


### PR DESCRIPTION
They're too OP, especially on close quarter survival maps making it near impossible to win against them.

They still retain a small speed advantage (+2.5%) so they can eventually catch up to normal players.

Leader speed was reduced but he's still fast (+12.5%) and can't be staggered.