### PR TITLE
Level Updates... and other stuff.

### DIFF
--- a/DH_Guns/Classes/DH_M1927Cannon.uc
+++ b/DH_Guns/Classes/DH_M1927Cannon.uc
@@ -40,18 +40,18 @@ defaultproperties
     ProjectileDescriptions(1)="HEAT"
 
     nProjectileDescriptions(0)="OF-350"
-    nProjectileDescriptions(1)="BP-350M"
+    nProjectileDescriptions(1)="BP-353A"
 
     PrimaryProjectileClass=Class'DH_M1927CannonShellHE'
-    SecondaryProjectileClass=Class'DH_LeIG18CannonShellHEAT'
+    SecondaryProjectileClass=Class'DH_M1927CannonShellHEAT'
 
     InitialPrimaryAmmo=28
-    InitialSecondaryAmmo=4
+    InitialSecondaryAmmo=5 //HEAT came in crates of 5 shells.
     MaxPrimaryAmmo=28
-    MaxSecondaryAmmo=4
+    MaxSecondaryAmmo=5
 
     Spread=0.020
-    SecondarySpread=0.00125
+    SecondarySpread=0.002
 
     // Weapon fire
     WeaponFireOffset=0

--- a/DH_Guns/Classes/DH_M1927CannonShellHEAT.uc
+++ b/DH_Guns/Classes/DH_M1927CannonShellHEAT.uc
@@ -1,0 +1,64 @@
+//==============================================================================
+// Darkest Hour: Europe '44-'45
+// Copyright (c) Darklight Games.  All rights reserved.
+//==============================================================================
+
+class DH_M1927CannonShellHEAT extends DHCannonShellHEAT;
+
+defaultproperties
+{
+    Speed=18770.0
+    MaxSpeed=18770.0
+    SpeedFudgeScale=1.0
+    ShellDiameter=7.62
+    BallisticCoefficient=2.1 //TODO: pls, check
+
+    //Damage
+    ImpactDamage=350   //~600 gramms TNT
+    Damage=300.0
+    DamageRadius=700.0
+
+    //Effects
+    CoronaClass=Class'DHShellTracer_GreenLarge'
+    ShellTrailClass=Class'DHShellTrail_Green'
+    TracerHue=64
+
+    bDebugInImperial=false
+
+    //Penetration
+    DHPenetrationTable(0)=7.5
+    DHPenetrationTable(1)=7.5
+    DHPenetrationTable(2)=7.5
+    DHPenetrationTable(3)=7.5
+    DHPenetrationTable(4)=7.5
+    DHPenetrationTable(5)=7.5
+    DHPenetrationTable(6)=7.5
+    DHPenetrationTable(7)=7.5
+    DHPenetrationTable(8)=7.5
+    DHPenetrationTable(9)=7.5
+    DHPenetrationTable(10)=7.5
+
+    //Gunsight adjustments
+    MechanicalRanges(1)=(Range=100,RangeValue=28.0)
+    MechanicalRanges(2)=(Range=200,RangeValue=40.0)
+    MechanicalRanges(3)=(Range=300,RangeValue=58.0)
+    MechanicalRanges(4)=(Range=400,RangeValue=78.0)
+    MechanicalRanges(5)=(Range=500,RangeValue=94.0)
+    MechanicalRanges(6)=(Range=600,RangeValue=114.0)
+    MechanicalRanges(7)=(Range=700,RangeValue=134.0)
+    MechanicalRanges(8)=(Range=800,RangeValue=154.0)
+    MechanicalRanges(9)=(Range=900,RangeValue=180.0)
+    MechanicalRanges(10)=(Range=1000,RangeValue=200.0)
+    MechanicalRanges(11)=(Range=1100,RangeValue=224.0)
+    MechanicalRanges(12)=(Range=1200,RangeValue=250.0)
+    MechanicalRanges(13)=(Range=1300,RangeValue=274.0)
+    MechanicalRanges(14)=(Range=1400,RangeValue=302.0)
+    MechanicalRanges(15)=(Range=1500,RangeValue=328.0)
+    MechanicalRanges(16)=(Range=1600,RangeValue=352.0)
+    MechanicalRanges(17)=(Range=1700,RangeValue=378.0)
+    MechanicalRanges(18)=(Range=1800,RangeValue=408.0)
+    MechanicalRanges(19)=(Range=1900,RangeValue=438.0)
+    MechanicalRanges(20)=(Range=2000,RangeValue=468.0)
+
+    bMechanicalAiming=true
+}

--- a/DarkestHourDev/Maps/DH-Chambois_Push.rom
+++ b/DarkestHourDev/Maps/DH-Chambois_Push.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12a410fdcbcdfc323e7a5df025ed1008422e0404c7e6af480cf16bbaeb97e435
-size 54825866
+oid sha256:e81d0bfb59ceda9b95afef1e5691fb5396455451babdd8986f538f7014532caa
+size 54811887

--- a/DarkestHourDev/Maps/DH-Dzerzhinsky_Tractor_Factory_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Dzerzhinsky_Tractor_Factory_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba8d0eca92ca5ca3c081d031410db7e3dd684eb464d563731c9e5f4f343fa377
-size 74422155
+oid sha256:e32fadda8db65d551d9a1747ef8c79949f1c2f2dcaec6513be4b67202a043169
+size 74422479

--- a/DarkestHourDev/Maps/DH-Dzerzhinsky_Tractor_Factory_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Dzerzhinsky_Tractor_Factory_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8c62154df3c0744ed4357435d951685e6828e10e338ad2cc93ca8002c03deeb
-size 73722685
+oid sha256:ba8d0eca92ca5ca3c081d031410db7e3dd684eb464d563731c9e5f4f343fa377
+size 74422155

--- a/DarkestHourDev/Maps/DH-Hedgerow_Hell_Advance.rom
+++ b/DarkestHourDev/Maps/DH-Hedgerow_Hell_Advance.rom
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d1cab8a7c40cc011d933eae8c18069fc2d689bfe4f9d293b26a6676285d2d48
-size 69359809
+oid sha256:748e9691ee44aab41e1e694746b80039c221bcd71163dfedfb4166825f51c2e3
+size 69361225


### PR DESCRIPTION
[Chambois:](https://github.com/DarklightGames/DarkestHour/commit/6c188c6dbd98a89d788432b3f9b8cf32decc2bd4)

- Fixed a number of static stairs on the map being old myLevel type with broken collision.
- Fixed floating roof static.

[Dzerzhinsky Tractor Factory:](https://github.com/DarklightGames/DarkestHour/commit/5a08dd9e9bd98d6d3a386318953c398702249767)

- Fixed missing texture causing the map to not load.
- Reduced sound radius on bullet whizzes.

[Hedgerow Hell:](https://github.com/DarklightGames/DarkestHour/commit/7581e2085f75f56f38d9cc9a84976d525c3f8e1a)

- Increased setup phase duration from 140 to 180 seconds.
- Increased Allied AT roles from 1 to 2.
- Added additional Axis AT role equipped with a Panzerfaust.
- Reduced Axis tank crewman roles from 4 to 3 (number of tanks is unchanged, this simply prevents tank jumping).
- Removed Allied and Axis mortar operator roles, as these have been largely replaced by mortar constructions and the map is generally player-artillery heavy as it is.
- Changed M7 Priest to unlock when Barn and Tellier Farm objectives are captured.
- Changed M5 Stuart to unlock when Bunker objective is captured.
- Reworked construction limits to use new system.
- Axis can now build 2 Pak 40, 2 Pak 38, 1 Flak 36, 1 Flakvierling, 1 LeIG 18, 2 GrW34, 6 HQs.
- Allies can build 5 M1 AT Gun, 3 M5 AT Guns, 3 M1 Mortars, 7 HQs.

M1927 Howitzer (totally a map btw): 

- Replaced placeholder German LeIG HEAT shell with new proper BP-353A class.
- Updated shell name to reflect the new shell type.
- Increased ammo capacity for this shell from 4 to 5 (Soviet manual mentioned these rounds came in crates of 5).