### PR TITLE
Despawn MDVs when they're abandoned in Danger Zone

### DIFF
--- a/DH_Engine/Classes/DHHud.uc
+++ b/DH_Engine/Classes/DHHud.uc
@@ -953,6 +953,7 @@ function DrawHudPassC(Canvas C)
         {
             case SPBR_None:
                 DrawSpriteWidget(C, DeployOkayIcon); break;
+            case SPBR_InDangerZone:
             case SPBR_InObjective:
                 DrawSpriteWidget(C, DeployInObjectiveIcon); break;
             case SPBR_EnemiesNearby:

--- a/DH_Engine/Classes/DHSpawnPoint_Vehicle.uc
+++ b/DH_Engine/Classes/DHSpawnPoint_Vehicle.uc
@@ -58,7 +58,7 @@ function DHSpawnPointBase.ESpawnPointBlockReason GetSpawnPointBlockReason()
     // Check that we are not inside the danger zone.
     if (GRI.IsInDangerZone(Location.X, Location.Y, GetTeamIndex()))
     {
-        return SPBR_EnemiesNearby;
+        return SPBR_InDangerZone;
     }
 
     if (bIsTemporary)

--- a/DH_Engine/Classes/DHVehicle.uc
+++ b/DH_Engine/Classes/DHVehicle.uc
@@ -4059,7 +4059,7 @@ simulated function SwitchMesh(int PositionIndex, optional bool bUpdateAnimations
 
 // Modified to include setting ResetTime for an empty vehicle, which natively calls future CheckReset() event that may destroy & respawn an apparently abandoned vehicle
 // Moved this functionality here from DriverLeft() as it fits well here, but functionality has been substantially modified & improved
-// We never consider destroying a spawn vehicle, or a factory's last/only vehicle (it won't spawn a replacement so no point 'recycling') unless factory deactivated
+// We never consider destroying a persistent spawn vehicle, or a factory's last/only vehicle (it won't spawn a replacement so no point 'recycling') unless factory deactivated
 // But we do do now set a ResetTime for an empty bNeverReset vehicle (e.g, AT gun) if its factory has since been deactivated & should destroy an empty vehicle
 // And we skip check that vehicle has moved from its spawning location if parent is DH spawn manager, as that has no location & doesn't spawn empty vehicle like a factory
 function MaybeDestroyVehicle()
@@ -4078,8 +4078,8 @@ function MaybeDestroyVehicle()
 
         // (If the vehicle was spawned by a vehicle factory that has since been deactivated & wants to destroy its vehicle when empty
         // AND is not meant to reset)
-        // OR is a spawn vehicle, return
-        if ((!bDeactivatedFactoryWantsToDestroy && bNeverReset) || IsPermanentSpawnVehicle())
+        // OR is a persistent spawn vehicle, return
+        if ((!bDeactivatedFactoryWantsToDestroy && bNeverReset) || CanSpawnVehiclePersistWhenIdle())
         {
             return;
         }
@@ -4121,10 +4121,10 @@ event CheckReset()
     local float      Distance;
     local ROVehicleFactory VF;
 
-    // Do nothing if vehicle is a spawn vehicle or it isn't empty
+    // Do nothing if vehicle is a persistent spawn vehicle, or it isn't empty
     // Originally this set a new timer if vehicle was found to be occupied, but there's no reason for that
     // Occupied vehicle shouldn't have CheckReset timer running & if player exits, leaving vehicle empty, then a new CheckReset timer gets started
-    if (IsPermanentSpawnVehicle() || !IsVehicleEmpty())
+    if (CanSpawnVehiclePersistWhenIdle() || !IsVehicleEmpty())
     {
         return;
     }
@@ -4278,10 +4278,13 @@ simulated function DisplayVehicleMessage(int MessageNumber, optional Pawn P, opt
     }
 }
 
-// New helper function to check whether vehicle is a spawn vehicle
-simulated function bool IsPermanentSpawnVehicle()
+// Helper function to check whether a spawn vehicle shouldn't despawn after being abandoned (when IdleTimeBeforeReset is reached)
+simulated function bool CanSpawnVehiclePersistWhenIdle()
 {
-    return SpawnPointAttachment != none && !SpawnPointAttachment.bIsTemporary;
+    // The vehicle must be a permanent spawn (MDV) and within reach of the owning team
+    return SpawnPointAttachment != none &&
+           !SpawnPointAttachment.bIsTemporary &&
+           SpawnPointAttachment.BlockReason != SPBR_InDangerZone;
 }
 
 // Modified so vehicle is treated as disabled if it suffers a range of damage that renders it of very limited use, as well as if the engine is dead


### PR DESCRIPTION
Changes:

- MDVs are despawned like regular vehicles when they're left inside Danger Zone and no friendlies are nearby. This is done to prevent MDVs from becoming unrecoverable when abandoned behind the lines.

- HUD indicator shown when a spawn vehicle is located in Danger Zone has been replaced with a red flag icon (same as when inside an objective). In both cases it indicates to the player that they're in some area controlled by an enemy. This should be less confusing than using "enemy is nearby" icon when inside Danger Zone.

- Removed `IsPermanentSpawnVehicle()` function as it's no longer used.