### PR TITLE
Hotfix Armored San Tortellini Domination:

### DIFF
--- a/DarkestHourDev/Maps/DH-San_Celeste_Defence.rom
+++ b/DarkestHourDev/Maps/DH-San_Celeste_Defence.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d2d3de0e761618ac8d81a6f3d14abef5d8e192ea68e7766f2d1e725a15fd1d7
-size 103842641
+oid sha256:8c56819229a9d9c48df57b57af1a505b3879dbedf3a2008783665c553f59b663
+size 103842643


### PR DESCRIPTION
- Restored accidentally deleted Axis spawn point on the Pillbox objective.
- Fixed objectives being set to bRecaptureable=False resulting in recapture by the Italians permanently locking the objectives.
- Adjusted all objectives to have slightly faster capture speeds.
- Added a new minefield to block off the lighthouse area.
- Added grenades to the US automatic rifleman role.
- Fixed some terrain issues.
- Tweaked East Gate objective volume to be slightly more intuitive.